### PR TITLE
The mail() function shouldn't be executed when no recipients are given.

### DIFF
--- a/inc/mail.php
+++ b/inc/mail.php
@@ -104,6 +104,9 @@ function _mail_send_action($data) {
     $headers = isset($data['headers']) ? $data['headers'] : null;
     $params = isset($data['params']) ? $data['params'] : null;
 
+    // discard mail request if no recipients are available
+    if(trim($to) === '' && trim($cc) === '' && trim($bcc) === '') return false;
+    
     // end additional code to support event ... original mail_send() code from here
 
     if(defined('MAILHEADER_ASCIIONLY')){


### PR DESCRIPTION
Empty to, cc or bcc fields could lead to an Internal Server Error:
malformed header from script. Bad header=No recipient addresses found...
