### PR TITLE
FS#1833 (b)

### DIFF
--- a/_test/tests/inc/parser/parser_table.test.php
+++ b/_test/tests/inc/parser/parser_table.test.php
@@ -626,5 +626,24 @@ def');
         );
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
+
+    function testTable_FS1833() {
+        $syntax = " \n| Row 0 Col 1    |\n";
+        $this->P->addMode('table',new Doku_Parser_Mode_Table());
+        $this->P->parse($syntax);
+        $calls = array (
+            array('document_start',array()),
+            array('table_open',array(1, 1, 2)),
+            array('tablerow_open',array()),
+            array('tablecell_open',array(1,'left',1)),
+            array('cdata',array(' Row 0 Col 1    ')),
+            array('tablecell_close',array()),
+            array('tablerow_close',array()),
+            array('table_close',array(strlen($syntax))),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
 }
 

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -454,8 +454,8 @@ class Doku_Parser_Mode_table extends Doku_Parser_Mode {
     }
 
     function connectTo($mode) {
-        $this->Lexer->addEntryPattern('\s*\n\^',$mode,'table');
-        $this->Lexer->addEntryPattern('\s*\n\|',$mode,'table');
+        $this->Lexer->addEntryPattern('[\t ]*\n\^',$mode,'table');
+        $this->Lexer->addEntryPattern('[\t ]*\n\|',$mode,'table');
     }
 
     function postConnect() {


### PR DESCRIPTION
Prevent table entry syntax swallowing multiple preceeding blank lines
(a) this shouldn't be necessary, blank lines are handled by paragraph
    processing
(b) avoids issues with greedy table syntax competing with plugins
