### PR TITLE
Fixes messages.txt's modification timestamp not being updated.

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -25,11 +25,14 @@ function checkUpdateMessages(){
 
     // check if new messages needs to be fetched
     if($lm < time()-(60*60*24) || $lm < @filemtime(DOKU_INC.DOKU_SCRIPT)){
+        dbglog("checkUpdatesMessages(): downloading messages.txt");
         $http = new DokuHTTPClient();
         $http->timeout = 8;
         $data = $http->get(DOKU_MESSAGEURL.$updateVersion);
         io_saveFile($cf,$data);
+        @touch($cf);
     }else{
+        dbglog("checkUpdatesMessages(): messages.txt up to date");
         $data = io_readFile($cf);
     }
 


### PR DESCRIPTION
This bug occurs on systems where writing a zero-length string to an
empty file does not update the file's modification timestamp.

This leads to the messages.txt being downloaded almost endlessly, causing
long delays for logged-in users. Visitors are not affected, because the
messages.txt is only updated for logged-in users.
