### PR TITLE
search and ACL forms should not post to '/' but rather to $conf['start']

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -694,6 +694,7 @@ function tpl_action($type,$link=0,$wrapper=false,$return=false,$pre='',$suf='',$
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function tpl_searchform($ajax=true,$autocomplete=true){
+    global $conf;
     global $lang;
     global $ACT;
     global $QUERY;
@@ -701,7 +702,7 @@ function tpl_searchform($ajax=true,$autocomplete=true){
     // don't print the search form if search action has been disabled
     if (!actionOk('search')) return false;
 
-    print '<form action="'.wl().'" accept-charset="utf-8" class="search" id="dw__search" method="get"><div class="no">';
+    print '<form action="'.wl($conf['start']).'" accept-charset="utf-8" class="search" id="dw__search" method="get"><div class="no">';
     print '<input type="hidden" name="do" value="search" />';
     print '<input type="text" ';
     if($ACT == 'search') print 'value="'.htmlspecialchars($QUERY).'" ';

--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -325,7 +325,7 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
         global $conf;
         global $ID;
 
-        echo '<form action="'.wl().'" method="post" accept-charset="utf-8"><div class="no">'.NL;
+        echo '<form action="'.wl($conf['start']).'" method="post" accept-charset="utf-8"><div class="no">'.NL;
 
         echo '<div id="acl__user">';
         echo $this->getLang('acl_perms').' ';
@@ -584,10 +584,11 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
      * @author Andreas Gohr <andi@splitbrain.org>
      */
     function _html_table(){
+        global $conf
         global $lang;
         global $ID;
 
-        echo '<form action="'.wl().'" method="post" accept-charset="utf-8"><div class="no">'.NL;
+        echo '<form action="'.wl($conf['start']).'" method="post" accept-charset="utf-8"><div class="no">'.NL;
         if($this->ns){
             echo '<input type="hidden" name="ns" value="'.hsc($this->ns).'" />'.NL;
         }else{


### PR DESCRIPTION
this fixes behavior in some more complex setups like having both static content (index.html) and dokuwiki (index.php, doku.php) running under the same domain ...
