### PR TITLE
handle bz (bzip not bzip2) better

### DIFF
--- a/_test/tests/inc/tar.test.php
+++ b/_test/tests/inc/tar.test.php
@@ -73,7 +73,7 @@ class Tar_TestCase extends DokuWikiTest {
     public function test_tarcontent() {
         $dir = dirname(__FILE__).'/tar';
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -96,7 +96,7 @@ class Tar_TestCase extends DokuWikiTest {
         $dir = dirname(__FILE__).'/tar';
         $out = sys_get_temp_dir().'/dwtartest'.md5(time());
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -122,7 +122,7 @@ class Tar_TestCase extends DokuWikiTest {
         $dir = dirname(__FILE__).'/tar';
         $out = sys_get_temp_dir().'/dwtartest'.md5(time());
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -148,7 +148,7 @@ class Tar_TestCase extends DokuWikiTest {
         $dir = dirname(__FILE__).'/tar';
         $out = sys_get_temp_dir().'/dwtartest'.md5(time());
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -174,7 +174,7 @@ class Tar_TestCase extends DokuWikiTest {
         $dir = dirname(__FILE__).'/tar';
         $out = sys_get_temp_dir().'/dwtartest'.md5(time());
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -199,7 +199,7 @@ class Tar_TestCase extends DokuWikiTest {
         $dir = dirname(__FILE__).'/tar';
         $out = sys_get_temp_dir().'/dwtartest'.md5(time());
 
-        foreach(array('tar', 'tgz', 'tbz') as $ext) {
+        foreach(array('tar', 'tgz', 'tbz', 'tbz2') as $ext) {
             $tar  = new Tar();
             $file = "$dir/test.$ext";
 
@@ -229,6 +229,10 @@ class Tar_TestCase extends DokuWikiTest {
         $this->assertEquals(Tar::COMPRESS_GZIP, $tar->filetype('foo.tar.gz'));
         $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tbz'));
         $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tBZ'));
+        $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tbz2'));
+        $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tBZ2'));
+        $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tar.bz'));
+        $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tar.BZ'));
         $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tar.BZ2'));
         $this->assertEquals(Tar::COMPRESS_BZIP, $tar->filetype('foo.tar.bz2'));
     }

--- a/inc/Tar.class.php
+++ b/inc/Tar.class.php
@@ -618,7 +618,7 @@ class Tar {
         $file = strtolower($file);
         if(substr($file, -3) == '.gz' || substr($file, -4) == '.tgz') {
             $comptype = Tar::COMPRESS_GZIP;
-        } elseif(substr($file, -4) == '.bz2' || substr($file, -4) == '.tbz') {
+        } elseif(substr($file, -4) == '.bz2' || substr($file, -3) == '.bz' || substr($file, -4) == '.tbz' || substr($file, -5) == ".tbz2") {
             $comptype = Tar::COMPRESS_BZIP;
         } else {
             $comptype = Tar::COMPRESS_NONE;

--- a/lib/plugins/plugin/classes/ap_download.class.php
+++ b/lib/plugins/plugin/classes/ap_download.class.php
@@ -195,7 +195,7 @@ class ap_download extends ap_manage {
         if (substr($target, -1) == "/") $target = substr($target, 0, -1);
 
         $ext = $this->guess_archive($file);
-        if (in_array($ext, array('tar','bz','gz'))) {
+        if (in_array($ext, array('tar','bz','bz2','gz'))) {
             switch($ext){
                 case 'bz':
                     $compress_type = Tar::COMPRESS_BZIP;


### PR DESCRIPTION
in fact .tbz is tar.bz (bzip1) and .tbz2 is what tar.bz2 is used
commonly.

i modified the code, but did not run any tests (not automated unittests or uploads with the ui), haven't figured out yet how to run them

anyway, seems the two bytes of both compressor match signature used in dokuwiki and php-bz2 extension opens the stream without errors:

```
$ tar -cf /tmp/a.tar.bz --use-compress=bzip .gitignore 
$ tar -cf /tmp/a.tar.bz2 --use-compress=bzip2 .gitignore 

$ file /tmp/a.tar.bz*
/tmp/a.tar.bz:  data
/tmp/a.tar.bz2: bzip2 compressed data, block size = 900k

$ cut -c1-4 /tmp/a.tar.bz | od -cx
0000000   B   Z   0   9  \n   `  \0  \n
           5a42    3930    600a    0a00
0000010
$ cut -c1-4 /tmp/a.tar.bz2 | od -cx
0000000   B   Z   h   9  \n  \t   % 032 017  \n   J  \f 311 206  \n   X
           5a42    3968    090a    1a25    0a0f    0c4a    86c9    580a
0000020   >   j   *  \n 367   w   m 031  \n
           6a3e    0a2a    77f7    196d    000a
0000031

$ php -r '$f=bzopen("/tmp/a.tar.bz", "r"); var_dump($f);'|less
resource(4) of type (stream)
$ php -r '$f=bzopen("/tmp/a.tar.bz2", "r"); var_dump($f);'|less
resource(4) of type (stream)
```
