### PR TITLE
Made auth_aclcheck always return int

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -580,7 +580,7 @@ function auth_aclcheck($id, $user, $groups) {
         }
         if($perm > -1) {
             //we had a match - return it
-            return $perm;
+            return (int) $perm;
         }
     }
 
@@ -610,7 +610,7 @@ function auth_aclcheck($id, $user, $groups) {
             }
             //we had a match - return it
             if($perm != -1) {
-                return $perm;
+                return (int) $perm;
             }
         }
         //get next higher namespace


### PR DESCRIPTION
The returned type is important in particular when we deal with xmlrpc. Indeed,
this value is directly returned to the client eg when the wiki.getAllPages method
is queried.

Currently the 'perms' attribute may be either an int or a string, and its up to
the xmlrpc client to resolve it (although Dokuwiki's documentation only tells it
can be an int).

This patch makes sure we'll always return perms as int.
