### PR TITLE
Quick fix for #765 - ACL checks in the media manager ajax calls

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1428,14 +1428,14 @@ function tpl_mediaFileList() {
  * @author Kate Arzamastseva <pshns@ukr.net>
  */
 function tpl_mediaFileDetails($image, $rev) {
-    global $AUTH, $NS, $conf, $DEL, $lang;
+    global $conf, $DEL, $lang;
     /** @var Input $INPUT */
     global $INPUT;
 
     $removed = (!file_exists(mediaFN($image)) && file_exists(mediaMetaFN($image, '.changes')) && $conf['mediarevisions']);
     if(!$image || (!file_exists(mediaFN($image)) && !$removed) || $DEL) return;
     if($rev && !file_exists(mediaFN($image, $rev))) $rev = false;
-    if(isset($NS) && getNS($image) != $NS) return;
+    $ns = getNS($image);
     $do = $INPUT->str('mediado');
 
     $opened_tab = $INPUT->str('tab_details');
@@ -1471,13 +1471,13 @@ function tpl_mediaFileDetails($image, $rev) {
     echo '<div class="panelContent">'.NL;
 
     if($opened_tab == 'view') {
-        media_tab_view($image, $NS, $AUTH, $rev);
+        media_tab_view($image, $ns, null, $rev);
 
     } elseif($opened_tab == 'edit' && !$removed) {
-        media_tab_edit($image, $NS, $AUTH);
+        media_tab_edit($image, $ns);
 
     } elseif($opened_tab == 'history' && $conf['mediarevisions']) {
-        media_tab_history($image, $NS, $AUTH);
+        media_tab_history($image, $ns);
     }
 
     echo '</div>'.NL;

--- a/lib/exe/ajax.php
+++ b/lib/exe/ajax.php
@@ -254,7 +254,7 @@ function ajax_mediadiff(){
 
     $image = '';
     if ($INPUT->has('image')) $image = cleanID($INPUT->str('image'));
-    $NS = $INPUT->post->str('ns');
+    $NS = getNS($image);
     $auth = auth_quickaclcheck("$NS:*");
     media_diff($image, $NS, $auth, true);
 }


### PR DESCRIPTION
This should be superseded by a proper rewrite of the media manager code. I tried to touch as little code as possible, my main goal was to provide a clean environment for the `media_tab_*`-functions and the `media_diff` function and not to rely too much on the globals and possibly wrong URL parameters.
