### PR TITLE
Submit current edit on Ctrl-Enter

### DIFF
--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -125,15 +125,26 @@ var dw_editor = {
      * of lists and code blocks
      *
      * Currently handles space, backspce and enter presses
+     * 
+     * Additionally submits current edit on ctrl-enter.
      *
      * @author Andreas Gohr <andi@splitbrain.org>
      * @fixme handle tabs
      * @param event e - the key press event object
      */
     keyHandler: function(e){
-        if(jQuery.inArray(e.keyCode,[8, 13, 32]) === -1) {
+        if(jQuery.inArray(e.keyCode,[8, 10, 13, 32]) === -1) {
             return;
         }
+
+        if((e.keyCode == 13 || e.keyCode == 10) && e.ctrlKey) { // Ctrl-Enter (With Chrome workaround)
+            // Submit current edit
+            jQuery('input#edbtn__save').click();
+            
+            e.preventDefault(); // Prevents enter key
+            return;
+        }
+        
         var selection = getSelection(this);
         if(selection.getLength() > 0) {
             return; //there was text selected, keep standard behavior


### PR DESCRIPTION
Commonly used key combination in web applications to submit the current
text area.

Tested in Chrome 32, Firefox 26 and Internet Explorer 11.
