### PR TITLE
remoteuser - Patch for default setting and improved checking in hasAccess()

### DIFF
--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -157,6 +157,8 @@ class remote_test extends DokuWikiTest {
     }
 
     function test_hasAccessSuccess() {
+        global $conf;
+        $conf['remoteuser'] = '';
         $this->assertTrue($this->remote->hasAccess());
     }
 
@@ -203,6 +205,7 @@ class remote_test extends DokuWikiTest {
     function test_forceAccessSuccess() {
         global $conf;
         $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
         $this->remote->forceAccess(); // no exception should occur
     }
 
@@ -217,7 +220,11 @@ class remote_test extends DokuWikiTest {
 
     function test_generalCoreFunctionWithoutArguments() {
         global $conf;
+        global $USERINFO;
         $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 1;
+        $USERINFO['grps'] = array('grp');
         $remoteApi = new RemoteApi();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
@@ -243,7 +250,10 @@ class remote_test extends DokuWikiTest {
 
     function test_generalCoreFunctionWithArguments() {
         global $conf;
+        global $USERINFO;
         $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 1;
 
         $remoteApi = new RemoteApi();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
@@ -256,7 +266,10 @@ class remote_test extends DokuWikiTest {
 
     function test_pluginCallMethods() {
         global $conf;
+        global $USERINFO;
         $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 1;
 
         $remoteApi = new RemoteApi();
         $this->assertEquals($remoteApi->call('plugin.testplugin.method1'), null);
@@ -313,6 +326,11 @@ class remote_test extends DokuWikiTest {
     }
 
     function test_pluginCallCustomPath() {
+        global $conf;
+        global $USERINFO;
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 1;
         global $EVENT_HANDLER;
         $EVENT_HANDLER->register_hook('RPC_CALL_ADD', 'BEFORE', $this, 'pluginCallCustomPathRegister');
 

--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -65,7 +65,7 @@ $conf['disableactions'] = '';            //comma separated list of actions to di
 $conf['auth_security_timeout'] = 900;    //time (seconds) auth data is considered valid, set to 0 to recheck on every page view
 $conf['securecookie'] = 1;               //never send HTTPS cookies via HTTP
 $conf['remote']      = 0;                //Enable/disable remote interfaces
-$conf['remoteuser']  = '!!not set !!';   //user/groups that have access to remote interface (comma separated)
+$conf['remoteuser']  = '!!not set!!';    //user/groups that have access to remote interface (comma separated)
 
 /* Antispam Features */
 $conf['usewordblock']= 1;                //block spam based on words? 0|1

--- a/inc/remote.php
+++ b/inc/remote.php
@@ -175,6 +175,9 @@ class RemoteAPI {
         if (!$conf['remote']) {
             return false;
         }
+        if(trim($conf['remoteuser']) == '!!not set!!') {
+            return false;
+        }
         if(!$conf['useacl']) {
             return true;
         }


### PR DESCRIPTION
I noticed a strange default setting of remoteuser.

I also noticed hasAccess() did not check this default setting.

Furthermore I think the following code in hasAccess() should at least return false, even better would be to remove it completely, as this feels like circumventing all security mechanisms:

        if(trim($conf['remoteuser']) == '') {
            return true;
        }
