### PR TITLE
Fixes in rtl.css

### DIFF
--- a/lib/tpl/default/rtl.css
+++ b/lib/tpl/default/rtl.css
@@ -91,6 +91,8 @@ div.dokuwiki div.level5 { margin-left: 0px; margin-right: 83px; }
 /* TOC control */
 div.dokuwiki div.toc {
   float: left;
+  margin-left: 0em;
+  margin-right: 2em;
 }
 
 div.dokuwiki div.tocheader {
@@ -104,6 +106,11 @@ div.dokuwiki #toc__inside {
 div.dokuwiki ul.toc {
   padding: 0;
   padding-right: 1em;
+}
+
+div.dokuwiki span.toc_open,
+div.dokuwiki span.toc_close {
+    float: left;
 }
 
 div.dokuwiki ul.toc li {


### PR DESCRIPTION
Hi,
Fix: RTL toc margin must be at right
Fix: RTL toc header open/close image must be in the left

Thanks.
