### PR TITLE
Improved pagetools event in dokuwiki template

### DIFF
--- a/lib/tpl/dokuwiki/detail.php
+++ b/lib/tpl/dokuwiki/detail.php
@@ -110,7 +110,6 @@ header('X-UA-Compatible: IE=edge,chrome=1');
                         <ul>
                             <?php
                                 $data = array();
-                                $data['tpl']  = $conf['template'];
                                 $data['view'] = 'detail';
 
                                 // View in media manager; @todo: transfer logic to backend

--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -75,7 +75,6 @@ $showSidebar = $hasSidebar && ($ACT=='show');
                     <ul>
                         <?php
                             $data = array(
-                                'tpl'   => $conf['template'],
                                 'view'  => 'main',
                                 'items' => array(
                                     'edit'      => tpl_action('edit',      1, 'li', 1, '<span>', '</span>'),


### PR DESCRIPTION
I still don't like the `TEMPLATE_DOKUWIKI_PAGETOOLS_DISPLAY` event in the default template for two reasons:
1. Plugins would need to handle every template separately. (Sometimes that would be sensible, most times it wouldn't.)
2. Plugins would insert into both the standard pagetools and the different ones on the image detail page. (Again, sometimes that makes sense, most times it doesn't.)

This moves the template name away from the hook name into the event data (as the 'tpl' value). Therefore it moves the previous data items into the 'items' sub array. A 'view' value has also been added to describe in which template file the event was called ('main' or 'detail').

See #236 for the previous discussion.
