### PR TITLE
skips 'count' entries in ldap results. Fixes FS#2370

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -208,8 +208,8 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
                 if(is_array($key)) {
                     // use regexp to clean up user_result
                     list($key, $regexp) = each($key);
-                    if($user_result[$key]) foreach($user_result[$key] as $grp) {
-                        if(preg_match($regexp, $grp, $match)) {
+                    if($user_result[$key]) foreach($user_result[$key] as $grpkey => $grp) {
+                        if($grpkey !== 'count' && preg_match($regexp, $grp, $match)) {
                             if($localkey == 'grps') {
                                 $info[$localkey][] = $match[1];
                             } else {


### PR DESCRIPTION
Implements the fix as suggested by
https://bugs.dokuwiki.org/index.php?do=details&task_id=2370

**This is not tested**
