### PR TITLE
some tweaks to the pagetool css FS#2481

### DIFF
--- a/lib/tpl/dokuwiki/css/pagetools.css
+++ b/lib/tpl/dokuwiki/css/pagetools.css
@@ -14,7 +14,9 @@
     padding-left: 40px;
 }
 .dokuwiki div.page {
+    height: 190px;
     min-height: 190px; /* 30 (= height of icons) x 6 (= maximum number of possible tools) + 2x5 */
+    height: auto;
 }
 #dokuwiki__usertools {
     /* move the tools just outside of the site */
@@ -27,10 +29,12 @@
     right: -40px;
     /* on same vertical level as first headline, because .page has 2em padding */
     top: 2em;
+    width: 40px;
 }
 
 #dokuwiki__pagetools div.tools {
     position: fixed;
+    width: 40px;
 }
 
 #dokuwiki__pagetools ul {
@@ -66,7 +70,8 @@
 /* hide labels accessibly when neither on hover nor on focus */
 #dokuwiki__pagetools ul li a span {
     position: absolute;
-    left: -99999px;
+    clip: rect(0 0 0 0); /* IE7, IE6 */
+    clip: rect(0, 0, 0, 0);
 }
 
 /* show all tools on hover and individual tools on focus */


### PR DESCRIPTION
These changes seem to fix the pagetool problems in the Android browser. Interesting enough all these seemingly unrelated changes are needed to fix the problem:
- give a width for the pagetool outer and inner elements (this seems not to affect the hover width)
- change the way how the labels are hidden (found the method here: http://adaptivethemes.com/using-css-clip-as-an-accessible-method-of-hiding-content)
- give a height, then override it again to auto (no idea why that works on Android, maybe it does reimplement IE6's non-support for min-height)

I put this in a pull request because I might have broken desktop browsers with this. I only tested this in Chrome (Desktop) and the Android 4.0.3 browser.

@selfthinker would be great if you could have a look at it if you find the time.

cross browser tests by everyone else are more than welcome
