### PR TITLE
FS#2901: Fix lessphp on PHP 5.2.0

### DIFF
--- a/inc/lessc.inc.php
+++ b/inc/lessc.inc.php
@@ -708,7 +708,7 @@ class lessc {
 				}
 
 				$oldParent = $mixin->parent;
-				if ($mixin != $block) $mixin->parent = $block;
+				if ($mixin !== $block) $mixin->parent = $block;
 
 				foreach ($this->sortProps($mixin->props) as $subProp) {
 					if ($suffix !== null &&


### PR DESCRIPTION
Upstream issue for this change: leafo/lessphp#522

For me this fixes the problem on PHP 5.2.0 on Debian Etch. This change might break the less compiler (on all PHP versions). I haven't tried understanding what exactly the code does and if this change matters or not. Earlier in the code the same two objects are compared using `===` so this change might be okay or it might also be intentional that in this case it is not `!==` but `!=`.
