### PR TITLE
Another attempt at fixing combinations of em and links

### DIFF
--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -357,53 +357,58 @@ class Doku_Parser_Mode_hr extends Doku_Parser_Mode {
  */
 class Doku_Parser_Mode_formatting extends Doku_Parser_Mode {
     var $type;
-
-    var $formatting = array (
-        'strong' => array (
-            'entry'=>'\*\*(?=.*\*\*)',
-            'exit'=>'\*\*',
-            'sort'=>70
-            ),
-
-        'emphasis'=> array (
-            'entry'=>'//(?=[^\x00]*[^:])', //hack for bugs #384 #763 #1468
-            'exit'=>'//',
-            'sort'=>80
-            ),
-
-        'underline'=> array (
-            'entry'=>'__(?=.*__)',
-            'exit'=>'__',
-            'sort'=>90
-            ),
-
-        'monospace'=> array (
-            'entry'=>'\x27\x27(?=.*\x27\x27)',
-            'exit'=>'\x27\x27',
-            'sort'=>100
-            ),
-
-        'subscript'=> array (
-            'entry'=>'<sub>(?=.*</sub>)',
-            'exit'=>'</sub>',
-            'sort'=>110
-            ),
-
-        'superscript'=> array (
-            'entry'=>'<sup>(?=.*</sup>)',
-            'exit'=>'</sup>',
-            'sort'=>120
-            ),
-
-        'deleted'=> array (
-            'entry'=>'<del>(?=.*</del>)',
-            'exit'=>'</del>',
-            'sort'=>130
-            ),
-        );
+    var $formatting;
 
     function Doku_Parser_Mode_formatting($type) {
         global $PARSER_MODES;
+        $ltrs = '\w';
+        $gunk = '/\#~:.?+=&%@!\-\[\]';
+        $punc = '.:?\-;,';
+        $any = $ltrs.$gunk.$punc;
+
+        $this->formatting = array (
+            'strong' => array (
+                'entry'=>'\*\*(?=.*\*\*)',
+                'exit'=>'\*\*',
+                'sort'=>70
+                ),
+
+            'emphasis'=> array (
+                'entry'=>'//(?=.*(?:[^:]//|//[^'.$any.']))',
+                'exit'=>'//',
+                'sort'=>80
+                ),
+
+            'underline'=> array (
+                'entry'=>'__(?=.*__)',
+                'exit'=>'__',
+                'sort'=>90
+                ),
+
+            'monospace'=> array (
+                'entry'=>'\x27\x27(?=.*\x27\x27)',
+                'exit'=>'\x27\x27',
+                'sort'=>100
+                ),
+
+            'subscript'=> array (
+                'entry'=>'<sub>(?=.*</sub>)',
+                'exit'=>'</sub>',
+                'sort'=>110
+                ),
+
+            'superscript'=> array (
+                'entry'=>'<sup>(?=.*</sup>)',
+                'exit'=>'</sup>',
+                'sort'=>120
+                ),
+
+            'deleted'=> array (
+                'entry'=>'<del>(?=.*</del>)',
+                'exit'=>'</del>',
+                'sort'=>130
+                ),
+            );
 
         if ( !array_key_exists($type, $this->formatting) ) {
             trigger_error('Invalid formatting type '.$type, E_USER_WARNING);


### PR DESCRIPTION
As requested by Julian Fagir (gnrp) in the [irc](http://irc.dokuwiki.org/index.php?d=2014-03-08#msg502297) channel I'm proposing this fix for the italics/em syntax.

This fixes cases with "normal" URLs but creates some weird special cases:
- `this triggers // italics [[http://ärmel.de]] some test` (`this does not trigger // italics [[http://www.ärmel.de]] some test`)
- `//no italics://this is neither a url nor italics` but `//italics://this triggers italics because there are //more slashes later`
