### PR TITLE
Provide an XMLRPC logoff method.

### DIFF
--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -3,7 +3,7 @@
 /**
  * Increased whenever the API is changed
  */
-define('DOKU_API_VERSION', 8);
+define('DOKU_API_VERSION', 9);
 
 class RemoteAPICore {
 


### PR DESCRIPTION
Rationale: XMLRPC is thought for scripts, which typically should not store
their authentication cookies/credentials on disk. So for pure script usage such a log-off method might not be considered useful. However, I do not think that it is that easy. 

1st: DW cannot tell if an external script is in this respect well-behaved, or monitored by some other spy-ware script. In this respect any web-bot is no better than any GUI-web-browser. Although a break-in is somewhat more unlikely in the case of hand-written scripts.

2nd: it does not hurt to provide means for a voluntary sign-off. It does neither complicate things (if the method is not called by the client, everything stays the same) but provides an additional security measure for the client ("I'm done with my work, so tell the server to also destroy its half of the login-credentials")

3rd: I make use of the remote-call "stuff " (thanks for that) in order to embed a DW instance into an OwnCloud instance. For this I forward the credentials (the cookies) obtained by the XMLRPC login-method to the "calling" web-browser of the user. In this context a clean sign-OFF really makes sense.

There are two parts of authentication data: one is stored in the
cookie-storage of the client, and the other part is stored in the
session data of the DW instance on the server. This logoff call is
responsible for invalidating the credentials stored on the server,
regardless of any cookie data remaining (or being stolen) on the client
side.
This is my first hack into DW. Stuff seemed to be fairly straight forward. My apologies if It did over-look something.
As far as I understand any XMLRPC call which is NOT flagged as public needs authenticated access (of course only if authentication is required at all by the global config of DW). Therefore the log-off respect is, of course, NOT a public method. Everything else boils down to a call to the logoff() method form inc/auth.php, after checking that ACL and stuff are enabled at all.

Best,

Claus
