### PR TITLE
show login form when perm denied instead of just error

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -154,7 +154,11 @@ function tpl_content_core() {
             html_resendpwd();
             break;
         case 'denied':
-            print p_locale_xhtml('denied');
+            if($_SERVER['REMOTE_USER']){
+                print p_locale_xhtml('denied');
+            } else {
+                html_login();
+            }
             break;
         case 'profile' :
             html_updateprofile();


### PR DESCRIPTION
Right now, if you have your wiki protected, you get just a permission denied message, this changes it to display a login form, unless you're already logged in, in which case, it displays the denied message. 
