### PR TITLE
Add support for marking a wiki as readonly, such as for a replica/failover site

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -50,6 +50,8 @@ $conf['deaccent']    = 1;                 //deaccented chars in pagenames (1) or
 $conf['useheading']  = 0;                 //use the first heading in a page as its name
 $conf['sneaky_index']= 0;                 //check for namespace read permission in index view (0|1) (1 might cause unexpected behavior)
 $conf['hidepages']   = '';                //Regexp for pages to be skipped from RSS, Search and Recent Changes
+$conf['readonly']    = 0;                 //make entire wiki read-only, used for read-only failover sites
+$conf['readonlymsg'] = '';                //if defined, display this message if server is read-only
 
 /* Authentication Settings */
 $conf['useacl']      = 0;                //Use Access Control Lists to restrict access?

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -24,6 +24,11 @@ function act_dispatch(){
     global $lang;
     global $conf;
 
+    // Message indicating read only status of the server
+    if($conf['readonly'] && $conf['readonlymsg']){
+      msg($conf['readonlymsg']);
+    }
+
     $preact = $ACT;
 
     // give plugins an opportunity to process the action
@@ -45,7 +50,7 @@ function act_dispatch(){
         }
 
         //check if user is asking to (un)subscribe a page
-        if($ACT == 'subscribe') {
+        if($ACT == 'subscribe' && !$conf['readonly']) {
             try {
                 $ACT = act_subscription($ACT);
             } catch (Exception $e) {
@@ -84,11 +89,11 @@ function act_dispatch(){
         }
 
         //register
-        if($ACT == 'register' && $INPUT->post->bool('save') && register()){
+        if($ACT == 'register' && $INPUT->post->bool('save') && register() && !$conf['readonly']){
             $ACT = 'login';
         }
 
-        if ($ACT == 'resendpwd' && act_resendpwd()) {
+        if ($ACT == 'resendpwd' && act_resendpwd() && !$conf['readonly']) {
             $ACT = 'login';
         }
 
@@ -117,7 +122,7 @@ function act_dispatch(){
         }
 
         //revert
-        if($ACT == 'revert'){
+        if($ACT == 'revert' && !$conf['readonly']){
             if(checkSecurityToken()){
                 $ACT = act_revert($ACT);
             }else{
@@ -126,7 +131,7 @@ function act_dispatch(){
         }
 
         //save
-        if($ACT == 'save'){
+        if($ACT == 'save' && !$conf['readonly']){
             if(checkSecurityToken()){
                 $ACT = act_save($ACT);
             }else{
@@ -139,26 +144,26 @@ function act_dispatch(){
             $ACT = 'show';
 
         //draft deletion
-        if($ACT == 'draftdel')
+        if($ACT == 'draftdel' && !$conf['readonly'])
             $ACT = act_draftdel($ACT);
 
         //draft saving on preview
-        if($ACT == 'preview')
+        if($ACT == 'preview' && !$conf['readonly'])
             $ACT = act_draftsave($ACT);
 
         //edit
-        if(in_array($ACT, array('edit', 'preview', 'recover'))) {
+        if(in_array($ACT, array('edit', 'preview', 'recover')) && !$conf['readonly']) {
             $ACT = act_edit($ACT);
         }else{
             unlock($ID); //try to unlock
         }
 
         //handle export
-        if(substr($ACT,0,7) == 'export_')
+        if(substr($ACT,0,7) == 'export_' && !$conf['readonly'])
             $ACT = act_export($ACT);
 
         //handle admin tasks
-        if($ACT == 'admin'){
+        if($ACT == 'admin' && !$conf['readonly']){
             // retrieve admin plugin name from $_REQUEST['page']
             if (($page = $INPUT->str('page', '', true)) != '') {
                 $pluginlist = plugin_list('admin');

--- a/inc/template.php
+++ b/inc/template.php
@@ -325,7 +325,7 @@ function tpl_metaheaders($alt = true) {
             'title'=> $lang['currentns'],
             'href' => DOKU_BASE.'feed.php?mode=list&ns='.$INFO['namespace']
         );
-        if(($ACT == 'show' || $ACT == 'search') && $INFO['writable']) {
+        if(($ACT == 'show' || $ACT == 'search') && $INFO['writable'] && !$conf['readonly']) {
             $head['link'][] = array(
                 'rel'  => 'edit',
                 'title'=> $lang['btn_edit'],
@@ -619,7 +619,7 @@ function tpl_get_action($type) {
             // most complicated type - we need to decide on current action
             if($ACT == 'show' || $ACT == 'search') {
                 $method = 'post';
-                if($INFO['writable']) {
+                if($INFO['writable'] && !$conf['readonly']) {
                     $accesskey = 'e';
                     if(!empty($INFO['draft'])) {
                         $type         = 'draft';
@@ -681,29 +681,29 @@ function tpl_get_action($type) {
             }
             break;
         case 'register':
-            if(!empty($_SERVER['REMOTE_USER'])) {
+            if(!empty($_SERVER['REMOTE_USER']) || $conf['readonly']) {
                 return false;
             }
             break;
         case 'resendpwd':
-            if(!empty($_SERVER['REMOTE_USER'])) {
+            if(!empty($_SERVER['REMOTE_USER']) || $conf['readonly']) {
                 return false;
             }
             break;
         case 'admin':
-            if(!$INFO['ismanager']) {
+            if(!$INFO['ismanager'] && !$conf['readonly']) {
                 return false;
             }
             break;
         case 'revert':
-            if(!$INFO['ismanager'] || !$REV || !$INFO['writable']) {
+            if(!$INFO['ismanager'] || !$REV || !$INFO['writable'] || $conf['readonly']) {
                 return false;
             }
             $params['rev']    = $REV;
             $params['sectok'] = getSecurityToken();
             break;
         case 'subscribe':
-            if(!$_SERVER['REMOTE_USER']) {
+            if(!$_SERVER['REMOTE_USER'] || $conf['readonly']) {
                 return false;
             }
             break;


### PR DESCRIPTION
This just adds a pair of config options to do a simple readonly flag for a wiki. I use this on a a failover server that is one-way synced from live server. 
