### PR TITLE
Corrected typo: ruke -> rule

### DIFF
--- a/_cs/DokuWiki/ruleset.xml
+++ b/_cs/DokuWiki/ruleset.xml
@@ -25,7 +25,7 @@
     <rule ref="Generic.CodeAnalysis.EmptyStatement" />
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod" />
     <rule ref="Generic.Commenting.Todo" />
-    <ruke ref="Generic.Files.ByteOrderMark" />
+    <rule ref="Generic.Files.ByteOrderMark" />
     <rule ref="Generic.Files.LineEndings" />
     <rule ref="Generic.Formatting.DisallowMultipleStatements" />
     <rule ref="Generic.Metrics.NestingLevel">


### PR DESCRIPTION
One of the CodeSniffer rule entries was listed as ruke instead of rule.
