### PR TITLE
FS#2718, fix IE9, 10 not executing js after @media layout changes

### DIFF
--- a/lib/tpl/dokuwiki/script.js
+++ b/lib/tpl/dokuwiki/script.js
@@ -12,7 +12,7 @@ var device_classes = 'desktop mobile tablet phone';
 function tpl_dokuwiki_mobile(){
 
     // the z-index in mobile.css is (mis-)used purely for detecting the screen mode here
-    var screen_mode = jQuery('#screen__mode').css('z-index');
+    var screen_mode = jQuery('#screen__mode').css('z-index') + '';
 
     // determine our device pattern
     // TODO: consider moving into dokuwiki core


### PR DESCRIPTION
issue not related to resizing, but the type of the value returned by css('z-index').
