### PR TITLE
Add support for named templates

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -833,6 +833,22 @@ function pageTemplate($id) {
         // the before event might have loaded the content already
         if(empty($data['tpl'])) {
             // if the before event did not set a template file, try to find one
+            // first try to find a template file that matches the name of the current page
+            // only performs looks up the tree, not in the current directory due to
+            // DokuWiki only allowing one page per name per namespace
+            if(empty($data['tplfile'])){
+                // search upper namespaces for templates
+                $path = dirname(wikiFN($id));
+                $len = strlen(rtrim($conf['datadir'],'/'));
+                while (strlen($path) >= $len){
+                    if(@file_exists($path.'/__'.noNS($id).'.txt')){
+                        $data['tplfile'] = $path.'/__'.noNS($id).'.txt';
+                        break;
+                    }
+                    $path = substr($path, 0, strrpos($path, '/'));
+                }
+            }
+            // search for standard template files
             if(empty($data['tplfile'])) {
                 $path = dirname(wikiFN($id));
                 if(@file_exists($path.'/_template.txt')) {


### PR DESCRIPTION
This allows you to use named templates instead of only [_]_template.txt.
The main benefit is if you have many sub-namespaces each of which has
the same page.

A summary page on movies, for example. A namespace for movies could
contain __summary.txt and then a subnamespace for each movie could be
created. In each movie's namespace, the summary page would be able to
pull from the template the the parent directory.
