### PR TITLE
fix TestRequest

### DIFF
--- a/_test/core/TestRequest.php
+++ b/_test/core/TestRequest.php
@@ -44,13 +44,18 @@ class TestRequest {
      * @return TestResponse the resulting output of the request
      */
     public function execute($uri='/doku.php') {
+        global $INPUT;
+        global $ID;
+        global $INFO;
+
         // save old environment
         $server = $_SERVER;
         $session = $_SESSION;
         $get = $_GET;
         $post = $_POST;
         $request = $_REQUEST;
-
+        $input = $INPUT;
+        
         // prepare the right URI
         $this->setUri($uri);
 
@@ -74,6 +79,7 @@ class TestRequest {
         // now execute dokuwiki and grep the output
         header_remove();
         ob_start('ob_start_callback');
+        $INPUT = new Input();
         include(DOKU_INC.$this->script);
         ob_end_flush();
 
@@ -89,6 +95,7 @@ class TestRequest {
         $_GET = $get;
         $_POST = $post;
         $_REQUEST = $request;
+        $INPUT = $input;
 
         return $response;
     }

--- a/_test/tests/test/basic.test.php
+++ b/_test/tests/test/basic.test.php
@@ -33,7 +33,7 @@ class InttestsBasicTest extends DokuWikiTest {
         $response = $request->execute();
 
         $this->assertTrue(
-            strpos($response->getContent(), 'DokuWiki') >= 0,
+            strpos($response->getContent(), 'DokuWiki') !== false,
             'DokuWiki was not a word in the output'
         );
     }
@@ -60,7 +60,7 @@ class InttestsBasicTest extends DokuWikiTest {
         $this->assertEquals('wiki:dokuwiki', $request->getPost('id'));
 
         // output check
-        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') >= 0);
+        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') !== false);
     }
 
     function testPostGet() {
@@ -84,7 +84,7 @@ class InttestsBasicTest extends DokuWikiTest {
         $this->assertEquals('wiki:dokuwiki', $request->getGet('id'));
 
         // output check
-        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') >= 0);
+        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') !== false);
     }
 
     function testGet() {
@@ -116,7 +116,7 @@ class InttestsBasicTest extends DokuWikiTest {
         $this->assertEquals('bar', $request->getGet('test'));
 
         // output check
-        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') >= 0);
+        $this->assertTrue(strpos($response->getContent(), 'Andreas Gohr') !== false);
     }
 
     function testScripts() {
@@ -167,6 +167,14 @@ class InttestsBasicTest extends DokuWikiTest {
 
        $response = new TestResponse('',array_slice($this->some_headers,0,-2));  // slice off the last two headers to leave no status header
        $this->assertNull($response->getStatusCode());
+    }
+    
+    function testINPUT() {
+        $request = new TestRequest();
+        $response = $request->get(array('id' => 'mailinglist'), '/doku.php');
+
+        // output check
+        $this->assertTrue(strpos($response->getContent(), 'Netiquette') !== false);
     }
 
 }


### PR DESCRIPTION
The testcases which checked against >=0 were not correct.

$INPUT is instantiated  in inc/init.php and doku.php calls inc/init.php with require_once so $INPUT wont be updated to the new requested id.

I had to add $ID and $INFO as global variables to execute() to get the tests working. (see http://www.php.net/manual/de/language.variables.scope.php#63500 and http://www.php.net/manual/de/language.variables.scope.php#3596)

maybe the are some more globals we have to add here...
