### PR TITLE
Added PAGEUTILS_ID_HIDEPAGE Event

### DIFF
--- a/_test/tests/inc/PageUtilsIsHiddenPage.test.php
+++ b/_test/tests/inc/PageUtilsIsHiddenPage.test.php
@@ -33,16 +33,62 @@ class PageUtilsIsHiddenPageTest extends DokuWikiTest {
         $this->assertFalse(isHiddenPage('another'));
     }
 
-    function testEventHandler() {
+    function testEventHandlerBefore() {
         global $EVENT_HANDLER;
         $this->prepare();
         $EVENT_HANDLER->register_hook('PAGEUTILS_ID_HIDEPAGE', 'BEFORE', $this, 'alwaysHide');
 
-        $this->assertFalse(isHiddenPage('test'));
+        $this->assertTrue(isHiddenPage('another'));
     }
 
     function alwaysHide(Doku_Event &$event, $params) {
-        $event->data['hide'] = true;
+        $event->data['hidden'] = true;
+    }
+
+    function testEventHandlerBeforeAndPrevent() {
+        global $EVENT_HANDLER;
+        $this->prepare();
+        $EVENT_HANDLER->register_hook('PAGEUTILS_ID_HIDEPAGE', 'BEFORE', $this, 'showBefore');
+
+        $this->assertFalse(isHiddenPage('test'));
+    }
+
+    function showBefore(Doku_Event &$event, $params) {
+        $event->data['hidden'] = false;
+        $event->preventDefault();
+        $event->stopPropagation();
+    }
+
+    function testEventHandlerAfter() {
+        global $EVENT_HANDLER;
+        $this->prepare();
+        $EVENT_HANDLER->register_hook('PAGEUTILS_ID_HIDEPAGE', 'AFTER', $this, 'alwaysHide');
+
+        $this->assertTrue(isHiddenPage('another'));
+    }
+
+    function testEventHandlerAfterHide() {
+        global $EVENT_HANDLER;
+        $this->prepare();
+        $EVENT_HANDLER->register_hook('PAGEUTILS_ID_HIDEPAGE', 'AFTER', $this, 'hideBeforeWithoutPrevent');
+
+        $this->assertTrue(isHiddenPage('another'));
+    }
+
+    function hideBeforeWithoutPrevent(Doku_Event &$event, $params) {
+        $event->data['hidden'] = true;
+    }
+
+    function testEventHandlerAfterShow() {
+        global $EVENT_HANDLER;
+        $this->prepare();
+        $EVENT_HANDLER->register_hook('PAGEUTILS_ID_HIDEPAGE', 'AFTER', $this, 'showAfter');
+
+        $this->assertFalse(isHiddenPage('test'));
+    }
+
+    function showAfter(Doku_Event &$event, $params) {
+        $event->data['hidden'] = false;
     }
 
 }

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -536,23 +536,25 @@ function getCacheName($data,$ext=''){
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
 function isHiddenPage($id){
-    global $conf;
-    global $ACT;
-
     $data = array(
         'id' => $id,
         'hidden' => false
     );
-    trigger_event('PAGEUTILS_ID_HIDEPAGE', $id);
+    trigger_event('PAGEUTILS_ID_HIDEPAGE', $data, '_isHiddenPage');
+    return $data['hidden'];
+}
 
-    if ($data['hidden']) return true;
-    if(empty($conf['hidepages'])) return false;
-    if($ACT == 'admin') return false;
+function _isHiddenPage(&$data) {
+    global $conf;
+    global $ACT;
 
-    if(preg_match('/'.$conf['hidepages'].'/ui',':'.$id)){
-        return true;
+    if ($data['hidden']) return;
+    if(empty($conf['hidepages'])) return;
+    if($ACT == 'admin') return;
+
+    if(preg_match('/'.$conf['hidepages'].'/ui',':'.$data['id'])){
+        $data['hidden'] = true;
     }
-    return false;
 }
 
 /**


### PR DESCRIPTION
This page adds an event that allow to hide pages.

Especially for plug-ins this is a nice event. Pages can be easily hidden in various locations like recent changes or sitemap.

In my case this applies to the publish plug-in. Unpublished pages should be hidden from these locations in some scenarios to provide the user a clean looking UI without "Access denied" pages.
