### PR TITLE
allow require/require_once/include in config files other than just @include

### DIFF
--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -156,7 +156,7 @@ if (!class_exists('configuration')) {
         }else{
             $contents = '';
         }
-        $pattern = '/\$'.$this->_name.'\[[\'"]([^=]+)[\'"]\] ?= ?(.*?);(?=[^;]*(?:\$'.$this->_name.'|@include|$))/s';
+        $pattern = '/\$'.$this->_name.'\[[\'"]([^=]+)[\'"]\] ?= ?(.*?);(?=[^;]*(?:\$'.$this->_name.'|@?(?:require|include)(?:_once)?|$))/s';
         $matches=array();
         preg_match_all($pattern,$contents,$matches,PREG_SET_ORDER);
 


### PR DESCRIPTION
this allows you to put `require_once 'ldap.conf.php';` into local.php
and still resume editing with config editor.

i want require, so if in case ldap.conf.php is somewhy not readable, i
don't accidentally open my wiki for whole world, but 500 internal server
error is given.

importing old patch:
http://cvs.pld-linux.org/packages/dokuwiki/dokuwiki-config-allow-require.patch
