### PR TITLE
add editorconfig policy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; http://editorconfig.org/
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[inc/{geshi,phpseclib}/**]
+; Use editor default (possible autodetection).
+indent_style =
+indent_size =
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) helps developers define and maintain consistent coding styles between different editors and IDEs.

Plugin for PHPStorm exists as well
