### PR TITLE
adding ACL handlers to xmlrpc

### DIFF
--- a/lib/plugins/acl/remote.php
+++ b/lib/plugins/acl/remote.php
@@ -1,32 +1,30 @@
 <?php
 
 class remote_plugin_acl extends DokuWiki_Remote_Plugin {
-	function _getMethods() {
+    function _getMethods() {
         return array(
-            'plugin.acl.addAcl' => array(
+            'addAcl' => array(
                 'args' => array('string','string','int'),
                 'return' => 'int',
                 'name' => 'addAcl',
                 'doc' => 'Adds a new ACL rule.'
-			), 'plugin.delAcl' => array(
+            ), 'delAcl' => array(
                 'args' => array('string','string'),
                 'return' => 'int',
                 'name' => 'delAcl',
                 'doc' => 'Delete an existing ACL rule.'
-			),
+            ),
         );
     }
-
 	
-	function addAcl($scope, $user, $level){
-		$apa = new admin_plugin_acl(); 
-		return $apa->_acl_add($scope, $user, $level);
-	}
+    function addAcl($scope, $user, $level){
+        $apa = plugin_load('admin', 'acl'); 
+        return $apa->_acl_add($scope, $user, $level);
+    }
 	
-	function delAcl($scope, $user){
-		$apa = new admin_plugin_acl(); 
-		return $apa->_acl_del($scope, $user);
-	}
+    function delAcl($scope, $user){
+        $apa = plugin_load('admin', 'acl'); 
+        return $apa->_acl_del($scope, $user);
+    }
 }
 
-?>


### PR DESCRIPTION
Adding methods to xmlrpc to remotely add or remove an ACL rule.
The purpose is to develop a dokuwiki plugin for redmine to replace existing wiki which automatically adds an ACL rule whenever a user is added to a group or a project
