### PR TITLE
Fix interwiki icon clipping

### DIFF
--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -204,7 +204,7 @@ function css_interwiki(){
     // default style
     echo 'a.interwiki {';
     echo ' background: transparent url('.DOKU_BASE.'lib/images/interwiki.png) 0px 1px no-repeat;';
-    echo ' padding-left: 16px;';
+    echo ' padding: 1px 0px 1px 16px;';
     echo '}';
 
     // additional styles when icon available


### PR DESCRIPTION
Add 1px top & bottom margins so that full 16x16 icons don't get clipped.
