### PR TITLE
wiki.getAttachments returns 'perms' according to documentation

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -3,7 +3,7 @@
 /**
  * Increased whenever the API is changed
  */
-define('DOKU_API_VERSION', 7);
+define('DOKU_API_VERSION', 8);
 
 class RemoteAPICore {
 


### PR DESCRIPTION
The xml-rpc methods [wiki.getAllPages](https://www.dokuwiki.org/devel:xmlrpc#wikigetallpages), [wiki.getRecentMediaChanges](https://www.dokuwiki.org/devel:xmlrpc#wikigetrecentmediachanges)  and [wiki.getAttachments](https://www.dokuwiki.org/devel:xmlrpc#wikigetattachments) send information about permissions through a 'perms' attribute.

However, in practice, wiki.getAttachment doesn't but sends a 'perm' attribute (because of the way media are searched [1](https://github.com/splitbrain/dokuwiki/blob/master/inc/search.php#L164)). It's therefore not consistent, and it doesn't respect Dokuwiki's documentation.

A solution could be the following patch:

```
--- a/inc/search.php
+++ b/inc/search.php
@@ -161,8 +161,8 @@ function search_media(&$data,$base,$file,$type,$lvl,$opts){
     }

     //check ACL for namespace (we have no ACL for mediafiles)
-    $info['perm'] = auth_quickaclcheck(getNS($info['id']).':*');
-    if(!$opts['skipacl'] && $info['perm'] < AUTH_READ){
+    $info['perms'] = auth_quickaclcheck(getNS($info['id']).':*');
+    if(!$opts['skipacl'] && $info['perms'] < AUTH_READ){
         return false;
     }
```

There would be however two drawbacks:
- it would change an existing behavior (and therefore plugins relying on it)
- search_media would be inconsistent with search_universal

Hence this pull request which doesn't change search.php, but acts at the xml-rpc level.
