### PR TITLE
add context stream options in HTTPClient FS#2911

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -315,15 +315,6 @@ class HTTPClient {
                 return false;
             }
 
-
-
-
-
-
-            $this->_debug('context', stream_context_get_params($socket));
-
-
-
             // try establish a CONNECT tunnel for SSL
             if($this->_ssltunnel($socket, $request_url)){
                 // no keep alive for tunnels


### PR DESCRIPTION
This might fix FS#2911 though I'm not sure it's really needed. Why not enabling verify_peer by default? Because you need to provide it with a valid CA cert. It seems not to look those up in the OS so we would need to provide our own list which is certainly not a business we want to get involved with.
