### PR TITLE
fix behavior new lines for NOTOC and NOCACHE syntax FS#2517

### DIFF
--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -289,7 +289,7 @@ class Doku_Parser_Mode_header extends Doku_Parser_Mode {
 class Doku_Parser_Mode_notoc extends Doku_Parser_Mode {
 
     function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('~~NOTOC~~',$mode,'notoc');
+        $this->Lexer->addSpecialPattern('~~NOTOC~~\s?',$mode,'notoc');
     }
 
     function getSort() {
@@ -301,7 +301,7 @@ class Doku_Parser_Mode_notoc extends Doku_Parser_Mode {
 class Doku_Parser_Mode_nocache extends Doku_Parser_Mode {
 
     function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('~~NOCACHE~~',$mode,'nocache');
+        $this->Lexer->addSpecialPattern('~~NOCACHE~~\s?',$mode,'nocache');
     }
 
     function getSort() {


### PR DESCRIPTION
Whitespaces for the first header are already removed (by other parsing stuff i guess).

But this removed additional newline/whitespaces around this syntax.

https://bugs.dokuwiki.org/index.php?do=details&task_id=2517
