### PR TITLE
remove some code duplication from syntax plugins

### DIFF
--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -125,41 +125,91 @@ class Doku_Parser {
 }
 
 //-------------------------------------------------------------------
+
+/**
+ * Class Doku_Parser_Mode_Interface
+ *
+ * Defines a mode (syntax component) in the Parser
+ */
+interface Doku_Parser_Mode_Interface {
+    /**
+     * returns a number used to determine in which order modes are added
+     */
+    public function getSort();
+
+    /**
+     * Called before any calls to connectTo
+     */
+    function preConnect();
+
+    /**
+     * Connects the mode
+     *
+     * @param string $mode
+     */
+    function connectTo($mode);
+
+    /**
+     * Called after all calls to connectTo
+     */
+    function postConnect();
+
+    /**
+     * Check if given mode is accepted inside this mode
+     *
+     * @param string $mode
+     * @return bool
+     */
+    function accepts($mode);
+}
+
 /**
  * This class and all the subclasses below are used to reduce the effort required to register
  * modes with the Lexer.
  *
- * Inherits from DokuWiki_Plugin for giving additional functions to syntax plugins
- *
  * @author Harry Fuecks <hfuecks@gmail.com>
  */
-class Doku_Parser_Mode extends DokuWiki_Plugin {
-
+class Doku_Parser_Mode implements Doku_Parser_Mode_Interface {
     /**
      * @var Doku_Lexer $Lexer
      */
     var $Lexer;
-
     var $allowedModes = array();
 
-    // returns a number used to determine in which order modes are added
     function getSort() {
         trigger_error('getSort() not implemented in '.get_class($this), E_USER_WARNING);
     }
 
-    // Called before any calls to connectTo
     function preConnect() {}
-
-    // Connects the mode
     function connectTo($mode) {}
-
-    // Called after all calls to connectTo
     function postConnect() {}
-
     function accepts($mode) {
         return in_array($mode, (array) $this->allowedModes );
     }
+}
 
+/**
+ * Basically the same as Doku_Parser_Mode but extends from DokuWiki_Plugin
+ *
+ * Adds additional functions to syntax plugins
+ */
+class Doku_Parser_Mode_Plugin extends DokuWiki_Plugin implements Doku_Parser_Mode_Interface {
+    /**
+     * @var Doku_Lexer $Lexer
+     */
+    var $Lexer;
+    var $allowedModes = array();
+
+    function getSort() {
+        trigger_error('getSort() not implemented in '.get_class($this), E_USER_WARNING);
+    }
+
+    function preConnect() {}
+    function connectTo($mode) {}
+    function postConnect() {}
+    function accepts($mode) {
+        return in_array($mode, (array) $this->allowedModes );
+    }
 }
 
 //-------------------------------------------------------------------

--- a/lib/plugins/syntax.php
+++ b/lib/plugins/syntax.php
@@ -12,7 +12,7 @@ if(!defined('DOKU_INC')) die();
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
-class DokuWiki_Syntax_Plugin extends Doku_Parser_Mode {
+class DokuWiki_Syntax_Plugin extends Doku_Parser_Mode_Plugin {
 
     var $allowedModesSetup = false;
 


### PR DESCRIPTION
Until now syntax plugins did not inherit from DokuPlugin but instead duplicated quite a bit of code from it. This should make the code easier to maintain.
