### PR TITLE
renamed conflicting JavaScript functions FS#2915

### DIFF
--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -148,7 +148,7 @@ function addBtnActionSignature($btn, props, edid) {
 function currentHeadlineLevel(textboxId){
     var field = jQuery('#' + textboxId)[0],
         s = false,
-        opts = [field.value.substr(0,getSelection(field).start)];
+        opts = [field.value.substr(0,DWgetSelection(field).start)];
     if (field.form.prefix) {
         // we need to look in prefix context
         opts.push(field.form.prefix.value);
@@ -217,10 +217,10 @@ jQuery(function () {
         }
 
         // set focus and place cursor at the start
-        var sel = getSelection($edit_text[0]);
+        var sel = DWgetSelection($edit_text[0]);
         sel.start = 0;
         sel.end   = 0;
-        setSelection(sel);
+        DWsetSelection(sel);
         $edit_text.focus();
     }
 

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -134,7 +134,7 @@ var dw_editor = {
         if(jQuery.inArray(e.keyCode,[8, 13, 32]) === -1) {
             return;
         }
-        var selection = getSelection(this);
+        var selection = DWgetSelection(this);
         if(selection.getLength() > 0) {
             return; //there was text selected, keep standard behavior
         }
@@ -155,7 +155,7 @@ var dw_editor = {
                                  this.value.substr(selection.start);
                     selection.start = linestart + 1;
                     selection.end = linestart + 1;
-                    setSelection(selection);
+                    DWsetSelection(selection);
                 } else {
                     insertAtCarret(this.id,match[1]);
                 }
@@ -180,7 +180,7 @@ var dw_editor = {
                     selection.start = linestart;
                     selection.end   = linestart;
                 }
-                setSelection(selection);
+                DWsetSelection(selection);
                 e.preventDefault(); // prevent backspace
                 return false;
             }
@@ -192,7 +192,7 @@ var dw_editor = {
                              this.value.substr(linestart);
                 selection.start = selection.start + 2;
                 selection.end   = selection.start;
-                setSelection(selection);
+                DWsetSelection(selection);
                 e.preventDefault(); // prevent space
                 return false;
             }

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -214,7 +214,7 @@ var dw_linkwiz = {
             return;
         }
 
-        sel = getSelection(dw_linkwiz.textArea);
+        sel = DWgetSelection(dw_linkwiz.textArea);
         if(sel.start == 0 && sel.end == 0) {
             sel = dw_linkwiz.selection;
         }
@@ -295,7 +295,7 @@ var dw_linkwiz = {
      * Show the link wizard
      */
     show: function(){
-        dw_linkwiz.selection  = getSelection(dw_linkwiz.textArea);
+        dw_linkwiz.selection  = DWgetSelection(dw_linkwiz.textArea);
         dw_linkwiz.$wiz.show();
         dw_linkwiz.$entry.focus();
         dw_linkwiz.autocomplete();

--- a/lib/scripts/textselection.js
+++ b/lib/scripts/textselection.js
@@ -5,7 +5,7 @@
 /**
  * selection prototype
  *
- * Object that capsulates the selection in a textarea. Returned by getSelection.
+ * Object that capsulates the selection in a textarea. Returned by DWgetSelection.
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  */
@@ -34,7 +34,7 @@ function selection_class(){
  * @link   http://linebyline.blogspot.com/2006/11/textarea-cursor-position-in-internet.html
  * @returns object - a selection object
  */
-function getSelection(textArea) {
+function DWgetSelection(textArea) {
     var sel = new selection_class();
 
     sel.obj   = textArea;
@@ -119,14 +119,14 @@ function getSelection(textArea) {
 /**
  * Set the selection
  *
- * You need to get a selection object via getSelection() first, then modify the
+ * You need to get a selection object via DWgetSelection() first, then modify the
  * start and end properties and pass it back to this function.
  *
  * @link http://groups.drupal.org/node/1210
  * @author Andreas Gohr <andi@splitbrain.org>
- * @param object selection - a selection object as returned by getSelection()
+ * @param {selection_class} selection  a selection object as returned by DWgetSelection()
  */
-function setSelection(selection){
+function DWsetSelection(selection){
     if(document.getSelection){ // FF
         // what a pleasure in FF ;)
         selection.obj.setSelectionRange(selection.start,selection.end);
@@ -144,11 +144,11 @@ function setSelection(selection){
  * selection
  *
  * @author Andreas Gohr <andi@splitbrain.org>
- * @param string text          - the new text to be pasted
- * @param objct  selecttion    - selection object returned by getSelection
- * @param int    opts.startofs - number of charcters at the start to skip from new selection
- * @param int    opts.endofs   - number of characters at the end to skip from new selection
- * @param bool   opts.nosel    - set true if new text should not be selected
+ * @param {string}  text           the new text to be pasted
+ * @param {selection_class}  selection     selection object returned by DWgetSelection
+ * @param {int}     opts.startofs  number of charcters at the start to skip from new selection
+ * @param {int}     opts.endofs    number of characters at the end to skip from new selection
+ * @param {boolean} opts.nosel     set true if new text should not be selected
  */
 function pasteText(selection,text,opts){
     if(!opts) opts = {};
@@ -173,7 +173,7 @@ function pasteText(selection,text,opts){
     // no selection wanted? set cursor to end position
     if(opts.nosel) selection.start = selection.end;
 
-    setSelection(selection);
+    DWsetSelection(selection);
 }
 
 
@@ -188,7 +188,7 @@ function pasteText(selection,text,opts){
 function insertTags(textAreaID, tagOpen, tagClose, sampleText){
     var txtarea = jQuery('#' + textAreaID)[0];
 
-    var selection = getSelection(txtarea);
+    var selection = DWgetSelection(txtarea);
     var text = selection.getText();
     var opts;
 
@@ -226,6 +226,6 @@ function insertTags(textAreaID, tagOpen, tagClose, sampleText){
  */
 function insertAtCarret(textAreaID, text){
     var txtarea = jQuery('#' + textAreaID)[0];
-    var selection = getSelection(txtarea);
+    var selection = DWgetSelection(txtarea);
     pasteText(selection,text,{nosel: true});
 }

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -101,7 +101,7 @@ function tb_format(btn, props, edid) {
 function tb_formatln(btn, props, edid) {
     var sample = props.sample || props.title,
         opts,
-        selection = getSelection(jQuery('#'+edid)[0]);
+        selection = DWgetSelection(jQuery('#'+edid)[0]);
 
     sample = fixtxt(sample);
     props.open  = fixtxt(props.open);


### PR DESCRIPTION
This renames getSelection and setSelection to avoid conflicts with standard browser's own functions. This might break plugins relying on the DokuWiki implementation, but I see no way around that.
