### PR TITLE
add TEMPLATE_DOKUWIKI_PAGETOOLFLOAT_DISPLAY event to template

### DIFF
--- a/lib/tpl/dokuwiki/detail.php
+++ b/lib/tpl/dokuwiki/detail.php
@@ -124,7 +124,11 @@ header('X-UA-Compatible: IE=edge,chrome=1');
                                 $data['img_backto'] = '<li><a href="'.wl($ID).'" class="back"><span>'.$lang['img_backto'].' '.$ID.'</span></a></li>';
 
                                 // the page tools can be ammended through a custom plugin hook
-                                $evt = new Doku_Event('TEMPLATE_DOKUWIKI_PAGETOOLFLOAT_DISPLAY', $data);
+                                // if you're deriving from this template and your design is close enough to
+                                // the dokuwiki template you might want to trigger a DOKUWIKI event instead
+                                // of using $conf['tpl'] here
+                                $hook = 'TEMPLATE_'.strtoupper($conf['tpl']).'_PAGETOOLS_DISPLAY';
+                                $evt = new Doku_Event($hook, $data);
                                 if($evt->advise_before()){
                                     foreach($evt->data as $k => $html) echo $html;
                                 }

--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -85,7 +85,11 @@ $showSidebar = $hasSidebar && ($ACT=='show');
                             );
 
                             // the page tools can be ammended through a custom plugin hook
-                            $evt = new Doku_Event('TEMPLATE_DOKUWIKI_PAGETOOLFLOAT_DISPLAY', $data);
+                            // if you're deriving from this template and your design is close enough to
+                            // the dokuwiki template you might want to trigger a DOKUWIKI event instead
+                            // of using $conf['tpl'] here
+                            $hook = 'TEMPLATE_'.strtoupper($conf['tpl']).'_PAGETOOLS_DISPLAY';
+                            $evt = new Doku_Event($hook, $data);
                             if($evt->advise_before()){
                                 foreach($evt->data as $k => $html) echo $html;
                             }


### PR DESCRIPTION
This adds a custom event to the 'dokuwiki' template that allows plugin
authors to easily integrate custom pagetool buttons into the template.
