### PR TITLE
Properly fix RSS namespace listings containing hidden pages FS#2891

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -476,8 +476,12 @@ function rssListNamespace($opt) {
     $ns = str_replace(':', '/', $ns);
 
     $data = array();
-    sort($data);
-    search($data, $conf['datadir'], 'search_list', '', $ns);
+    $search_opts = array(
+        'depth' => 1,
+        'pagesonly' => true,
+        'listfiles' => true
+    );
+    search($data, $conf['datadir'], 'search_universal', $search_opts, $ns);
 
     return $data;
 }


### PR DESCRIPTION
This reverts #376 and the indentation fix and instead changes feed.php to use `search_universal` instead of `search_list`. The `search_universal` function already filters out hidden pages and both the recent changes loading as well as the fulltext search do the same.

Filtering the items later by visibility is imho arbitrary as we might as well filter by ACL for example. I think the list of pages should be filtered instead of the feed items. Furthermore the previous fix prevented plugins from adding hidden pages to the feed if they didn't override the feed item adding code. Adding hidden items in a plugin might be intentional if the feed is only for admins or if the feed only concerns a single page (e.g. all changes of a single page).
