### PR TITLE
Add indexer job to clean out geshi fragment cache

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -84,6 +84,7 @@ $conf['htmlok']      = 0;                //may raw HTML be embedded? This may br
 $conf['phpok']       = 0;                //may PHP code be embedded? Never do this on the internet! 0|1
 $conf['locktime']    = 15*60;            //maximum age for lockfiles (defaults to 15 minutes)
 $conf['cachetime']   = 60*60*24;         //maximum age for cachefile in seconds (defaults to a day)
+$conf['geshi_cache_expiry'] = 60*60*24*28; // age of cached geshi files before expiry & purging (defaults to 28 days)
 
 /* Link Settings */
 // Set target to use when creating links - leave empty for same window

--- a/lib/exe/indexer.php
+++ b/lib/exe/indexer.php
@@ -36,6 +36,8 @@ if ($evt->advise_before()) {
     sendDigest() or
     runTrimRecentChanges() or
     runTrimRecentChanges(true) or
+    runGeshiCleanUp() or
+
     $evt->advise_after();
 }
 
@@ -184,6 +186,40 @@ function sendDigest() {
     echo "sendDigest(): sent $sent mails".NL;
     echo 'sendDigest(): finished'.NL;
     return (bool) $sent;
+}
+
+/**
+ * Clean out old cached geshi files
+ *
+ * @author Christopher Smith
+ */
+function runGeshiCleanUp() {
+    global $conf;
+
+    print "runGeshiCleanUp(): started".NL;
+
+    $purgeFile = $conf['cachedir'].'/lastgeshipurge';
+    $now = time();
+
+    // to prevent reading through all the cache directories too frequently
+    // only carry out clean up checks at an interval 1/4 * cache expiry
+    if ($now - @filemtime($purgeFile) > ($conf['geshi_cache_expiry']/4)) {
+        // minimize possibility of two cleanUps proceeding simultaneously
+        io_saveFile($purgeFile, $now);
+
+        $geshi_files = glob($conf['cachedir'].'/*/*.code');
+
+        foreach($geshi_files as $file) {
+            if ($now - filemtime($file) > $conf['geshi_cache_expiry']) {
+                @unlink($file);
+            }
+        }
+        print "runGeshiCleanUp(): cleaned / finished".NL;
+        return true;
+    }
+
+    print "runGeshiCleanUp(): not required / finished".NL;
+    return false;
 }
 
 /**

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -119,6 +119,7 @@ $lang['htmlok']      = 'Allow embedded HTML';
 $lang['phpok']       = 'Allow embedded PHP';
 $lang['locktime']    = 'Maximum age for lock files (sec)';
 $lang['cachetime']   = 'Maximum age for cache (sec)';
+$lang['geshi_cache_expiry'] = 'Minimum age of cached GeSHi files before purging (sec)';
 
 /* Link settings */
 $lang['target____wiki']      = 'Target window for internal links';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -158,6 +158,7 @@ $meta['htmlok']      = array('onoff','_caution' => 'security');
 $meta['phpok']       = array('onoff','_caution' => 'security');
 $meta['locktime']    = array('numeric');
 $meta['cachetime']   = array('numeric');
+$meta['geshi_cache_expiry'] = array('numeric');
 
 $meta['_links']    = array('fieldset');
 $meta['target____wiki']      = array('string');


### PR DESCRIPTION
This addresses FS#1418 & FS#923

https://bugs.dokuwiki.org/index.php?do=details&task_id=1418
https://bugs.dokuwiki.org/index.php?do=details&task_id=923

I've put config value to 28 days.  To be meaningful it should be higher than `$conf['cachetime']`.  Geshi output is included within the renderers .xhtml cache.  The Geshi fragments go alongside the instruction cache speeding up rendering.
