### PR TITLE
Jpegmeta fixes

### DIFF
--- a/inc/JpegMeta.php
+++ b/inc/JpegMeta.php
@@ -1452,7 +1452,7 @@ class JpegMeta {
             if ($this->_markers[$i]['marker'] == 0xE1) {
                 $signature = $this->_getFixedString($this->_markers[$i]['data'], 0, 29);
                 if ($signature == "http://ns.adobe.com/xap/1.0/\0") {
-                    $data =& substr($this->_markers[$i]['data'], 29);
+                    $data = substr($this->_markers[$i]['data'], 29);
                     break;
                 }
             }
@@ -2337,7 +2337,7 @@ class JpegMeta {
     function _readIPTC(&$data, $pos = 0) {
         $totalLength = strlen($data);
 
-        $IPTCTags =& $this->_iptcTagNames();
+        $IPTCTags = $this->_iptcTagNames();
 
         while ($pos < ($totalLength - 5)) {
             $signature = $this->_getShort($data, $pos);


### PR DESCRIPTION
Todo:
- about line 1511: IDEA intelliJ marks as error: `cannot use [] for reading` at the argument `$meta[]`

``` php
        if ($values[$i]['tag'] == 'rdf:Bag' || $values[$i]['tag'] == 'rdf:Seq') {
            // Array property
            $meta = array();
            while ($values[++$i]['tag'] == 'rdf:li') {
                $this->_parseXmpNode($values, $i, $meta[], $count);
            }
            $i++; // skip closing Bag/Seq tag

        } elseif ($values[$i]['tag'] == 'rdf:Alt') {
```

Someone suggestions?

Further there are (i guess) still many possible `Only variables should be assigned by reference`
- due to that results of functions are assigned by reference (only useful for referenced returns http://php.net/manual/en/language.references.return. ) 
- i guess some references returns are nonsense, for read only purposes..

I have no data available to test these stuff, so i cannot finish this properly.
