### PR TITLE
Don't hide search suggestion during typing & limit suggestions.

### DIFF
--- a/lib/exe/ajax.php
+++ b/lib/exe/ajax.php
@@ -45,6 +45,8 @@ function ajax_qsearch(){
     global $lang;
     global $INPUT;
 
+    $maxnumbersuggestions = 50;
+
     $query = $INPUT->post->str('q');
     if(empty($query)) $query = $INPUT->get->str('q');
     if(empty($query)) return;
@@ -72,7 +74,7 @@ function ajax_qsearch(){
         echo '<li>' . html_wikilink(':'.$id,$name) . '</li>';
 
         $counter ++;
-        if($counter > 50) {
+        if($counter > $maxnumbersuggestions) {
             echo '<li>...</li>';
             break;
         }

--- a/lib/scripts/qsearch.js
+++ b/lib/scripts/qsearch.js
@@ -37,6 +37,7 @@ var dw_qsearch = {
         do_qsearch = function () {
             var value = dw_qsearch.$inObj.val();
             if (value === '') {
+                dw_qsearch.clear_results();
                 return;
             }
             jQuery.post(
@@ -83,7 +84,10 @@ var dw_qsearch = {
     onCompletion: function(data) {
         var max, $links, too_big;
 
-        if (data === '') { return; }
+        if (data === '') {
+            dw_qsearch.clear_results();
+            return;
+        }
 
         dw_qsearch.$outObj
             .html(data)


### PR DESCRIPTION
#### Keep search suggestions, during typing in search field

It is quite annoying that when the suggestions are shown, they immediately hide when you continue typing. Removing unneeded clear actions solves this. When clicked beside the input or output `closePopups()` in `lib/scripts/script.js` closes the popup.
#### Shorten search results for a few character search term

When the search input is still only a few characters, the number of matching pages is big.
Browsers have heavy work to progress this whole return, better cut off so only the part that is directly displayed will be sent. 50 is quite random number.
