### PR TITLE
fix E_STRICT errors FS#2427

### DIFF
--- a/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
+++ b/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
@@ -50,7 +50,8 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest {
     function helper_set_metadata($event, $meta) {
         if ($this->active) {
             p_set_metadata($this->id, $meta, false, true);
-            $key = array_pop(array_keys($meta));
+            $keys = array_keys($meta);
+            $key = array_pop($keys);
             $this->assertTrue(is_string($meta[$key])); // ensure we really have a key
             // ensure that the metadata property hasn't been set previously
             $this->assertNotEquals($meta[$key], p_get_metadata($this->id, $key));

--- a/inc/SafeFN.class.php
+++ b/inc/SafeFN.class.php
@@ -44,7 +44,7 @@ class SafeFN {
      *
      * @author   Christopher Smith <chris@jalakai.co.uk>
      */
-    public function encode($filename) {
+    public static function encode($filename) {
         return self::unicode_to_safe(utf8_to_unicode($filename));
     }
 
@@ -73,15 +73,15 @@ class SafeFN {
      *
      * @author   Christopher Smith <chris@jalakai.co.uk>
      */
-    public function decode($filename) {
+    public static function decode($filename) {
         return unicode_to_utf8(self::safe_to_unicode(strtolower($filename)));
     }
 
-    public function validate_printable_utf8($printable_utf8) {
+    public static function validate_printable_utf8($printable_utf8) {
         return !preg_match('#[\x01-\x1f]#',$printable_utf8);
     }
 
-    public function validate_safe($safe) {
+    public static function validate_safe($safe) {
         return !preg_match('#[^'.self::$plain.self::$post_indicator.self::$pre_indicator.']#',$safe);
     }
 
@@ -93,7 +93,7 @@ class SafeFN {
      *
      * @author   Christopher Smith <chris@jalakai.co.uk>
      */
-    private function unicode_to_safe($unicode) {
+    private static function unicode_to_safe($unicode) {
 
         $safe = '';
         $converted = false;
@@ -126,7 +126,7 @@ class SafeFN {
      *
      * @author   Christopher Smith <chris@jalakai.co.uk>
      */
-    private function safe_to_unicode($safe) {
+    private static function safe_to_unicode($safe) {
 
         $unicode = array();
         $split = preg_split('#(?=['.self::$post_indicator.self::$pre_indicator.'])#',$safe,-1,PREG_SPLIT_NO_EMPTY);

--- a/inc/events.php
+++ b/inc/events.php
@@ -132,7 +132,7 @@ class Doku_Event_Handler {
         $pluginlist = plugin_list('action');
 
         foreach ($pluginlist as $plugin_name) {
-            $plugin =& plugin_load('action',$plugin_name);
+            $plugin = plugin_load('action',$plugin_name);
 
             if ($plugin !== null) $plugin->register($this);
         }

--- a/inc/parser/metadata.php
+++ b/inc/parser/metadata.php
@@ -133,27 +133,6 @@ class Doku_Renderer_metadata extends Doku_Renderer {
     }
   }
 
-  function strong_open(){}
-  function strong_close(){}
-
-  function emphasis_open(){}
-  function emphasis_close(){}
-
-  function underline_open(){}
-  function underline_close(){}
-
-  function monospace_open(){}
-  function monospace_close(){}
-
-  function subscript_open(){}
-  function subscript_close(){}
-
-  function superscript_open(){}
-  function superscript_close(){}
-
-  function deleted_open(){}
-  function deleted_close(){}
-
   /**
    * Callback for footnote start syntax
    *
@@ -217,14 +196,6 @@ class Doku_Renderer_metadata extends Doku_Renderer {
   function unformatted($text){
     if ($this->capture) $this->doc .= $text;
   }
-
-  function php($text){}
-
-  function phpblock($text){}
-
-  function html($text){}
-
-  function htmlblock($text){}
 
   function preformatted($text){
     if ($this->capture) $this->doc .= $text;
@@ -392,18 +363,6 @@ class Doku_Renderer_metadata extends Doku_Renderer {
                 min($this->meta['date']['valid']['age'],$params['refresh']) :
                 $params['refresh'];
   }
-
-  function table_open($maxcols = NULL, $numrows = NULL){}
-  function table_close(){}
-
-  function tablerow_open(){}
-  function tablerow_close(){}
-
-  function tableheader_open($colspan = 1, $align = NULL, $rowspan = 1){}
-  function tableheader_close(){}
-
-  function tablecell_open($colspan = 1, $align = NULL, $rowspan = 1){}
-  function tablecell_close(){}
 
   //----------------------------------------------------------
   // Utils

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -62,7 +62,7 @@ class Doku_Renderer extends DokuWiki_Plugin {
 
     //handle plugin rendering
     function plugin($name,$data){
-        $plugin =& plugin_load('syntax',$name);
+        $plugin = plugin_load('syntax',$name);
         if($plugin != null){
             $plugin->render($this->getFormat(),$this,$data);
         }

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -570,7 +570,7 @@ function p_get_parsermodes(){
         $obj = null;
         foreach($pluginlist as $p){
             /** @var DokuWiki_Syntax_Plugin $obj */
-            if(!$obj =& plugin_load('syntax',$p)) continue; //attempt to load plugin into $obj
+            if(!$obj = plugin_load('syntax',$p)) continue; //attempt to load plugin into $obj
             $PARSER_MODES[$obj->getType()][] = "plugin_$p"; //register mode type
             //add to modes
             $modes[] = array(

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -191,7 +191,7 @@ class DokuWiki_Plugin {
      */
     function loadHelper($name, $msg){
         if (!plugin_isdisabled($name)){
-            $obj =& plugin_load('helper',$name);
+            $obj = plugin_load('helper',$name);
         }else{
             $obj = null;
         }

--- a/lib/plugins/action.php
+++ b/lib/plugins/action.php
@@ -17,7 +17,7 @@ class DokuWiki_Action_Plugin extends DokuWiki_Plugin {
      /**
       * Registers a callback function for a given event
       */
-      function register($controller) {
+      function register(Doku_Event_Handler $controller) {
         trigger_error('register() not implemented in '.get_class($this), E_USER_WARNING);
       }
 }

--- a/lib/plugins/popularity/action.php
+++ b/lib/plugins/popularity/action.php
@@ -18,7 +18,7 @@ class action_plugin_popularity extends Dokuwiki_Action_Plugin {
     /**
      * Register its handlers with the dokuwiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER',  $this, '_autosubmit', array());
     }
 

--- a/lib/plugins/safefnrecode/action.php
+++ b/lib/plugins/safefnrecode/action.php
@@ -13,7 +13,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_safefnrecode extends DokuWiki_Action_Plugin {
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
 
        $controller->register_hook('INDEXER_TASKS_RUN', 'BEFORE', $this, 'handle_indexer_tasks_run');
 

--- a/lib/plugins/testing/action.php
+++ b/lib/plugins/testing/action.php
@@ -7,7 +7,8 @@
  * @author Tobias Sarnowski <tobias@trustedco.de>
  */
 class action_plugin_testing extends DokuWiki_Action_Plugin {
-    function register(&$controller) {
+
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'dokuwikiStarted');
     }
 


### PR DESCRIPTION
This commit fixes all E_STRICT messages shown when running the test
suite. There might be more problems not covered by tests, yet.

For compatibility reasons with plugins, E_STRICT errors are still
supressed.

Since a few pass by reference thingies were changed, this has the potential to break something. So this should be merged right _after_ the release to be tested.

We probably need a good way to test for strict errors without breaking when plugins are not strict. Maybe we can run the testsuite with strict errors.
