### PR TITLE
Added @ALL handeling in auth_isMember

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -638,6 +638,7 @@ function auth_isMember($memberlist, $user, array $groups) {
 
     // compare cleaned values
     foreach($members as $member) {
+        if($member == '@ALL' ) return true;
         if(!$auth->isCaseSensitive()) $member = utf8_strtolower($member);
         if($member[0] == '@') {
             $member = $auth->cleanGroup(substr($member, 1));


### PR DESCRIPTION
Issue #637
Presuming the @ALL group is a reserved groupname identifying any user.
During members parsing if member equals @ALL we return true;
