### PR TITLE
Fix adLDAP exclusion in CodeSniffer rule set

### DIFF
--- a/_cs/DokuWiki/ruleset.xml
+++ b/_cs/DokuWiki/ruleset.xml
@@ -3,7 +3,7 @@
     <description>DokuWiki Coding Standard</description>
 
     <!-- ignore 3rd party libraries (that we haven't adopted) -->
-    <exclude-pattern>*/adLDAP.php</exclude-pattern>
+    <exclude-pattern>*/adLDAP/*</exclude-pattern>
     <exclude-pattern>*/EmailAddressValidator.php</exclude-pattern>
     <exclude-pattern>*/feedcreator.class.php</exclude-pattern>
     <exclude-pattern>*/SimplePie.php</exclude-pattern>


### PR DESCRIPTION
Fix the exclusion of adLDAP to exclude all of its dependent
subdirectories in addition to the main adLDAP.php file.
