### PR TITLE
Empty database password

### DIFF
--- a/inc/auth/mysql.class.php
+++ b/inc/auth/mysql.class.php
@@ -46,7 +46,7 @@ class auth_mysql extends auth_basic {
 
       // set capabilities based upon config strings set
       if (empty($this->cnf['server']) || empty($this->cnf['user']) ||
-          empty($this->cnf['password']) || empty($this->cnf['database'])){
+          !isset($this->cnf['password']) || empty($this->cnf['database'])){
         if ($this->cnf['debug'])
           msg("MySQL err: insufficient configuration.",-1,__LINE__,__FILE__);
         $this->success = false;


### PR DESCRIPTION
For users trying to run DokuWiki on their local machine, the default MySQL password is often empty. Actually, the application does not accept empty string as password.

This is a patch to accept empty strings as database password and simplify the life of beginners and developers...
