### PR TITLE
dokuwiki template: Fix the preview width on small screens FS#2914

### DIFF
--- a/lib/tpl/dokuwiki/css/mobile.less
+++ b/lib/tpl/dokuwiki/css/mobile.less
@@ -65,6 +65,15 @@
     margin-right: 0;
 }
 
+/* preview */
+.dokuwiki.hasSidebar div.preview {
+    border-right: none;
+}
+
+[dir=rtl] .dokuwiki.hasSidebar div.preview {
+    border-left: none;
+}
+
 /* toc */
 #dw__toc {
     float: none;


### PR DESCRIPTION
This removes the border/margin from the preview when the content has full width on mobile devices as this border should simulate the sidebar.
