### PR TITLE
process a crop as a resize when possible

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1795,6 +1795,9 @@ function media_resize_image($file, $ext, $w, $h=0){
     // we wont scale up to infinity
     if($w > 2000 || $h > 2000) return $file;
 
+    // resize necessary? - (w,h) = native dimensions
+    if(($w == $info[0]) && ($h == $info[1])) return $file;
+
     //cache
     $local = getCacheName($file,'.media.'.$w.'x'.$h.'.'.$ext);
     $mtime = @filemtime($local); // 0 if not exists


### PR DESCRIPTION
Currently dokuwiki will generate two cached images when both width & height for an image in the wiki, a 'crop' then a 'resize'.  When the aspect ratio of the crop matches the aspect ratio of the source image, it is effectively the equivalent of a resize.

This patches adds a check in the crop function to see if the final image dimensions would match those of a resize and if so, calls resize immediately rather than after the crop, resulting in one cached image.

e.g.  source image.jpg  2574px x 1926px
image.jpg?1000
image.jpg?1000x748
will now both use the same cached image, cache/hash.media.1000x748.jpg
rather than the previous three images
cache/hash.media.1000x748.jpg
cache/hash.media.2574x1926.crop.jpg
cache/hash2.media.1000x748.jpg
