### PR TITLE
set error level so it is propagated correctly to dokuwiki

### DIFF
--- a/_test/bootstrap.php
+++ b/_test/bootstrap.php
@@ -15,7 +15,7 @@ require_once DOKU_UNITTEST.'core/TestUtils.php';
 define('SIMPLE_TEST', true);
 
 // basic behaviours
-define('DOKU_E_LEVEL',E_ALL);
+define('DOKU_E_LEVEL',E_ALL ^ E_NOTICE);
 error_reporting(DOKU_E_LEVEL);
 set_time_limit(0);
 ini_set('memory_limit','2048M');


### PR DESCRIPTION
DokuWiki sets its error reporting level based on the DOKU_E_LEVEL constant over-writing any previously set error_reporting value.

Although E_ALL is the current value used in bootstrap.php's error_reporting() call, it may not be desirable.  There are a lot of E_NOTICEs in dokuwiki.
