### PR TITLE
Redirect only in the show action to namespace start pages FS#2743

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -21,6 +21,7 @@
 function getID($param='id',$clean=true){
     global $INPUT;
     global $conf;
+    global $ACT;
 
     $id = $INPUT->str($param);
 
@@ -75,7 +76,7 @@ function getID($param='id',$clean=true){
             // fall back to default
             $id = $id.$conf['start'];
         }
-        send_redirect(wl($id,'',true));
+        if (isset($ACT) && $ACT === 'show') send_redirect(wl($id,'',true));
     }
 
     if($clean) $id = cleanID($id);


### PR DESCRIPTION
When the current page id ends with ":" (or "/" with useslash enabled)
DokuWiki tries to find the start page of namespaces automatically and
then redirects to this page. The target of the redirect is always the
show action regardless if the current request contains another action or
is an ajax request. In practice you can get this problem when your
search query ends with ":" (e.g. because you want to match a namespace),
then you are redirected to the show action.

This change completely disables the redirect when $ACT is undefined or
the current action is not "show".
