### PR TITLE
tar: test. skip instead of error if bz2 or zlib extension is missing

### DIFF
--- a/_test/tests/inc/tar.test.php
+++ b/_test/tests/inc/tar.test.php
@@ -7,6 +7,7 @@ class Tar_TestCase extends DokuWikiTest {
     protected $extensions = array('tar');
 
     public function setUp() {
+        parent::setUp();
         if (extension_loaded('zlib')) {
             $this->extensions[] = 'tgz';
         }


### PR DESCRIPTION
there's long discussion on irc, why the PR is as it is:

http://irc.dokuwiki.org/index.php?d=2014-04-14#msg506129
