### PR TITLE
Improbement and "bug"fixing of the xmlrpc interface

### DIFF
--- a/lib/exe/xmlrpc.php
+++ b/lib/exe/xmlrpc.php
@@ -411,7 +411,7 @@ class dokuwiki_xmlrpc_server extends IXR_IntrospectionServer {
 
             $pages[] = array(
                 'id'      => $id,
-                'score'   => $score,
+                'score'   => intval($score),
                 'rev'     => filemtime($file),
                 'mtime'   => filemtime($file),
                 'size'    => filesize($file),


### PR DESCRIPTION
The 2 commits with the error codes, would be really an improvement, because some right now if you need to seperate between several insidents, you need to parse the error message. I guess that should really change. 

The base64 bugfix was a bit a problem of the library you use. Its autodetecting the type of the value is not the best. So you must explicit tell them, it should be base64 encoded and not encode it yourself.
