### PR TITLE
Accept some new gTLD e-Mail addresses

### DIFF
--- a/inc/mail.php
+++ b/inc/mail.php
@@ -27,7 +27,7 @@ if(!defined('MAILHEADER_EOL')) define('MAILHEADER_EOL',"\n");
  * Check if a given mail address is valid
  */
 if (!defined('RFC2822_ATEXT')) define('RFC2822_ATEXT',"0-9a-zA-Z!#$%&'*+/=?^_`{|}~-");
-if (!defined('PREG_PATTERN_VALID_EMAIL')) define('PREG_PATTERN_VALID_EMAIL', '['.RFC2822_ATEXT.']+(?:\.['.RFC2822_ATEXT.']+)*@(?i:[0-9a-z][0-9a-z-]*\.)+(?i:[a-z]{2,4}|museum|travel)');
+if (!defined('PREG_PATTERN_VALID_EMAIL')) define('PREG_PATTERN_VALID_EMAIL', '['.RFC2822_ATEXT.']+(?:\.['.RFC2822_ATEXT.']+)*@(?i:[0-9a-z][0-9a-z-]*\.)+(?i:[a-z]{2,63})');
 
 /**
  * Prepare mailfrom replacement patterns


### PR DESCRIPTION
by allowing longer TLDs (up to 63 characters, which is the DN maximum: https://tools.ietf.org/html/rfc1034):
"Each node has a label, which is zero to 63 octets in length."

For an up-to-date-length, see http://stackoverflow.com/a/22038535
