### PR TITLE
Ignore empty email headers

### DIFF
--- a/_test/tests/inc/mailer.test.php
+++ b/_test/tests/inc/mailer.test.php
@@ -98,6 +98,9 @@ class mailer_test extends DokuWikiTest {
         }
     }
 
+    /**
+     * @see https://forum.dokuwiki.org/post/35822
+     */
     function test_emptyBCCorCC() {
         $mail = new TestMailer();
         $headers = &$mail->propRef('headers');

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -553,22 +553,12 @@ class Mailer {
      * @returns string the headers
      */
     protected function prepareHeaders() {
-        $this->removeEmptyBccOrCcHeader();
         $headers = '';
         foreach($this->headers as $key => $val) {
+            if ($val === '') continue;
             $headers .= "$key: $val".MAILHEADER_EOL;
         }
         return $headers;
-    }
-
-    /**
-     * Removes empty BCC and CC Header.
-     *
-     * Empty BCC/CC Header can cause an error with Microsoft IIS.
-     */
-    protected function removeEmptyBccOrCcHeader() {
-        if (isset($this->headers['Bcc']) && empty($this->headers['Bcc'])) unset($this->headers['Bcc']);
-        if (isset($this->headers['Cc']) && empty($this->headers['Cc'])) unset($this->headers['Cc']);
     }
 
     /**


### PR DESCRIPTION
In the current mailer class the setHeader method drops empty header fields. But this can be bypassed in the MAIL_MESSAGE_SEND event. This patch ensure that there are no empty header fields.

Reason:
Some mail server rejecting mails with empty Cc or Bcc headers, see https://forum.dokuwiki.org/post/35822.
