### PR TITLE
improve qsearch suggestions

### DIFF
--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -215,7 +215,7 @@ function ft_pageLookup($id, $in_ns=false, $in_title=false){
 function _ft_pageLookup(&$data){
     // split out original parameters
     $id = $data['id'];
-    if (preg_match('/(?:^| )@(\w+)/', $id, $matches)) {
+    if (preg_match('/(?:^| )(?:@|ns:)([\w:]+)/', $id, $matches)) {
         $ns = cleanID($matches[1]) . ':';
         $id = str_replace($matches[0], '', $id);
     }


### PR DESCRIPTION
- support namespaces with more then one level e.g. `@your:namespace`
- support `ns:<ns>` as well

Currently, we don't support namespaces like: `kaugtöö:` or `星期一test:` in the qsearch.
While the `ft_pageSearch()` via `ft_queryParser()` breaks the search query and matches with `/^(?:\^|-ns:)(.+)$/u` the separated terms. That handles these example namespaces fine.
https://github.com/splitbrain/dokuwiki/blob/master/inc/fulltext.php#L595

Using something like `'/(?:^| )(?:@|ns:)(.+?\b)/'` in `_ft_pageLookup()` breaks also at the non-latin characters. Has someone a better regexp?
