### PR TITLE
Fix CodeSniffer whitespace violoations

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -333,7 +333,6 @@ class RemoteAPICore {
         if (!is_array($options)) $options = array();
         $options['skipacl'] = 0; // no ACL skipping for XMLRPC
 
-
         if(auth_quickaclcheck($ns.':*') >= AUTH_READ) {
             $dir = utf8_encodeFN(str_replace(':', '/', $ns));
 

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -391,7 +391,6 @@ function auth_randombytes($length) {
         }
     }
 
-
     // If no strong randoms available, try OS the specific ways
     if(!$strong) {
         // Unix/Linux platform

--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -395,7 +395,6 @@ function ft_snippet_re_preprocess($term) {
         $BR = '\b';
     }
 
-
     if(substr($term,0,2) == '\\*'){
         $term = substr($term,2);
     }else{

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -193,7 +193,6 @@ function check(){
         msg('Valid locale '.hsc($loc).' found.', 1);
     }
 
-
     if($conf['allowdebug']){
         msg('Debugging support is enabled. If you don\'t need it you should set $conf[\'allowdebug\'] = 0',-1);
     }else{

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -618,7 +618,6 @@ function Doku_Handler_Parse_Media($match) {
     // Split title from URL
     $link = explode('|',$link,2);
 
-
     // Check alignment
     $ralign = (bool)preg_match('/^ /',$link[0]);
     $lalign = (bool)preg_match('/ $/',$link[0]);
@@ -1341,7 +1340,6 @@ class Doku_Handler_Table {
                                 break;
                             }
 
-
                         }
                     }
 
@@ -1367,7 +1365,6 @@ class Doku_Handler_Table {
                                     $spanning_cell = $i;
                                     break;
                                 }
-
 
                             }
                         }
@@ -1402,7 +1399,6 @@ class Doku_Handler_Table {
 
             }
         }
-
 
         // condense cdata
         $cnt = count($this->tableCalls);

--- a/inc/parser/metadata.php
+++ b/inc/parser/metadata.php
@@ -292,7 +292,6 @@ class Doku_Renderer_metadata extends Doku_Renderer {
             $id = $parts[0];
         }
 
-
         $default = $this->_simpleTitle($id);
 
         // first resolve and clean up the $id

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -807,7 +807,6 @@ class Doku_Parser_Mode_quotes extends Doku_Parser_Mode {
                     "\"",$mode,'doublequoteclosing'
                 );
 
-
     }
 
     function getSort() {

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -737,7 +737,6 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $link['class'] = 'media';
         }
 
-
         $link['title'] = $this->_xmlEntities($url);
         $url = str_replace('\\','/',$url);
         $url = 'file:///'.$url;

--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -61,7 +61,6 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
         // fresh 1:1 copy without replacements
         $AUTH_ACL = file($config_cascade['acl']['default']);
 
-
         // namespace given?
         if($INPUT->str('ns') == '*'){
             $this->ns = '*';
@@ -386,7 +385,6 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
             echo '<legend>'.$this->getLang('acl_mod').'</legend>';
         }
 
-
         echo $this->_html_checkboxes($current,empty($this->ns),'acl');
 
         if(is_null($current)){
@@ -686,7 +684,6 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
             if($acl_level > AUTH_EDIT) $acl_level = AUTH_EDIT;
         }
 
-
         $new_acl = "$acl_scope\t$acl_user\t$acl_level\n";
 
         $new_config = $acl_config.$new_acl;
@@ -774,7 +771,6 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
             $gsel = '';
             $inlist = true;
         }
-
 
         echo '<select name="acl_t" class="edit">'.NL;
         echo '  <option value="__g__" class="aclgroup"'.$gsel.'>'.$this->getLang('acl_group').':</option>'.NL;

--- a/lib/plugins/acl/style.css
+++ b/lib/plugins/acl/style.css
@@ -1,4 +1,3 @@
-
 #acl__tree {
     font-size: 90%;
     width: 25%;
@@ -138,4 +137,3 @@
 #acl_manager table tr:hover {
     background-color: __background_alt__;
 }
-

