### PR TITLE
added bin/gittool.php for simpler git management of plugins

### DIFF
--- a/bin/gittool.php
+++ b/bin/gittool.php
@@ -260,7 +260,7 @@ EOF;
         } else {
             $this->msg_success('Found '.count($data).' .git directories');
         }
-        $data = array_map('dirname', $data);
+        $data = array_map('fullpath', array_map('dirname', $data));
         return $data;
     }
 


### PR DESCRIPTION
This script adds an easy method to install new plugins or templates from the command line via git. It can also apply commands to all git repositories with a DokuWiki install making it easy to update all git installed extensions in one go. Useful alternative to the extension manager for power users.
