### PR TITLE
preserve comments in less if 'compress' config disabled

### DIFF
--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -166,8 +166,11 @@ function css_out(){
  * @return string
  */
 function css_parseless($css) {
+    global $conf;
+
     $less = new lessc();
     $less->importDir[] = DOKU_INC;
+    $less->setPreserveComments(!$conf['compress']);
 
     if (defined('DOKU_UNITTEST')){
         $less->importDir[] = TMP_DIR;


### PR DESCRIPTION
Otherwise comments are never visible in css.php

https://www.dokuwiki.org/config:compress
