### PR TITLE
Update auth.php

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -242,13 +242,9 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
 
             if(is_array($result)) foreach($result as $grp) {
                 if(!empty($grp[$this->getConf('groupkey')][0])) {
-                    if(is_array($grp[$this->getConf('groupkey')][0])) {
-                        $this->_debug('LDAP usergroup: '.htmlspecialchars($grp[$this->getConf('groupkey')][0]), 0, __LINE__, __FILE__);
-                        $info['grps'][] = $grp[$this->getConf('groupkey')][0];
-                    } else {
-                        $this->_debug('LDAP usergroup: '.htmlspecialchars($grp[$this->getConf('groupkey')]), 0, __LINE__, __FILE__);
-                        $info['grps'][] = $grp[$this->getConf('groupkey')];
-                    }
+                    $groupkey = (is_array($grp[$this->getConf('groupkey')][0])) ? $grp[$this->getConf('groupkey')][0] : $grp[$this->getConf('groupkey')];
+                    $this->_debug('LDAP usergroup: '.htmlspecialchars($groupkey), 0, __LINE__, __FILE__);
+                    $info['grps'][] = $groupkey;
                 }
             }
         }


### PR DESCRIPTION
In Novell eDir the group search returns strings, not arrays. Added if-statement which determines if the result is an array or a string.

Without that I received using <url>?do=check the following group infos:
You are part of the groups c, c, c, user

With that change I received the following result:
You are part of the groups cn=ITSYS,ou=dsbuk,o=bug, cn=WIKI-USER,ou=dsbuk,o=bug, cn=MOBILE-USER,ou=dsbuk,o=bug, user
