### PR TITLE
correct parenthesis in image crop calculations to ensure integer values

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1831,23 +1831,23 @@ function media_crop_image($file, $ext, $w, $h=0){
     if($tr >= 1){
         if($tr > $fr){
             $cw = $info[0];
-            $ch = (int) $info[0]/$tr;
+            $ch = (int) ($info[0]/$tr);
         }else{
-            $cw = (int) $info[1]*$tr;
+            $cw = (int) ($info[1]*$tr);
             $ch = $info[1];
         }
     }else{
         if($tr < $fr){
-            $cw = (int) $info[1]*$tr;
+            $cw = (int) ($info[1]*$tr);
             $ch = $info[1];
         }else{
             $cw = $info[0];
-            $ch = (int) $info[0]/$tr;
+            $ch = (int) ($info[0]/$tr);
         }
     }
     // calculate crop offset
-    $cx = (int) ($info[0]-$cw)/2;
-    $cy = (int) ($info[1]-$ch)/3;
+    $cx = (int) (($info[0]-$cw)/2);
+    $cy = (int) (($info[1]-$ch)/3);
 
     //cache
     $local = getCacheName($file,'.media.'.$cw.'x'.$ch.'.crop.'.$ext);


### PR DESCRIPTION
The cw & ch values are used in the cropped image cache file name.  If these values remain as floats, crop cache file names will vary for identical images generated by different crop parameters potentially resulting in an excess of cached images.
