### PR TITLE
Snippet fixes

### DIFF
--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -354,12 +354,12 @@ function ft_snippet($id,$highlight){
             }
 
             // set $offset for next match attempt
-            //   substract strlen to avoid splitting a potential search success,
-            //   this is an approximation as the search pattern may match strings
-            //   of varying length and it will fail if the context snippet
-            //   boundary breaks a matching string longer than the current match
-            $utf8_offset = $utf8_idx + $post;
-            $offset = $idx + strlen(utf8_substr($text,$utf8_idx,$post));
+            // continue matching after the current match
+            // if the current match is not the longest possible match starting at the current offset
+            // this prevents further matching of this snippet but for possible matches of length
+            // smaller than match length + context (at least 50 characters) this match is part of the context
+            $utf8_offset = $utf8_idx + $utf8_len;
+            $offset = $idx + strlen(utf8_substr($text,$utf8_idx,$utf8_len));
             $offset = utf8_correctIdx($text,$offset);
         }
 


### PR DESCRIPTION
This fixes the snippet creation process for snippets at the end of the content, previously two matches at the end of the content had the effect that the whole content was returned as snippet. Furthermore the matching now continues directly after the previous match and not at the previous position + the context length after the snippet which lead to problems when the match was at the end of the content (no context after the snippet, thus matching the same snippet again).
