### PR TITLE
fixed some bi-directionality issues

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -575,18 +575,18 @@ function html_revisions($first=0, $media_id = false){
         if ($info['sum']) {
             $form->addElement(form_makeOpenTag('span', array('class' => 'sum')));
             if (!$media_id) $form->addElement(' – ');
-            $form->addElement(htmlspecialchars($info['sum']));
+            $form->addElement('<bdi>'.htmlspecialchars($info['sum']).'</bdi>');
             $form->addElement(form_makeCloseTag('span'));
         }
 
         $form->addElement(form_makeOpenTag('span', array('class' => 'user')));
         if($info['user']){
-            $form->addElement(editorinfo($info['user']));
+            $form->addElement('<bdi>'.editorinfo($info['user']).'</bdi>');
             if(auth_ismanager()){
-                $form->addElement(' ('.$info['ip'].')');
+                $form->addElement(' <bdo dir="ltr">('.$info['ip'].')</bdo>');
             }
         }else{
-            $form->addElement($info['ip']);
+            $form->addElement('<bdo dir="ltr">'.$info['ip'].'</bdo>');
         }
         $form->addElement(form_makeCloseTag('span'));
 
@@ -774,12 +774,12 @@ function html_recent($first=0, $show_changes='both'){
 
         $form->addElement(form_makeOpenTag('span', array('class' => 'user')));
         if($recent['user']){
-            $form->addElement(editorinfo($recent['user']));
+            $form->addElement('<bdi>'.editorinfo($recent['user']).'</bdi>');
             if(auth_ismanager()){
-                $form->addElement(' ('.$recent['ip'].')');
+                $form->addElement(' <bdo dir="ltr">('.$recent['ip'].')</bdo>');
             }
         }else{
-            $form->addElement($recent['ip']);
+            $form->addElement('<bdo dir="ltr">'.$recent['ip'].'</bdo>');
         }
         $form->addElement(form_makeCloseTag('span'));
 
@@ -1027,52 +1027,52 @@ function html_diff_head($l_rev, $r_rev, $id = null, $media = false, $inline = fa
     }else{
         $l_info   = getRevisionInfo($id,$l_rev,true, $media);
         if($l_info['user']){
-            $l_user = editorinfo($l_info['user']);
-            if(auth_ismanager()) $l_user .= ' ('.$l_info['ip'].')';
+            $l_user = '<bdi>'.editorinfo($l_info['user']).'</bdi>';
+            if(auth_ismanager()) $l_user .= ' <bdo dir="ltr">('.$l_info['ip'].')</bdo>';
         } else {
-            $l_user = $l_info['ip'];
+            $l_user = '<bdo dir="ltr">'.$l_info['ip'].'</bdo>';
         }
         $l_user  = '<span class="user">'.$l_user.'</span>';
-        $l_sum   = ($l_info['sum']) ? '<span class="sum">'.hsc($l_info['sum']).'</span>' : '';
+        $l_sum   = ($l_info['sum']) ? '<span class="sum"><bdi>'.hsc($l_info['sum']).'</bdi></span>' : '';
         if ($l_info['type']===DOKU_CHANGE_TYPE_MINOR_EDIT) $l_minor = 'class="minor"';
 
         $l_head_title = ($media) ? dformat($l_rev) : $id.' ['.dformat($l_rev).']';
-        $l_head = '<a class="wikilink1" href="'.$ml_or_wl($id,"rev=$l_rev").'">'.
-        $l_head_title.'</a>'.
+        $l_head = '<bdi><a class="wikilink1" href="'.$ml_or_wl($id,"rev=$l_rev").'">'.
+        $l_head_title.'</a></bdi>'.
         $head_separator.$l_user.' '.$l_sum;
     }
 
     if($r_rev){
         $r_info   = getRevisionInfo($id,$r_rev,true, $media);
         if($r_info['user']){
-            $r_user = editorinfo($r_info['user']);
-            if(auth_ismanager()) $r_user .= ' ('.$r_info['ip'].')';
+            $r_user = '<bdi>'.editorinfo($r_info['user']).'</bdi>';
+            if(auth_ismanager()) $r_user .= ' <bdo dir="ltr">('.$r_info['ip'].')</bdo>';
         } else {
-            $r_user = $r_info['ip'];
+            $r_user = '<bdo dir="ltr">'.$r_info['ip'].'</bdo>';
         }
         $r_user = '<span class="user">'.$r_user.'</span>';
-        $r_sum  = ($r_info['sum']) ? '<span class="sum">'.hsc($r_info['sum']).'</span>' : '';
+        $r_sum  = ($r_info['sum']) ? '<span class="sum"><bdi>'.hsc($r_info['sum']).'</bdi></span>' : '';
         if ($r_info['type']===DOKU_CHANGE_TYPE_MINOR_EDIT) $r_minor = 'class="minor"';
 
         $r_head_title = ($media) ? dformat($r_rev) : $id.' ['.dformat($r_rev).']';
-        $r_head = '<a class="wikilink1" href="'.$ml_or_wl($id,"rev=$r_rev").'">'.
-        $r_head_title.'</a>'.
+        $r_head = '<bdi><a class="wikilink1" href="'.$ml_or_wl($id,"rev=$r_rev").'">'.
+        $r_head_title.'</a></bdi>'.
         $head_separator.$r_user.' '.$r_sum;
     }elseif($_rev = @filemtime($media_or_wikiFN($id))){
         $_info   = getRevisionInfo($id,$_rev,true, $media);
         if($_info['user']){
-            $_user = editorinfo($_info['user']);
-            if(auth_ismanager()) $_user .= ' ('.$_info['ip'].')';
+            $_user = '<bdi>'.editorinfo($_info['user']).'</bdi>';
+            if(auth_ismanager()) $_user .= ' <bdo dir="ltr">('.$_info['ip'].')</bdo>';
         } else {
-            $_user = $_info['ip'];
+            $_user = '<bdo dir="ltr">'.$_info['ip'].'</bdo>';
         }
         $_user = '<span class="user">'.$_user.'</span>';
-        $_sum  = ($_info['sum']) ? '<span class="sum">'.hsc($_info['sum']).'</span>' : '';
+        $_sum  = ($_info['sum']) ? '<span class="sum"><bdi>'.hsc($_info['sum']).'</span></bdi>' : '';
         if ($_info['type']===DOKU_CHANGE_TYPE_MINOR_EDIT) $r_minor = 'class="minor"';
 
         $r_head_title = ($media) ? dformat($_rev) : $id.' ['.dformat($_rev).']';
-        $r_head  = '<a class="wikilink1" href="'.$ml_or_wl($id).'">'.
-        $r_head_title.'</a> '.
+        $r_head  = '<bdi><a class="wikilink1" href="'.$ml_or_wl($id).'">'.
+        $r_head_title.'</a></bdi> '.
         '('.$lang['current'].')'.
         $head_separator.$_user.' '.$_sum;
     }else{

--- a/inc/template.php
+++ b/inc/template.php
@@ -468,7 +468,7 @@ function tpl_link($url, $name, $more = '', $return = false) {
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function tpl_pagelink($id, $name = null) {
-    print html_wikilink($id, $name);
+    print '<bdi>'.html_wikilink($id, $name).'</bdi>';
     return true;
 }
 
@@ -800,13 +800,7 @@ function tpl_breadcrumbs($sep = '•') {
 
     $crumbs = breadcrumbs(); //setup crumb trace
 
-    //reverse crumborder in right-to-left mode, add RLM character to fix heb/eng display mixups
-    if($lang['direction'] == 'rtl') {
-        $crumbs     = array_reverse($crumbs, true);
-        $crumbs_sep = ' &#8207;<span class="bcsep">'.$sep.'</span>&#8207; ';
-    } else {
-        $crumbs_sep = ' <span class="bcsep">'.$sep.'</span> ';
-    }
+    $crumbs_sep = ' <span class="bcsep">'.$sep.'</span> ';
 
     //render crumbs, highlight the last one
     print '<span class="bchead">'.$lang['breadcrumb'].':</span>';
@@ -816,7 +810,9 @@ function tpl_breadcrumbs($sep = '•') {
         $i++;
         echo $crumbs_sep;
         if($i == $last) print '<span class="curid">';
+        print '<bdi>';
         tpl_link(wl($id), hsc($name), 'class="breadcrumbs" title="'.$id.'"');
+        print '</bdi>';
         if($i == $last) print '</span>';
     }
     return true;
@@ -889,7 +885,7 @@ function tpl_userinfo() {
     global $lang;
     global $INFO;
     if(isset($_SERVER['REMOTE_USER'])) {
-        print $lang['loggedinas'].': '.hsc($INFO['userinfo']['name']).' ('.hsc($_SERVER['REMOTE_USER']).')';
+        print $lang['loggedinas'].': <bdi>'.hsc($INFO['userinfo']['name']).'</bdi> (<bdi>'.hsc($_SERVER['REMOTE_USER']).'</bdi>)';
         return true;
     }
     return false;
@@ -928,14 +924,14 @@ function tpl_pageinfo($ret = false) {
     // print it
     if($INFO['exists']) {
         $out = '';
-        $out .= $fn;
+        $out .= '<bdi>'.$fn.'</bdi>';
         $out .= ' · ';
         $out .= $lang['lastmod'];
         $out .= ': ';
         $out .= $date;
         if($INFO['editor']) {
             $out .= ' '.$lang['by'].' ';
-            $out .= editorinfo($INFO['editor']);
+            $out .= '<bdi>'.editorinfo($INFO['editor']).'</bdi>';
         } else {
             $out .= ' ('.$lang['external_edit'].')';
         }
@@ -943,7 +939,7 @@ function tpl_pageinfo($ret = false) {
             $out .= ' · ';
             $out .= $lang['lockedby'];
             $out .= ': ';
-            $out .= editorinfo($INFO['locked']);
+            $out .= '<bdi>'.editorinfo($INFO['locked']).'</bdi>';
         }
         if($ret) {
             return $out;
@@ -1469,8 +1465,8 @@ function tpl_license($img = 'badge', $imgonly = false, $return = false, $wrap = 
     }
     if(!$imgonly) {
         $out .= $lang['license'].' ';
-        $out .= '<a href="'.$lic['url'].'" rel="license" class="urlextern"'.$target;
-        $out .= '>'.$lic['name'].'</a>';
+        $out .= '<bdi><a href="'.$lic['url'].'" rel="license" class="urlextern"'.$target;
+        $out .= '>'.$lic['name'].'</a></bdi>';
     }
     if($wrap) $out .= '</div>';
 


### PR DESCRIPTION
Fixed some issues which occur whenever RTL and LTR languages could
potentially be mixed, using the HTML5 `<bdi>` element.
This element is currently only supported by Chrome and Firefox.

The old and only partially working fix for tpl_breadcrumbs() was removed in
favour of this solution.
