### PR TITLE
Translatable string for "None" license selection

### DIFF
--- a/inc/lang/en/lang.php
+++ b/inc/lang/en/lang.php
@@ -311,6 +311,7 @@ $lang['i_pol1']                = 'Public Wiki (read for everyone, write and uplo
 $lang['i_pol2']                = 'Closed Wiki (read, write, upload for registered users only)';
 $lang['i_retry']               = 'Retry';
 $lang['i_license']             = 'Please choose the license you want to put your content under:';
+$lang['i_license_none']        = 'None of the above';
 
 $lang['recent_global']         = 'You\'re currently watching the changes inside the <b>%s</b> namespace. You can also <a href="%s">view the recent changes of the whole wiki</a>.';
 $lang['years']                 = '%d years ago';

--- a/install.php
+++ b/install.php
@@ -210,12 +210,12 @@ function print_form($d){
         <fieldset>
             <p><?php echo $lang['i_license']?></p>
             <?php
-            array_unshift($license,array('name' => 'None', 'url'=>''));
+            array_push($license,array('name' => $lang['i_license_none'], 'url'=>''));
             if(empty($d['license'])) $d['license'] = 'cc-by-sa';
             foreach($license as $key => $lic){
                 echo '<label for="lic_'.$key.'">';
                 echo '<input type="radio" name="d[license]" value="'.htmlspecialchars($key).'" id="lic_'.$key.'"'.
-                     (($d['license'] == $key)?' checked="checked"':'').'>';
+                     (($d['license'] === $key)?' checked="checked"':'').'>';
                 echo htmlspecialchars($lic['name']);
                 if($lic['url']) echo ' <a href="'.$lic['url'].'" target="_blank"><sup>[?]</sup></a>';
                 echo '</label>';


### PR DESCRIPTION
The position of the option was moved to the end of the list so
the English label "None of the above" will make sense.
