### PR TITLE
Exclude template named "default" from CS checks

### DIFF
--- a/_cs/DokuWiki/ruleset.xml
+++ b/_cs/DokuWiki/ruleset.xml
@@ -9,6 +9,7 @@
     <exclude-pattern>*/lib/plugins/authad/adLDAP/*</exclude-pattern>
     <exclude-pattern>*/lib/scripts/fileuploader.js</exclude-pattern>
     <exclude-pattern>*/lib/scripts/jquery/*</exclude-pattern>
+    <exclude-pattern>*/lib/tpl/default/*</exclude-pattern>
     <exclude-pattern>*/EmailAddressValidator.php</exclude-pattern>
     <exclude-pattern>*/feedcreator.class.php</exclude-pattern>
     <exclude-pattern>*/SimplePie.php</exclude-pattern>


### PR DESCRIPTION
Exclude the template named "default" from CodeSniffer checks since it
will move out of the core per comments in pull requests #314 and #325.
