### PR TITLE
Add encoding fix to tpl_img_getTag()

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1018,7 +1018,7 @@ function tpl_img_getTag($tags, $alt = '', $src = null) {
     static $meta = null;
     if(is_null($meta)) $meta = new JpegMeta($src);
     if($meta === false) return $alt;
-    $info = $meta->getField($tags);
+    $info = cleanText($meta->getField($tags));
     if($info == false) return $alt;
     return $info;
 }


### PR DESCRIPTION
Run jpeg meta tags through cleanText for a conversion to UTF-8
from latin-1 if possible.  MediaManager already uses this
conversion.  Addresses a side issue of [FS#1988](https://bugs.dokuwiki.org/index.php?do=details&task_id=1988&project=1)
