### PR TITLE
adds html label to plugins in plugin management page

### DIFF
--- a/lib/plugins/plugin/classes/ap_manage.class.php
+++ b/lib/plugins/plugin/classes/ap_manage.class.php
@@ -90,8 +90,8 @@ class ap_manage {
 
             ptln('    <fieldset'.$class.'>');
             ptln('      <legend>'.$plugin.'</legend>');
-            ptln('      <input type="checkbox" class="enable" name="enabled[]" value="'.$plugin.'"'.$checked.$check_disabled.' />');
-            ptln('      <h3 class="legend">'.$plugin.'</h3>');
+            ptln('      <input type="checkbox" class="enable" name="enabled[]" id="dw__p_'.$plugin.'" value="'.$plugin.'"'.$checked.$check_disabled.' />');
+            ptln('      <h3 class="legend"><label for="dw__p_'.$plugin.'">'.$plugin.'</label></h3>');
 
             $this->html_button($plugin, 'info', false, 6);
             if (in_array('settings', $this->manager->functions)) {


### PR DESCRIPTION
i needed to disable all plugins to figure out which plugin was causing
template error, so it was quite annoying to click on the tiny checkbox

added html label so i could at least click on the plugin name to toggle
checkbox state
