### PR TITLE
Rename ad_usernamepassword to admin_username/password

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -469,10 +469,10 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
             $this->cando['modPass'] = false;
         }
 
-        if(isset($opts['ad_username']) && isset($opts['ad_password'])) {
+        if(isset($opts['admin_username']) && isset($opts['admin_password'])) {
             $this->cando['getUsers'] = true;
         } else {
-            $this->cando['getUsers'] = true;
+            $this->cando['getUsers'] = false;
         }
 
         return $opts;


### PR DESCRIPTION
- Rename of ad_\* to admin_*
- canDo[getUsers] to false when admin_user&admin_password unavailable, is now always true.

Be aware: Untested!
