### PR TITLE
touch the config on save, even if no changes were made

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -67,6 +67,8 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
         $this->_close_session();
         header("Location: ".wl($ID,array('do'=>'admin','page'=>'config'),true,'&'));
         exit();
+      } elseif(!$this->_error) {
+          $this->_config->touch_settings(); // just touch to refresh cache
       }
 
       $this->_close_session();

--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -130,6 +130,15 @@ if (!class_exists('configuration')) {
       return true;
     }
 
+    /**
+     * Update last modified time stamp of the config file
+     */
+    function touch_settings(){
+        if ($this->locked) return false;
+        $file = end($this->_local_files);
+        return @touch($file);
+    }
+
     function _read_config_group($files) {
       $config = array();
       foreach ($files as $file) {


### PR DESCRIPTION
Sometimes, the DokuWiki's cache needs to be invalidated. The simplest way to do so is touching the local.php. However this is complicated for Windows and FTP-Users. One workaround is to change something in the config, save, change it back, save again. Still a bit complicated. This is because the config will not be saved when nothing was changed. This patch will simply touch the config when on saving, when no change was made.
