### PR TITLE
Add FULLTEXT_PHRASE_MATCH event for allowing plugins to match phrases FS#2936

### DIFF
--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -72,8 +72,20 @@ function _ft_pageSearch(&$data) {
                 $pages  = end($stack);
                 $pages_matched = array();
                 foreach(array_keys($pages) as $id){
-                    $text = utf8_strtolower(rawWiki($id));
-                    if (strpos($text, $phrase) !== false) {
+                    $evdata = array(
+                        'id' => $id,
+                        'phrase' => $phrase,
+                        'text' => rawWiki($id)
+                    );
+                    $evt = new Doku_Event('FULLTEXT_PHRASE_MATCH',$evdata);
+                    if ($evt->advise_before() && $evt->result !== true) {
+                        $text = utf8_strtolower($evdata['text']);
+                        if (strpos($text, $phrase) !== false) {
+                            $evt->result = true;
+                        }
+                    }
+                    $evt->advise_after();
+                    if ($evt->result === true) {
                         $pages_matched[$id] = 0; // phrase: always 0 hit
                     }
                 }


### PR DESCRIPTION
Our index doesn't support phrase searches so we are searching for the pages that contain all words of the phrase and then search again in the content of the pages. As plugins can also add additional text to the index this event allows plugins to do phrase matching in their content.

One can wonder if this should be merged with the event for collecting the content that shall be indexed, however as indexing isn't critical for the performance plugins might want to do something else during indexing than during the actual search. This could also be merged with the process of collecting the text that is used for the snippet creation process, however there might be plugins that want to separate this (e.g. a plugin that allows searching the text output instead of the raw text that wants to display rendered HTML snippets) so I'm simply introducing this as a new event but plugins that already simply add their text for the snippets can reuse their event handler as the basic parameters (id, text) are the same for both events (but unfortunately not for the indexer event).
