### PR TITLE
Removed acronyms for "Perl" and "PERL" as Perl is not an acronym.

### DIFF
--- a/conf/acronyms.conf
+++ b/conf/acronyms.conf
@@ -90,8 +90,6 @@ OTOH         On the other hand
 P2P          Peer to Peer
 PDA          Personal Digital Assistant
 PDF          Portable Document Format
-Perl         Practical Extraction and Report Language
-PERL         Practical Extraction and Report Language
 PHP          Hypertext Preprocessor
 PICS         Platform for Internet Content Selection
 PIN          Personal Identification Number


### PR DESCRIPTION
Removed acronyms for "Perl" and "PERL". There is a common misconception outside of the Perl community that it is an acronym, however it is not. See http://learn.perl.org/faq/perlfaq1.html#Whats-the-difference-between-perl-and-Perl-
