### PR TITLE
fix for FS#2676, inserting zero length spaces into long sequences of non...

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -1226,8 +1226,8 @@ function html_softbreak_callback($match){
   // breaking character (zero length space, U+200B / #8203) in front them.
   $regex = <<< REGEX
 (?(?=                                 # start a conditional expression with a positive look ahead ...
-&(\#\\d{1,4}|[[:alpha:]]{1,4});)      # ... for html entities - we don't want to split them
-&\#?\\w{1,4};                         # yes pattern - a quicker match for the html entity, since we know we have one
+&\#?\\w{1,6};)                        # ... for html entities - we don't want to split them (ok to catch some invalid combinations)
+&\#?\\w{1,6};                         # yes pattern - a quicker match for the html entity, since we know we have one
 |
 [?/,&\#;:]+                           # no pattern - any other group of 'special' characters to insert a breaking character after
 )                                     # end conditional expression


### PR DESCRIPTION
...-breaking characters in diffs

post process the html content string returned by Diff->format to locate long, unbroken strings of characters.  Examine those strings and insert zero length (zl) spaces after certain characters (e.g. /#!,:;).  When there are sequences of the 'special' characters only insert the zl space after the last character in the sequence.

Also, don't modify content within html tags and keep html entities together.
