### PR TITLE
Lessify pagetools

### DIFF
--- a/lib/tpl/dokuwiki/css/pagetools.less
+++ b/lib/tpl/dokuwiki/css/pagetools.less
@@ -169,7 +169,7 @@
  * page tools without highlighting
  *
  * @param string @action The action class
- * @param int @position Position in the page tools
+ * @param int @position Position in the page tools sprite
  */
 .pagetools-item(@action, @position) {
     @position-active: (@position+0.5);
@@ -201,7 +201,7 @@
  * page tools with highlighting
  *
  * @param string @action The action class
- * @param int @position Position in the page tools
+ * @param int @position Position in the page tools sprite
  * @param string @mode The mode in which this tool should be highlighted
  */
 .pagetools-item(@action, @position, @mode) {


### PR DESCRIPTION
Lessified pagetools items, added mixins to simplify maintenance.

I don't like the solution that I use two different mixins (`.pagetools-item()` and `.pagetools-item-highlight()`), but I couldn't find a way to do the highlighting in only one mixin...