--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -176,11 +176,9 @@ if (!class_exists('configuration')) {
                 for ($i=0; $i<count($matches); $i++) {
                     $value = $matches[$i][2];
 
-
                     // correct issues with the incoming data
                     // FIXME ... for now merge multi-dimensional array indices using ____
                     $key = preg_replace('/.\]\[./',CM_KEYMARKER,$matches[$i][1]);
-
 
                     // handle arrays
                     if(preg_match('/^array ?\((.*)\)/', $value, $match)){

--- a/lib/plugins/plugin/admin.php
+++ b/lib/plugins/plugin/admin.php
@@ -65,7 +65,6 @@ class admin_plugin_plugin extends DokuWiki_Admin_Plugin {
         // enable direct access to language strings
         $this->setupLocale();
 
-
         $fn = $INPUT->param('fn');
         if (is_array($fn)) {
             $this->cmd = key($fn);

--- a/lib/plugins/plugin/classes/ap_info.class.php
+++ b/lib/plugins/plugin/classes/ap_info.class.php
@@ -13,7 +13,6 @@ class ap_info extends ap_manage {
         $component_list = $this->get_plugin_components($this->manager->plugin);
         usort($component_list, array($this,'component_sort'));
 
-
         foreach ($component_list as $component) {
             if (($obj = &plugin_load($component['type'],$component['name'],false,true)) === null) continue;
 

--- a/lib/plugins/popularity/action.php
+++ b/lib/plugins/popularity/action.php
@@ -35,7 +35,6 @@ class action_plugin_popularity extends Dokuwiki_Action_Plugin {
         //Actually send it
         $status = $this->helper->sendData( $this->helper->gatherAsString() );
 
-
         if ( $status !== '' ){
             //If an error occured, log it
             io_saveFile( $this->helper->autosubmitErrorFile, $status );

--- a/lib/plugins/revert/admin.php
+++ b/lib/plugins/revert/admin.php
@@ -120,7 +120,6 @@ class admin_plugin_revert extends DokuWiki_Admin_Plugin {
         $recents = getRecents(0,$this->max_lines);
         echo '<ul>';
 
-
         $cnt = 0;
         foreach($recents as $recent){
             if($filter){

--- a/lib/plugins/syntax.php
+++ b/lib/plugins/syntax.php
@@ -216,12 +216,12 @@ class DokuWiki_Syntax_Plugin extends Doku_Parser_Mode {
 
         global $conf;            // definitely don't invoke "global $lang"
         $path = DOKU_PLUGIN.$this->getPluginName().'/lang/';
- 
+
         $lang = array();
         // don't include once, in case several plugin components require the same language file
         @include($path.'en/lang.php');
         if ($conf['lang'] != 'en') @include($path.$conf['lang'].'/lang.php');
- 
+
         $this->lang = $lang;
         $this->localised = true;
     }

--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -342,7 +342,6 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
             $autocomp  = '';
         }
 
-
         echo "<tr $class>";
         echo "<td><label for=\"$id\" >$label: </label></td>";
         echo "<td>";

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -237,7 +237,6 @@ var dw_linkwiz = {
            link = ':' + link;
         }
 
-
         var so = link.length;
         var eo = 0;
         if(dw_linkwiz.val){

--- a/lib/scripts/textselection.js
+++ b/lib/scripts/textselection.js
@@ -104,7 +104,6 @@ function getSelection(textArea) {
             }
         } while ((!before_finished || !selection_finished));
 
-
         // count number of newlines in str to work around stupid IE selection bug
         var countNL = function(str) {
             var m = str.split("\r\n");
@@ -230,4 +229,3 @@ function insertAtCarret(textAreaID, text){
     var selection = getSelection(txtarea);
     pasteText(selection,text,{nosel: true});
 }
-

--- a/lib/tpl/dokuwiki/css/_forms.css
+++ b/lib/tpl/dokuwiki/css/_forms.css
@@ -1,4 +1,3 @@
-
 /* TODO: this file is not up to the best standards and will be fixed after an overhaul of the form code */
 
 /**

--- a/lib/tpl/dokuwiki/css/_media_fullscreen.css
+++ b/lib/tpl/dokuwiki/css/_media_fullscreen.css
@@ -501,4 +501,3 @@
     width: 100%;
     max-width: none;
 }
-


### PR DESCRIPTION
Removed extraneous whitespace to eliminate errors reported by the
Squiz.WhiteSpace.SuperfluousWhitespace sniff.
