### PR TITLE
Enable auth failures based on 'groupfilter'

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -117,6 +117,14 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
                 return false;
             }
             $this->bound = 1;
+
+	    // We've authenticated the user, now verify group membership if groupfilter was specified 
+            if($this->getConf('groupfilter')){
+                if(!$info['satisfygroupfilter']){
+                        return false;
+                }
+            }
+
             return true;
         }
     }
@@ -243,7 +251,13 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
                 if(!empty($grp[$this->getConf('groupkey')][0])) {
                     $this->_debug('LDAP usergroup: '.htmlspecialchars($grp[$this->getConf('groupkey')][0]), 0, __LINE__, __FILE__);
                     $info['grps'][] = $grp[$this->getConf('groupkey')][0];
+		
+		    // checkPass will use this to authorize the user if groupfilter was used
+		    $info['satisfygroupfilter']=true;
+                } else {
+                    $info['satisfygroupfilter']=false;
                 }
+
             }
         }
 


### PR DESCRIPTION
We noticed that valid LDAP users could authenticate even if they weren't a member of the group specified by the groupfilter in local.php. The presence of valid 'grouptree' and 'groupfilter' configs in local.php would have no bearing on the login if the user's password is accepted.

It's possible that we have a misconfiguration in dokuwiki that is causing this behavior, but I couldn't determine from the authldap documentation that this was the case. I also could not see in master's authldap/auth.php where the login is denied based on membership in the groupfilter's group, so I added code to checkPass and getUserData to implement this check.

I hope this helps. Let me know if you have any questions.
