### PR TITLE
Check search limit depth with an inequality

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -247,7 +247,7 @@ function search_pagename(&$data,$base,$file,$type,$lvl,$opts){
  * @author  Andreas Gohr <andi@splitbrain.org>
  */
 function search_allpages(&$data,$base,$file,$type,$lvl,$opts){
-    if(isset($opts['depth'])){
+    if(isset($opts['depth']) && $opts['depth']){
         $parts = explode('/',ltrim($file,'/'));
         if(($type == 'd' && count($parts) > $opts['depth'])
           || ($type != 'd' && count($parts) > $opts['depth'] + 1)){


### PR DESCRIPTION
Otherwise, when we check for equality, the test fails if the search starts beneath
the max depth.
Eg: if I have the page ns1:ns2:mypage in my wiki, and launch the xmlrpc query
getPagelist("ns1", "depth => 1"), without this patch, it retrieves mypage

The following test (made with the xml-rpc client [dokuJClient](https://github.com/gturri/dokujclient)) fails without this patch, but succeeds with it:

```
@org.junit.Test
public void testGetPagelistWithAMaxDepth() throws Exception {
    //Setting up test environmnent
    DokuJClient client = new DokuJClient(TestParams.url, TestParams.user, TestParams.password);
    client.putPage("ns:shallow_page", "some text");
    client.putPage("ns:subns:deep_page", "some text");

    Map<String, Object> options = new HashMap<String, Object>();
    options.put("depth", 1);

    //Testing
    List<PageDW> pages = client.getPagelist("ns", options);
    assertEquals(1, pages.size());
    assertEquals("ns:shallow_page", pages.get(0).id());

    pages = client.getPagelist("ns:subns", options);
    assertEquals(0, pages.size());
}
```
