### PR TITLE
consider empty files as no file in installer

### DIFF
--- a/install.php
+++ b/install.php
@@ -431,7 +431,7 @@ function check_configs(){
 
     // configs shouldn't exist
     foreach ($config_files as $file) {
-        if (@file_exists($file)) {
+        if (@file_exists($file) && filesize($file)) {
             $file    = str_replace($_SERVER['DOCUMENT_ROOT'],'{DOCUMENT_ROOT}/', $file);
             $error[] = sprintf($lang['i_confexists'],$file);
             $ok      = false;


### PR DESCRIPTION
allow empty config file to proceed installation as we package default
config empty in first install

as packager may provide empty file in package, to ensure correct
file permissions.

import old patch:
http://cvs.pld-linux.org/packages/dokuwiki/install.patch
