### PR TITLE
fixed unclosed tags in some language translations

### DIFF
--- a/inc/lang/he/lang.php
+++ b/inc/lang/he/lang.php
@@ -285,7 +285,7 @@ $lang['i_modified']            = 'משיקולי אבטחה סקריפט זה י
                          עליך לחלץ שנית את הקבצים מהחבילה שהורדה או להיעזר בדף
                          <a href="http://dokuwiki.org/install">Dokuwiki installation instructions</a>';
 $lang['i_funcna']              = 'פונקציית ה-PHP&rlm; <code>%s</code> אינה זמינה. יתכן כי מארח האתר חסם אותה מסיבה כלשהי?';
-$lang['i_phpver']              = 'גרסת PHP שלך <code>%s</code> נמוכה מ <code>%s</ code> הצורך. אתה צריך לשדרג PHP שלך להתקין.';
+$lang['i_phpver']              = 'גרסת PHP שלך <code>%s</code> נמוכה מ <code>%s</code> הצורך. אתה צריך לשדרג PHP שלך להתקין.';
 $lang['i_permfail']            = '<code>%s</code> אינה ניתנת לכתיבה על ידי DokuWiki. עליך לשנות הרשאות תיקייה זו!';
 $lang['i_confexists']          = '<code>%s</code> כבר קיים';
 $lang['i_writeerr']            = 'אין אפשרות ליצור את <code>%s</code>. נא לבדוק את הרשאות הקובץ/תיקייה וליצור את הקובץ ידנית.';

--- a/lib/plugins/authad/lang/es/settings.php
+++ b/lib/plugins/authad/lang/es/settings.php
@@ -7,7 +7,7 @@
  * @author Antonio Bueno <atnbueno@gmail.com>
  * @author Juan De La Cruz <juann.dlc@gmail.com>
  */
-$lang['account_suffix']        = 'Su cuenta, sufijo. Ejem. <code> @ my.domain.org </ code>';
+$lang['account_suffix']        = 'Su cuenta, sufijo. Ejem. <code> @ my.domain.org </code>';
 $lang['base_dn']               = 'Su base DN. Ejem. <code>DC=my,DC=dominio,DC=org</code>';
 $lang['domain_controllers']    = 'Una lista separada por coma de los controladores de dominios. Ejem. <code>srv1.dominio.org,srv2.dominio.org</code>';
 $lang['admin_username']        = 'Un usuario con privilegios de Active Directory con acceso a los datos de cualquier otro usuario. Opcional, pero es necesario para determinadas acciones como el envío de suscripciones de correos electrónicos.';

--- a/lib/plugins/authldap/lang/et/settings.php
+++ b/lib/plugins/authldap/lang/et/settings.php
@@ -5,5 +5,5 @@
  * 
  * @author Janar Leas <janar.leas@eesti.ee>
  */
-$lang['grouptree']             = 'Kus kohast kasutaja rühmi otsida. Nt. <code>ou=Rühm, dc=server, dc=tld</code';
+$lang['grouptree']             = 'Kus kohast kasutaja rühmi otsida. Nt. <code>ou=Rühm, dc=server, dc=tld</code>';
 $lang['groupscope']            = 'Piiritle otsingu ulatus rühma otsinguga';

--- a/lib/plugins/authldap/lang/ja/settings.php
+++ b/lib/plugins/authldap/lang/ja/settings.php
@@ -7,7 +7,7 @@
  * @author Hideaki SAWADA <sawadakun@live.jp>
  * @author Hideaki SAWADA <chuno@live.jp>
  */
-$lang['server']                = 'LDAPサーバー。ホスト名（<code>localhost</code）又は完全修飾URL（<code>ldap://server.tld:389</code>）';
+$lang['server']                = 'LDAPサーバー。ホスト名（<code>localhost</code>）又は完全修飾URL（<code>ldap://server.tld:389</code>）';
 $lang['port']                  = '上記が完全修飾URLでない場合、LDAPサーバーポート';
 $lang['usertree']              = 'ユーザーアカウントを探す場所。例：<code>ou=People, dc=server, dc=tld</code>';
 $lang['grouptree']             = 'ユーザーグループを探す場所。例：<code>ou=Group, dc=server, dc=tld</code>';


### PR DESCRIPTION
Just some unclosed &lt;code&gt; tags that were fixed. 
