### PR TITLE
Fix for update messages never completely going away

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -29,18 +29,19 @@ function checkUpdateMessages(){
         dbglog("checkUpdateMessages(): downloading messages.txt");
         $http = new DokuHTTPClient();
         $http->timeout = 12;
-        $data = $http->get(DOKU_MESSAGEURL.$updateVersion);
-        if(substr(trim($data), -1) != '%') {
-            // this doesn't look like one of our messages, maybe some WiFi login interferred
-            $data = '';
-        }else {
-            io_saveFile($cf,$data);
+        $resp = $http->get(DOKU_MESSAGEURL.$updateVersion);
+        if(is_string($resp) && ($resp == "" || substr(trim($resp), -1) == '%')) {
+            // basic sanity check that this is either an empty string response (ie "no messages")
+            // or it looks like one of our messages, not WiFi login or other interposed response
+            io_saveFile($cf,$resp);
+        } else {
+            dbglog("checkUpdateMessages(): unexpected HTTP response received");
         }
     }else{
         dbglog("checkUpdateMessages(): messages.txt up to date");
-        $data = io_readFile($cf);
     }
 
+    $data = io_readFile($cf);
     // show messages through the usual message mechanism
     $msgs = explode("\n%\n",$data);
     foreach($msgs as $msg){


### PR DESCRIPTION
The existing logic for messages.txt requires some valid update
response (ending in %) to the messages update check before it clears
the current messages.

However update.dokuwiki.org appears to return an empty string response
if everything is up to date. (ie http://update.dokuwiki.org/check/46.1 )

As a result if there are update messages in messages.txt they don't
automatically go away after updating to the current version. The only
time they change is when a newer release comes out. The upgrade plugin
has logic in it to force a re-download of messages.txt, but currently
this just re-downloads the old update messages.

This change explicitly allows for "" as a valid "no messages"
indicator (distinct from false, which is the HTTP error indicator.)
