### PR TITLE
Reduces size of linkwizard suggestions 

### DIFF
--- a/lib/exe/ajax.php
+++ b/lib/exe/ajax.php
@@ -412,8 +412,16 @@ function ajax_linkwiz(){
 
     // output the found data
     $even = 1;
+    $count = 0;
     foreach($data as $item){
         $even *= -1; //zebra
+
+        //truncated output
+        if($count > 50) {
+            echo '<div class="'.(($even > 0)?'even':'odd').' type_'.$item['type'].'">...</div>';
+            break;
+        }
+        $count ++;
 
         if(($item['type'] == 'd' || $item['type'] == 'u') && $item['id']) $item['id'] .= ':';
         $link = wl($item['id']);


### PR DESCRIPTION
https://bugs.dokuwiki.org/index.php?do=details&task_id=2948
- It search request still finds all matches, but it reduced the number of returned suggestions.
- There seems no way to limit the number of results the search method may come up.
  So it is a bit of half improvement..
