### PR TITLE
Added comment to DiffFormatter _escape() method

### DIFF
--- a/inc/DifferenceEngine.php
+++ b/inc/DifferenceEngine.php
@@ -817,7 +817,16 @@ class DiffFormatter {
         $this->_added($closing);
     }
 
-    function _escape($str){
+    /**
+     * Escape string
+     * 
+     * Override this method within other formatters if escaping required.
+     * Base class requires $str to be returned WITHOUT escaping.
+     * 
+     * @param $str string Text string to escape
+     * @return string The escaped string.
+     */
+     function _escape($str){
         return $str;
     }
 }


### PR DESCRIPTION
Clarify use of _escape() method in base class.
