### PR TITLE
log deprecated function calls FS#2399

### DIFF
--- a/inc/TarLib.class.php
+++ b/inc/TarLib.class.php
@@ -26,6 +26,8 @@ class TarLib {
     public $_result = true;
 
     function __construct($file, $comptype = TarLib::COMPRESS_AUTO, $complevel = 9) {
+        dbg_deprecated('class Tar');
+
         if(!$file) $this->error('__construct', '$file');
 
         $this->file = $file;

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -1004,12 +1004,13 @@ class MediaChangelog extends ChangeLog {
  * changelog files, only the chunk containing the
  * requested changelog line is read.
  *
- * @deprecated 20-11-2013
+ * @deprecated 2013-11-20
  *
  * @author Ben Coburn <btcoburn@silicodon.net>
  * @author Kate Arzamastseva <pshns@ukr.net>
  */
 function getRevisionInfo($id, $rev, $chunk_size = 8192, $media = false) {
+    dbg_deprecated('class PageChangeLog or class MediaChanglog');
     if($media) {
         $changelog = new MediaChangeLog($id, $chunk_size);
     } else {
@@ -1036,12 +1037,13 @@ function getRevisionInfo($id, $rev, $chunk_size = 8192, $media = false) {
  * backwards in chunks until the requested number of changelog
  * lines are recieved.
  *
- * @deprecated 20-11-2013
+ * @deprecated 2013-11-20
  *
  * @author Ben Coburn <btcoburn@silicodon.net>
  * @author Kate Arzamastseva <pshns@ukr.net>
  */
 function getRevisions($id, $first, $num, $chunk_size = 8192, $media = false) {
+    dbg_deprecated('class PageChangeLog or class MediaChanglog');
     if($media) {
         $changelog = new MediaChangeLog($id, $chunk_size);
     } else {

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -384,6 +384,32 @@ function dbglog($msg,$header=''){
 }
 
 /**
+ * Log accesses to deprecated fucntions to the debug log
+ *
+ * @param string $alternative The function or method that should be used instead
+ */
+function dbg_deprecated($alternative = '') {
+    global $conf;
+    if(!$conf['allowdebug']) return;
+
+    $backtrace = debug_backtrace();
+    array_shift($backtrace);
+    $self = array_shift($backtrace);
+    $call = array_shift($backtrace);
+
+    $called = trim($self['class'].'::'.$self['function'].'()', ':');
+    $caller = trim($call['class'].'::'.$call['function'].'()', ':');
+
+    $msg = $called.' is deprecated. It was called from ';
+    $msg .= $caller.' in '.$call['file'].':'.$call['line'];
+    if($alternative) {
+        $msg .= ' '.$alternative.' should be used instead!';
+    }
+
+    dbglog($msg);
+}
+
+/**
  * Print a reversed, prettyprinted backtrace
  *
  * @author Gary Owen <gary_owen@bigfoot.com>

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -252,6 +252,7 @@ class DokuWiki_Plugin {
      */
     function __call($name, $arguments) {
         if($name == 'render'){
+            dbg_deprecated('render_text()');
             if(!isset($arguments[1])) $arguments[1] = 'xhtml';
             return $this->render_text($arguments[0], $arguments[1]);
         }

--- a/inc/subscription.php
+++ b/inc/subscription.php
@@ -700,6 +700,7 @@ class Subscription {
  * @deprecated 2012-12-07
  */
 function subscription_addresslist(&$data) {
+    dbg_deprecated('class Subscription');
     $sub = new Subscription();
     $sub->notifyaddresses($data);
 }


### PR DESCRIPTION
This introduces a new dbg_deprecated() function which allows for easy
marking of deprecated functions. Each call is logged to the debuglog
when debuggin is enabled.
