### PR TITLE
Fix sending empty and duplicated headers, FS#2887

### DIFF
--- a/_test/tests/inc/mailer.test.php
+++ b/_test/tests/inc/mailer.test.php
@@ -154,7 +154,19 @@ class mailer_test extends DokuWikiTest {
         $headers['Cc'] = '';
         $header = $mail->prepareHeaders();
         $this->assertEquals(0, preg_match('/(^|\n)Bcc: (\n|$)/', $header), 'Bcc found in headers.');
-        $this->assertEquals(0, preg_match('/(^|\n)Cc: (\n|$)/', $header), 'Bcc found in headers.');
+        $this->assertEquals(0, preg_match('/(^|\n)Cc: (\n|$)/', $header), 'Cc found in headers.');
+    }
+
+    function test_nullTOorCCorBCC() {
+        $mail = new TestMailer();
+        $headers = &$mail->propRef('headers');
+        $headers['Bcc'] = NULL;
+        $headers['Cc'] = NULL;
+        $headers['To'] = NULL;
+        $header = $mail->prepareHeaders();
+        $this->assertEquals(0, preg_match('/(^|\n)Bcc: (\n|$)/', $header), 'Bcc found in headers.');
+        $this->assertEquals(0, preg_match('/(^|\n)Cc: (\n|$)/', $header), 'Cc found in headers.');
+        $this->assertEquals(0, preg_match('/(^|\n)To: (\n|$)/', $header), 'To found in headers.');
     }
 
     /**

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -576,7 +576,7 @@ class Mailer {
     protected function prepareHeaders() {
         $headers = '';
         foreach($this->headers as $key => $val) {
-            if ($val === '') continue;
+            if ($val === '' || is_null($val)) continue;
             $headers .= $this->wrappedHeaderLine($key, $val);
         }
         return $headers;
@@ -640,16 +640,16 @@ class Mailer {
             ) return false;
 
             // The To: header is special
-            if(isset($this->headers['To'])) {
-                $to = $this->headers['To'];
+            if(array_key_exists('To', $this->headers)) {
+                $to = (string)$this->headers['To'];
                 unset($this->headers['To']);
             } else {
                 $to = '';
             }
 
             // so is the subject
-            if(isset($this->headers['Subject'])) {
-                $subject = $this->headers['Subject'];
+            if(array_key_exists('Subject', $this->headers)) {
+                $subject = (string)$this->headers['Subject'];
                 unset($this->headers['Subject']);
             } else {
                 $subject = '';


### PR DESCRIPTION
This fixes sending empty and duplicated To/Cc/Bcc, Subject and From
headers in the additional headers. The To-header in the additional
headers prevented mail sending on some systems.
