### PR TITLE
Added page title to search result in remote interface

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -302,7 +302,7 @@ class RemoteAPICore {
                 'mtime'   => filemtime($file),
                 'size'    => filesize($file),
                 'snippet' => $snippet,
-                'title' => p_get_first_heading($id)
+                'title' => useHeading('navigation') ? p_get_first_heading($id) : $id
             );
         }
         return $pages;


### PR DESCRIPTION
Add the first heading as title to the search results. This shouldn't need a new API version, since the current one hasn't been released yet.
