### PR TITLE
Replace tabs with spaces

### DIFF
--- a/lib/plugins/usermanager/style.css
+++ b/lib/plugins/usermanager/style.css
@@ -22,12 +22,12 @@
   border-color: #ccc!important;
 }
 #user__manager .import_users {
-	margin-top: 1.4em;
+  margin-top: 1.4em;
 }
 #user__manager .import_failures {
-	margin-top: 1.4em;
+  margin-top: 1.4em;
 }
 #user__manager .import_failures td.lineno {
-	text-align: center;
+  text-align: center;
 }
 /* IE won't understand but doesn't require it */


### PR DESCRIPTION
Replace tabs with spaces to fixed the
Generic.WhiteSpace.DisallowTabIndent.TabsUsed sniff.
