### PR TITLE
Fix display in popularity plugin

### DIFF
--- a/lib/plugins/popularity/admin.php
+++ b/lib/plugins/popularity/admin.php
@@ -95,7 +95,7 @@ class admin_plugin_popularity extends DokuWiki_Admin_Plugin {
             //Print the last time the data was sent
             $lastSent = $this->helper->lastSentTime();
             if ( $lastSent !== 0 ){
-                echo $this->getLang('lastSent') . datetime_h($lastSent);
+                echo $this->getLang('lastSent') . ' ' . datetime_h($lastSent);
             }
         } else {
             //If we just submitted the form

--- a/lib/plugins/popularity/lang/en/lang.php
+++ b/lib/plugins/popularity/lang/en/lang.php
@@ -6,4 +6,4 @@ $lang['autosubmit']       = 'Automatically send data once a month';
 $lang['submissionFailed'] = 'The data couldn\'t be sent due to the following error:';
 $lang['submitDirectly']   = 'You can send the data manually by submitting the following form.';
 $lang['autosubmitError']  = 'The last autosubmit failed, because of the following error: ';
-$lang['lastSent']         = 'The data has been sent ';
+$lang['lastSent']         = 'The data has been sent';


### PR DESCRIPTION
It appears that in every lang.php of the popularity plugin, the whitespace at the end of the string 'lastSent' is missing.
Therefore, it seems more relevant to add this whitespace in the admin.php
