### PR TITLE
Fix useless use of $auth->isCaseSensitive() in auth_aclcheck()

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -535,9 +535,6 @@ function auth_aclcheck($id, $user, $groups) {
         return AUTH_ADMIN;
     }
 
-    $ci = '';
-    if(!$auth->isCaseSensitive()) $ci = 'ui';
-
     if(!$auth->isCaseSensitive()) {
         $user   = utf8_strtolower($user);
         $groups = array_map('utf8_strtolower', $groups);
@@ -565,7 +562,7 @@ function auth_aclcheck($id, $user, $groups) {
     }
 
     //check exact match first
-    $matches = preg_grep('/^'.preg_quote($id, '/').'\s+(\S+)\s+/'.$ci, $AUTH_ACL);
+    $matches = preg_grep('/^'.preg_quote($id, '/').'\s+(\S+)\s+/u', $AUTH_ACL);
     if(count($matches)) {
         foreach($matches as $match) {
             $match = preg_replace('/#.*$/', '', $match); //ignore comments
@@ -593,7 +590,7 @@ function auth_aclcheck($id, $user, $groups) {
     }
 
     do {
-        $matches = preg_grep('/^'.preg_quote($path, '/').'\s+(\S+)\s+/'.$ci, $AUTH_ACL);
+        $matches = preg_grep('/^'.preg_quote($path, '/').'\s+(\S+)\s+/u', $AUTH_ACL);
         if(count($matches)) {
             foreach($matches as $match) {
                 $match = preg_replace('/#.*$/', '', $match); //ignore comments


### PR DESCRIPTION
ACL matching of DokuWiki is currently always case-sensitive
regardless of auth backend setting ($auth->isCaseSensitive).

These commits enable case-insensitive matching in the same way
of auth_isMember().
