### PR TITLE
media_isexternal do not capture

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -90,7 +90,7 @@ function media_metasave($id,$auth,$data){
  * @return bool
  */
 function media_isexternal($id){
-    if (preg_match('#^(https?|ftp)://#i', $id)) return true;
+    if (preg_match('#^(?:https?|ftp)://#i', $id)) return true;
     return false;
 }
 


### PR DESCRIPTION
do not capture groups in media_isexternal. saves perhaps some cpu cycles and some bytes memory
