### PR TITLE
Added bcrypt support for password hashes

### DIFF
--- a/_test/cases/inc/auth_password.test.php
+++ b/_test/cases/inc/auth_password.test.php
@@ -12,6 +12,7 @@ class auth_password_test extends UnitTestCase {
         'md5'   => '8fa22d62408e5351553acdd91c6b7003',
         'sha1'  => 'b456d3b0efd105d613744ffd549514ecafcfc7e1',
         'ssha'  => '{SSHA}QMHG+uC7bHNYKkmoLbNsNI38/dJhYmNk',
+        'lsmd5' => '{SMD5}HGbkPrkWgy9KgcRGWlrsUWFiY2RlZmdo',
         'crypt' => 'ablvoGr1hvZ5k',
         'mysql' => '4a1fa3780bd6fd55',
         'my411' => '*e5929347e25f82e19e4ebe92f1dc6b6e7c2dbd29',

--- a/inc/PassHash.class.php
+++ b/inc/PassHash.class.php
@@ -53,6 +53,9 @@ class PassHash {
         }elseif(substr($hash,0,6) == '{SSHA}'){
             $method = 'ssha';
             $salt   = substr(base64_decode(substr($hash, 6)),20);
+        }elseif(substr($hash,0,6) == '{SMD5}'){
+            $method = 'lsmd5';
+            $salt   = substr(base64_decode(substr($hash, 6)),16);
         }elseif($len == 32){
             $method = 'md5';
         }elseif($len == 40){
@@ -132,6 +135,20 @@ class PassHash {
             return $this->hash_apr1($clear, $salt, '1');
         }
     }
+
+
+    /**
+     * Password hashing method 'lsmd5'
+     *
+     * Uses salted MD5 hashs. Salt is 8 bytes long.
+     *
+     * This is the format used by LDAP.
+     */
+    public function hash_lsmd5($clear, $salt=null){
+        $this->init_salt($salt,8);
+        return "{SMD5}".base64_encode(md5($clear.$salt, true).$salt);
+    }
+
 
     /**
      * Password hashing method 'apr1'

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -123,7 +123,7 @@ $meta['_authentication'] = array('fieldset');
 $meta['useacl']      = array('onoff');
 $meta['autopasswd']  = array('onoff');
 $meta['authtype']    = array('authtype');
-$meta['passcrypt']   = array('multichoice','_choices' => array('smd5','md5','apr1','sha1','ssha','crypt','mysql','my411','kmd5','pmd5','hmd5','bcrypt'));
+$meta['passcrypt']   = array('multichoice','_choices' => array('smd5','md5','apr1','sha1','ssha','lsmd5','crypt','mysql','my411','kmd5','pmd5','hmd5','bcrypt'));
 $meta['defaultgroup']= array('string');
 $meta['superuser']   = array('string');
 $meta['manager']     = array('string');


### PR DESCRIPTION
bcrypt seems to be somewhat fashionable for password storing currently so it makes sense to have it available in DokuWiki. This will work in PHP 5.3+ only though

PS: this pull request should hopefully trigger a mail to the mailing list now. I encourage everyone to review pull requests and add feedback at github's code review interface
