### PR TITLE
Added comment to DiffFormatter _escape() method

### DIFF
--- a/inc/DifferenceEngine.php
+++ b/inc/DifferenceEngine.php
@@ -818,6 +818,8 @@ class DiffFormatter {
     }
 
     function _escape($str){
+        // Override this method in other formatters if escaping required
+        // Base class requires $str returned without escaping
         return $str;
     }
 }


### PR DESCRIPTION
Clarifies that base class should NOT process the incoming string.
