### PR TITLE
Move footer content from template into footer.html (FS#2847)

### DIFF
--- a/conf/footer.html
+++ b/conf/footer.html
@@ -1,0 +1,27 @@
+<?php 
+/**
+ * User-editable Footer
+ */
+?>
+
+<div id="dokuwiki__footer"><div class="pad">
+    
+    <?php tpl_license(''); // license text ?>
+    
+    <div class="buttons">
+        <?php
+            tpl_license('button', true, false, false); // license button, no wrapper
+            $target = ($conf['target']['extern']) ? 'target="'.$conf['target']['extern'].'"' : '';
+        ?>
+        <a href="http://www.dokuwiki.org/donate" title="Donate" <?php echo $target?>><img
+            src="<?php echo tpl_basedir(); ?>images/button-donate.gif" width="80" height="15" alt="Donate" /></a>
+        <a href="http://www.php.net" title="Powered by PHP" <?php echo $target?>><img
+            src="<?php echo tpl_basedir(); ?>images/button-php.gif" width="80" height="15" alt="Powered by PHP" /></a>
+        <a href="http://validator.w3.org/check/referer" title="Valid HTML5" <?php echo $target?>><img
+            src="<?php echo tpl_basedir(); ?>images/button-html5.png" width="80" height="15" alt="Valid HTML5" /></a>
+        <a href="http://jigsaw.w3.org/css-validator/check/referer?profile=css3" title="Valid CSS" <?php echo $target?>><img
+            src="<?php echo tpl_basedir(); ?>images/button-css.png" width="80" height="15" alt="Valid CSS" /></a>
+        <a href="http://dokuwiki.org/" title="Driven by DokuWiki" <?php echo $target?>><img
+            src="<?php echo tpl_basedir(); ?>images/button-dw.png" width="80" height="15" alt="Driven by DokuWiki" /></a>
+    </div>
+</div></div>

--- a/lib/tpl/dokuwiki/tpl_footer.php
+++ b/lib/tpl/dokuwiki/tpl_footer.php
@@ -1,33 +1,12 @@
 <?php
 /**
  * Template footer, included in the main and detail files
+ * Make changes in 'conf/footer.html'
  */
 
 // must be run from within DokuWiki
 if (!defined('DOKU_INC')) die();
+
+tpl_includeFile('footer.html')
+
 ?>
-
-<!-- ********** FOOTER ********** -->
-<div id="dokuwiki__footer"><div class="pad">
-    <?php tpl_license(''); // license text ?>
-
-    <div class="buttons">
-        <?php
-            tpl_license('button', true, false, false); // license button, no wrapper
-            $target = ($conf['target']['extern']) ? 'target="'.$conf['target']['extern'].'"' : '';
-        ?>
-        <a href="http://www.dokuwiki.org/donate" title="Donate" <?php echo $target?>><img
-            src="<?php echo tpl_basedir(); ?>images/button-donate.gif" width="80" height="15" alt="Donate" /></a>
-        <a href="http://www.php.net" title="Powered by PHP" <?php echo $target?>><img
-            src="<?php echo tpl_basedir(); ?>images/button-php.gif" width="80" height="15" alt="Powered by PHP" /></a>
-        <a href="http://validator.w3.org/check/referer" title="Valid HTML5" <?php echo $target?>><img
-            src="<?php echo tpl_basedir(); ?>images/button-html5.png" width="80" height="15" alt="Valid HTML5" /></a>
-        <a href="http://jigsaw.w3.org/css-validator/check/referer?profile=css3" title="Valid CSS" <?php echo $target?>><img
-            src="<?php echo tpl_basedir(); ?>images/button-css.png" width="80" height="15" alt="Valid CSS" /></a>
-        <a href="http://dokuwiki.org/" title="Driven by DokuWiki" <?php echo $target?>><img
-            src="<?php echo tpl_basedir(); ?>images/button-dw.png" width="80" height="15" alt="Driven by DokuWiki" /></a>
-    </div>
-</div></div><!-- /footer -->
-
-<?php
-tpl_includeFile('footer.html');


### PR DESCRIPTION
Users should be able to customize the footer without modifying the Dokuwiki default template.

The current Dokuwiki default template contains buttons and links in tpl_footer.php.  Removing or modifying this content requires changes to the template file. This is a bad approach because changes to the template will be lost after an upgrade.  

Here is an example of this bad advice: http://www.inmotionhosting.com/support/edu/dokuwiki/change-dokuwiki-appearance/removing-footer-buttons-text

Moving the buttons and text content from the template and into a user editable file ('footer.html') is a better approach that will still display the default buttons and text yet allow users to make changes that persist after an update.

Jon Jaroker
http://jaroker.com
