### PR TITLE
Fix https proxy authentication, the header was missing a colon so that

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -552,7 +552,7 @@ class HTTPClient {
         $request  = "CONNECT {$requestinfo['host']}:{$requestinfo['port']} HTTP/1.0".HTTP_NL;
         $request .= "Host: {$requestinfo['host']}".HTTP_NL;
         if($this->proxy_user) {
-            $request .= 'Proxy-Authorization Basic '.base64_encode($this->proxy_user.':'.$this->proxy_pass).HTTP_NL;
+            $request .= 'Proxy-Authorization: Basic '.base64_encode($this->proxy_user.':'.$this->proxy_pass).HTTP_NL;
         }
         $request .= HTTP_NL;
 


### PR DESCRIPTION
the auth info was not working.
The fix for the missing header that was still present in 2013-12-08 "Binky" was missing the colon after the header keyword.
I have written a unit test to verify this locally, however it makes not much sense to include the test in the normal source since that requires a proxy-auth running on the test proxy (if that can be set up, adding the user/pw to the unit tests httpclient_http*_proxy.test.php would be possible)
