### PR TITLE
Improve Linkwizard, make it can be used more than once

### DIFF
--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -22,6 +22,8 @@ var dw_linkwiz = {
         var pos = $editor.position();
 
         // create HTML Structure
+        if(dw_linkwiz.$wiz)
+            return;
         dw_linkwiz.$wiz = jQuery(document.createElement('div'))
                .dialog({
                    autoOpen: false,
@@ -235,15 +237,25 @@ var dw_linkwiz = {
            link = ':' + link;
         }
 
-        var so = link.length+3;
 
-        link = '[['+link+'|';
-        if(stxt) {
-            link += stxt;
+        var so = link.length;
+        var eo = 0;
+        if(dw_linkwiz.val){
+            if(dw_linkwiz.val.open) {
+                so += dw_linkwiz.val.open.length;
+                link = dw_linkwiz.val.open+link;
+            }
+            if(stxt) {
+                link += '|'+stxt;
+                so += 1;
+            }
+            if(dw_linkwiz.val.close) {
+                link += dw_linkwiz.val.close;
+                eo = dw_linkwiz.val.close.length;
+            }
         }
-        link += ']]';
 
-        pasteText(sel,link,{startofs: so, endofs: 2});
+        pasteText(sel,link,{startofs: so, endofs: eo});
         dw_linkwiz.hide();
 
         // reset the entry to the parent namespace

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -211,9 +211,10 @@ function addBtnActionPicker($btn, props, edid) {
  * @return boolean    If button should be appended
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
-function addBtnActionLinkwiz(btn, props, edid) {
+function addBtnActionLinkwiz($btn, props, edid) {
     dw_linkwiz.init(jQuery('#'+edid));
-    jQuery(btn).click(function(){
+    jQuery($btn).click(function(){
+        dw_linkwiz.val = props;
         dw_linkwiz.toggle();
         return false;
     });


### PR DESCRIPTION
As reported in https://forum.dokuwiki.org/thread/9988
the previous implementation can not handle the situation of use the
linkwiz more than once. Now you can use in you toolbar plugin
    'type' => 'linkwiz'
to make use of the handy Linkwizard for choosing the wiki pages.
