### PR TITLE
Some tidying up of the "auth" forms in the 'dokuwiki' template

### DIFF
--- a/lib/tpl/dokuwiki/css/_forms.css
+++ b/lib/tpl/dokuwiki/css/_forms.css
@@ -72,12 +72,12 @@
  */
 #dw__login label[for="remember__me"] {
     margin-left: 50%;
-    margin-bottom: 1.5em;
+    margin-bottom: 1.4em;
 }
 #dw__login fieldset,
 #dw__resendpwd fieldset,
 #dw__register fieldset {
-    padding-bottom: 1em;
+    padding-bottom: 0.7em;
 }
 
 


### PR DESCRIPTION
auth forms being, login, resend password, register and user profile.

commit messages should be pretty explanatory
