### PR TITLE
Symptom-Fix for FS#2393

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -108,7 +108,7 @@ function media_metaform($id,$auth){
     $src = mediaFN($id);
 
     // output
-    $form = new Doku_Form(array('action' => media_managerURL(array('tab_details' => 'view')),
+    $form = new Doku_Form(array('action' => media_managerURL(array('tab_details' => 'view'), '&'),
                                 'class' => 'meta'));
     $form->addHidden('img', $id);
     $form->addHidden('mediado', 'save');


### PR DESCRIPTION
This is a fix for [FS#2393](http://bugs.dokuwiki.org/index.php?do=details&task_id=2393)

My problem is: The fix only corrects the symptoms (NOT using & as the separator, but &). I still don't know, WHY the conversion to & is done here and nowhere else.

At least, this special thing works.
