### PR TITLE
Exclude templates from CS checks

### DIFF
--- a/_cs/DokuWiki/ruleset.xml
+++ b/_cs/DokuWiki/ruleset.xml
@@ -9,6 +9,7 @@
     <exclude-pattern>*/lib/plugins/authad/adLDAP/*</exclude-pattern>
     <exclude-pattern>*/lib/scripts/fileuploader.js</exclude-pattern>
     <exclude-pattern>*/lib/scripts/jquery/*</exclude-pattern>
+    <exclude-pattern>*/lib/tpl/*</exclude-pattern>
     <exclude-pattern>*/EmailAddressValidator.php</exclude-pattern>
     <exclude-pattern>*/feedcreator.class.php</exclude-pattern>
     <exclude-pattern>*/SimplePie.php</exclude-pattern>


### PR DESCRIPTION
Exclude the templates from CodeSniffer checks since they will be moving
out of the core per the comments in pull request #314.
