### PR TITLE
Multi-Domain Support for AD-Backend

### DIFF
--- a/inc/auth/ad.class.php
+++ b/inc/auth/ad.class.php
@@ -257,6 +257,7 @@ class auth_ad extends auth_basic {
         $group = str_replace('\\', '', $group);
         $group = str_replace('#', '', $group);
         $group = preg_replace('[\s]', '_', $group);
+        $group = utf8_strtolower(trim($group));
         return $group;
     }
 


### PR DESCRIPTION
Authenticating agains multiple Domains and Domain-Servers was half baked before: It did only work with SSO and did not account for same user names on different domains.

This should fix all these issues. There are some changes in how user names are cleaned that might need adjustments for previous users (see commit messages).

This should be refactored for merging with #74.

A plugin component to add a domain dropdown support to the login form is available at https://github.com/cosmocode/dokuwiki-plugin-addomain this should be integrated after merging #74
