### PR TITLE
strip sourcemaps in CSS and JS #601

### DIFF
--- a/_test/tests/inc/common_stripsourcemaps.test.php
+++ b/_test/tests/inc/common_stripsourcemaps.test.php
@@ -1,0 +1,29 @@
+<?php
+
+class common_stripsourcemaps_test extends DokuWikiTest {
+
+    function test_all() {
+
+        $text = <<<EOL
+//@ sourceMappingURL=/foo/bar/xxx.map
+//# sourceMappingURL=/foo/bar/xxx.map
+/*@ sourceMappingURL=/foo/bar/xxx.map */
+/*# sourceMappingURL=/foo/bar/xxx.map */
+bang
+EOL;
+
+        $expect = <<<EOL
+//
+//
+/**/
+/**/
+bang
+EOL;
+
+        stripsourcemaps($text);
+
+
+        $this->assertEquals($expect, $text);
+    }
+
+}

--- a/inc/common.php
+++ b/inc/common.php
@@ -1675,4 +1675,13 @@ function set_doku_pref($pref, $val) {
     }
 }
 
+/**
+ * Strips source mapping declarations from given text #601
+ *
+ * @param &string $text reference to the CSS or JavaScript code to clean
+ */
+function stripsourcemaps(&$text){
+    $text = preg_replace('/^(\/\/|\/\*)[@#]\s+sourceMappingURL=.*?(\*\/)?$/im', '\\1\\2', $text);
+}
+
 //Setup VIM: ex: et ts=2 :

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -133,6 +133,9 @@ function css_out(){
     $css = ob_get_contents();
     ob_end_clean();
 
+    // strip any source maps
+    stripsourcemaps($css);
+
     // apply style replacements
     $css = css_applystyle($css, $styleini['replacements']);
 

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -137,6 +137,9 @@ function js_out(){
     $js = ob_get_contents();
     ob_end_clean();
 
+    // strip any source maps
+    stripsourcemaps($js);
+
     // compress whitespace and comments
     if($conf['compress']){
         $js = js_compress($js);


### PR DESCRIPTION
source maps are invalid for our dispatched sources and may even cause
problems. this makes sure any sourcemap declarations are stripped from
the output
