### PR TITLE
Make getTitle method in remote interface public

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -44,7 +44,8 @@ class RemoteAPICore {
             ), 'dokuwiki.getTitle' => array(
                 'args' => array(),
                 'return' => 'string',
-                'doc' => 'Returns the wiki title.'
+                'doc' => 'Returns the wiki title.',
+                'public' => '1'
             ), 'dokuwiki.appendPage' => array(
                 'args' => array('string', 'string', 'array'),
                 'return' => 'int',


### PR DESCRIPTION
I think this method can safely be public, since the user can see the title of the wiki while not logged in, by just visiting the wiki itself.

I don't think a new remote API version is needed.
