### PR TITLE
Adding preventDefault to some toolbar icons.  

### DIFF
--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -151,7 +151,7 @@ function addBtnActionSignature($btn, props, edid) {
 function currentHeadlineLevel(textboxId){
     var field = jQuery('#' + textboxId)[0],
         s = false,
-        opts = [field.value.substr(0,getSelection(field).start)];
+        opts = [field.value.substr(0,DWgetSelection(field).start)];
     if (field.form.prefix) {
         // we need to look in prefix context
         opts.push(field.form.prefix.value);
@@ -220,10 +220,10 @@ jQuery(function () {
         }
 
         // set focus and place cursor at the start
-        var sel = getSelection($edit_text[0]);
+        var sel = DWgetSelection($edit_text[0]);
         sel.start = 0;
         sel.end   = 0;
-        setSelection(sel);
+        DWsetSelection(sel);
         $edit_text.focus();
     }
 

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -101,7 +101,7 @@ function tb_format(btn, props, edid) {
 function tb_formatln(btn, props, edid) {
     var sample = props.sample || props.title,
         opts,
-        selection = getSelection(jQuery('#'+edid)[0]);
+        selection = DWgetSelection(jQuery('#'+edid)[0]);
 
     sample = fixtxt(sample);
     props.open  = fixtxt(props.open);


### PR DESCRIPTION
I've added preventDefault to some of the toolbar buttons actions. Without this you cannot use initToolbar to initialize toolbar in any of your own HTML forms because clicking linkwiz, emotion icons, charter table or signature will send the form.(at least in FF26).
