### PR TITLE
AUTH_USER_CHANGE handler can modify passed data

### DIFF
--- a/lib/plugins/auth.php
+++ b/lib/plugins/auth.php
@@ -129,7 +129,7 @@ class DokuWiki_Auth_Plugin extends DokuWiki_Plugin {
         $eventdata = array('type' => $type, 'params' => $params, 'modification_result' => null);
         $evt       = new Doku_Event('AUTH_USER_CHANGE', $eventdata);
         if($evt->advise_before(true)) {
-            $result                           = call_user_func_array(array($this, $validTypes[$type]), $params);
+            $result                           = call_user_func_array(array($this, $validTypes[$type]), $evt->data['params']);
             $evt->data['modification_result'] = $result;
         }
         $evt->advise_after();


### PR DESCRIPTION
Originally AUTH_USER_CHANGE handler could modify the user data, however,
auth plugin consequently worked with different copy of the array thus
effectively preventing any changes by the AUTH_USER_CHANGE implementer.
