### PR TITLE
Require immediate HTTP revalidation for media serving

### DIFF
--- a/lib/exe/fetch.php
+++ b/lib/exe/fetch.php
@@ -98,27 +98,12 @@ if(!defined('SIMPLE_TEST')) {
  */
 function sendFile($file, $mime, $dl, $cache) {
     global $conf;
-    $fmtime = @filemtime($file);
     // send headers
     header("Content-Type: $mime");
-    // smart http caching headers
-    if($cache == -1) {
-        // cache
-        // cachetime or one hour
-        header('Expires: '.gmdate("D, d M Y H:i:s", time() + max($conf['cachetime'], 3600)).' GMT');
-        header('Cache-Control: public, proxy-revalidate, no-transform, max-age='.max($conf['cachetime'], 3600));
-        header('Pragma: public');
-    } else if($cache > 0) {
-        // recache
-        // remaining cachetime + 10 seconds so the newly recached media is used
-        header('Expires: '.gmdate("D, d M Y H:i:s", $fmtime + $conf['cachetime'] + 10).' GMT');
-        header('Cache-Control: public, proxy-revalidate, no-transform, max-age='.max($fmtime - time() + $conf['cachetime'] + 10, 0));
-        header('Pragma: public');
-    } else if($cache == 0) {
-        // nocache
-        header('Cache-Control: must-revalidate, no-transform, post-check=0, pre-check=0');
-        header('Pragma: public');
-    }
+    // avoid resending files from intermediate caches without revalidation
+    header('Expires: Thu, 01 Jan 1970 00:00:00 GMT');
+    header('Cache-Control: private, no-transform, max-age=0');
+    header('Pragma: no-cache');
     //send important headers first, script stops here if '304 Not Modified' response
     http_conditionalRequest($fmtime);
 


### PR DESCRIPTION
Original report by Eric Searcy

Dokuwiki currently provides HTTP/1.0 and HTTP/1.1 protocol cache headers
for _media content.  The author of this feature intended [1] to allow
public caching, with mandatory re-validation to enforce ACLs.  However,
there are two issues with it:

(A) HTTP/1.0 public caches may re-serve the response.  HTTP/1.0 caches,
given a response with the future Expires header and lack of "Pragma:
no-cache" (if supported by that cache), could therefore bypass ACLs when
re-serving restricted media to additional users (for 1 day by default).

(B) The proxy-revalidate directive only applies to stale content
according to RFC, though there is some misinformation about this in
secondary sources.  While proxy-revalidate has same meaning as
must-revalidate except applying only to shared caches, must-revalidate
only says that if cached data is _stale_ (past max-age), a stale
response cannot be served---it doesn't affect fresh cached data [2].
Therefore a public cache, even while respecting proxy-revalidate, can
still serve out restricted media to the wrong user during the time the
cache is fresh (1 day by default).

The attached patch (for "git am") conservatively requires immediate
revalidation (max-age=0/Expires in 1970) and should limit storage to the
browser cache (private).  I tested this with Chrome directly hitting a
dokuwiki site, which re-validated and received a "304 Not Modified"
response (did not have to re-download).  Testing with a public cache
required the full document to be re-downloaded each time, causing a
minor performance loss.  A further enhancement (not coded) would be to
allow public caching for HTTP/1.0 and 1.1 if an ACL check determines
@ALL access.  (Note, for HTTP/1.1, setting max-age >0 along with private
directive could still allow an ACL bypass from the same browser after a
user ends their dokuwiki session, hence the choice to require even
private caches to revalidate.)

[1] https://github.com/splitbrain/dokuwiki/commit/83730152bf
[2] http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4
