### PR TITLE
add newest plugin types to info plugin

### DIFF
--- a/lib/plugins/info/syntax.php
+++ b/lib/plugins/info/syntax.php
@@ -81,6 +81,12 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin {
                 case 'helperplugins':
                     $this->_plugins_xhtml('helper', $renderer);
                     break;
+                case 'authplugins':
+                    $this->_plugins_xhtml('auth', $renderer);
+                    break;
+                case 'remoteplugins':
+                    $this->_plugins_xhtml('remote', $renderer);
+                    break;
                 case 'helpermethods':
                     $this->_helpermethods_xhtml($renderer);
                     break;


### PR DESCRIPTION
The constructor of the authldap plugin push a message about missing ldap, when the right ldap libs aren't installed at the server the wiki is running. I don't know it that should receive any attention further?
