### PR TITLE
Resolve conflict for Concrete5

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -28,7 +28,7 @@ $opt = rss_parseOptions();
 // the feed is dynamic - we need a cache for each combo
 // (but most people just use the default feed so it's still effective)
 $key   = join('', array_values($opt)).'$'.$_SERVER['REMOTE_USER'].'$'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'];
-$cache = new cache($key, '.feed');
+$cache = new doku_cache($key, '.feed');
 
 // prepare cache depends
 $depends['files'] = getConfigFiles('main');

--- a/inc/cache.php
+++ b/inc/cache.php
@@ -11,7 +11,7 @@ if(!defined('DOKU_INC')) die('meh.');
 /**
  * Generic handling of caching
  */
-class cache {
+class doku_cache {
     public $key = '';          // primary identifier for this item
     public $ext = '';          // file ext for cache data, secondary identifier for this item
     public $cache = '';        // cache file name
@@ -174,7 +174,7 @@ class cache {
 /**
  * Parser caching
  */
-class cache_parser extends cache {
+class cache_parser extends doku_cache {
 
     public $file = '';       // source file for cache
     public $mode = '';       // input mode (represents the processing the input file will undergo)

--- a/inc/load.php
+++ b/inc/load.php
@@ -55,7 +55,7 @@ function load_autoload($name){
         'Diff'                  => DOKU_INC.'inc/DifferenceEngine.php',
         'UnifiedDiffFormatter'  => DOKU_INC.'inc/DifferenceEngine.php',
         'TableDiffFormatter'    => DOKU_INC.'inc/DifferenceEngine.php',
-        'cache'                 => DOKU_INC.'inc/cache.php',
+        'doku_cache'                 => DOKU_INC.'inc/cache.php',
         'cache_parser'          => DOKU_INC.'inc/cache.php',
         'cache_instructions'    => DOKU_INC.'inc/cache.php',
         'cache_renderer'        => DOKU_INC.'inc/cache.php',

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -45,7 +45,7 @@ function css_out(){
     if(!$tpl) $tpl = $conf['template'];
 
     // The generated script depends on some dynamic options
-    $cache = new cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl.$type,'.css');
+    $cache = new doku_cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl.$type,'.css');
 
     // load styl.ini
     $styleini = css_styleini($tpl);

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -32,7 +32,7 @@ function js_out(){
     global $config_cascade;
 
     // The generated script depends on some dynamic options
-    $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'],'.js');
+    $cache = new doku_cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'],'.js');
     $cache->_event = 'JS_CACHE_USE';
 
     // load minified version for some files


### PR DESCRIPTION
While integrating DokuWiki with Concrete5 (auth plugin), some
classes/classnames conflict. These changes resolve the issue.

Ultimately all classes should be namespaced to resolve classname
conflicts.