### PR TITLE
Fix page tools display with images disabled FS#2634

### DIFF
--- a/lib/tpl/dokuwiki/css/pagetools.css
+++ b/lib/tpl/dokuwiki/css/pagetools.css
@@ -133,6 +133,25 @@
     padding: 5px 5px 5px 40px;
 }
 
+/* IE7 fixes, doesn't work without images */
+
+#IE7 #dokuwiki__pagetools ul li a {
+    background-image: url(images/pagetools-sprite.png);
+}
+
+#IE7 #dokuwiki__pagetools:hover ul li a span,
+#IE7 #dokuwiki__pagetools ul li a:focus span,
+#IE7 #dokuwiki__pagetools ul li a:active span {
+    clip: auto;
+    display: inline;
+    position: static;
+}
+
+#IE7 #dokuwiki__pagetools ul li a span {
+    clip: rect(0 0 0 0);
+    position: absolute;
+}
+
 #dokuwiki__pagetools ul li a:hover,
 #dokuwiki__pagetools ul li a:active,
 #dokuwiki__pagetools ul li a:focus {


### PR DESCRIPTION
This uses the technique described at http://nicolasgallagher.com/css-image-replacement-with-pseudo-elements/ in order to show the text of the page tools when images are disabled. In the activated mode where text and images are shown the original method is used as otherwise the icons were on the left side of the text.

The second commit re-enables the old behavior for IE7 as this new technique doesn't work in IE7. With just the first commit IE7 looks as if images were disabled, when the text is fully shown images are visible, too.

The first commit also contains another fix for IE7: For making the text visible when the link is focused, one needs to use :active in IE7. I simply included :active everywhere where :focus was used already. If we should decide against this pull request this fix should be applied to the old code.

[Edit] I tested with: Chromium 25.0.1364.97 on Linux, Opera 12.14 on Linux and Windows XP, Internet Explorer 8 (and IE7 mode) on Windows XP, Firefox 19.0 on Linux. I tested with German and Arabic (RTL) localization (but without switching anything else to RTL).
