### PR TITLE
Fix double encoding in rss syntax FS#2731

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -889,7 +889,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                     // title is escaped by SimplePie, we unescape here because it
                     // is escaped again in externallink() FS#1705
                     $this->externallink($item->get_permalink(),
-                                        htmlspecialchars_decode($item->get_title()));
+                                        html_entity_decode($item->get_title(), ENT_QUOTES, 'UTF-8'));
                 }else{
                     $this->doc .= ' '.$item->get_title();
                 }


### PR DESCRIPTION
The new SimplePie version not only applies htmlspecialchars() but creates a DOM document which applies all sorts of HTML entities. This means that for example "ä" will become '"&amp;auml;'". htmlspecialchars_decode() does not decode these entities which leads to double encoding.

As far as I understood the documentation html_entity_decode() does everything htmlspecialchars_decode() does and in addition it decodes HTML entities, that's why I propose in this pull request to replace htmlspecialchars_decode() by html_entity_decode().
