### PR TITLE
xmlrpc putPage and appendPage should return bool

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -48,7 +48,7 @@ class RemoteAPICore {
                 'public' => '1'
             ), 'dokuwiki.appendPage' => array(
                 'args' => array('string', 'string', 'array'),
-                'return' => 'int',
+                'return' => 'bool',
                 'doc' => 'Append text to a wiki page.'
             ),  'wiki.getPage' => array(
                 'args' => array('string'),
@@ -102,7 +102,7 @@ class RemoteAPICore {
                 'name' => 'pageVersions'
             ), 'wiki.putPage' => array(
                 'args' => array('string', 'string', 'array'),
-                'return' => 'int',
+                'return' => 'bool',
                 'doc' => 'Saves a wiki page.'
             ), 'wiki.listLinks' => array(
                 'args' => array('string'),


### PR DESCRIPTION
According to dokuwiki's documentation (https://www.dokuwiki.org/devel:xmlrpc#wikiputpage),
those two xmlrpc methods should return bool, not int.

They currently return unconditionally the xmlrpc int 0 (which isn't cast automatically to bool for example with the java library http://ws.apache.org/xmlrpc/)

Please let me know if documentation should be updated instead.
