### PR TITLE
Bugfix: DOKU_CONF path in plugin.php

### DIFF
--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -97,7 +97,7 @@ class DokuWiki_Plugin {
     function localFN($id) {
         global $conf;
         $plugin = $this->getPluginName();
-        $file = DOKU_CONF.'/plugin_lang/'.$plugin.'/'.$conf['lang'].'/'.$id.'.txt';
+        $file = DOKU_CONF.'plugin_lang/'.$plugin.'/'.$conf['lang'].'/'.$id.'.txt';
         if (!@file_exists($file)){
             $file = DOKU_PLUGIN.$plugin.'/lang/'.$conf['lang'].'/'.$id.'.txt';
             if(!@file_exists($file)){


### PR DESCRIPTION
Remove extraneous slash. This extra slash was preventing the file being displayed by DokuWiki. (apologies for the two pulls instead of one)
