### PR TITLE
FS#2723, enable (horiz.) scrolling for the media manager on narrow screens

### DIFF
--- a/lib/tpl/dokuwiki/css/_media_fullscreen.css
+++ b/lib/tpl/dokuwiki/css/_media_fullscreen.css
@@ -501,9 +501,4 @@
     width: 100%;
     max-width: none;
 }
-/* enable horizontal scrolling on narrow screens */
-.tablet .mode_media div.page,
-.phone .mode_media div.page {
-    overflow: auto;
-}
 

--- a/lib/tpl/dokuwiki/css/mobile.css
+++ b/lib/tpl/dokuwiki/css/mobile.css
@@ -279,6 +279,12 @@ body {
     padding: .5em;
 }
 
+/* media manager
+   enable horizontal scrolling on narrow screens */
+.mode_media div.page,
+.mode_media div.page {
+    overflow: auto;
+}
 
 
 } /* /@media */


### PR DESCRIPTION
more info on bug report. https://bugs.dokuwiki.org/index.php?do=details&task_id=2723
