### PR TITLE
Bugfix: DOKU_CONF path in pageutils.php

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -366,7 +366,7 @@ function mediaFN($id, $rev=''){
  */
 function localeFN($id,$ext='txt'){
     global $conf;
-    $file = DOKU_CONF.'/lang/'.$conf['lang'].'/'.$id.'.'.$ext;
+    $file = DOKU_CONF.'lang/'.$conf['lang'].'/'.$id.'.'.$ext;
     if(!@file_exists($file)){
         $file = DOKU_INC.'inc/lang/'.$conf['lang'].'/'.$id.'.'.$ext;
         if(!@file_exists($file)){


### PR DESCRIPTION
Remove extraneous slash. This extra slash was preventing the file being displayed by DokuWiki. (apologies for the two pulls instead of one)
