### PR TITLE
visibility from private to protected for DokuCssFile

### DIFF
--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -421,7 +421,7 @@ class DokuCssFile {
 
     protected $filepath;             // file system path to the CSS/Less file
     protected $location;             // base url location of the CSS/Less file
-    private   $relative_path = null;
+    protected $relative_path = null;
 
     public function __construct($file) {
         $this->filepath = $file;
@@ -454,7 +454,7 @@ class DokuCssFile {
      *
      * @return string   relative file system path
      */
-    private function getRelativePath(){
+    protected function getRelativePath(){
 
         if (is_null($this->relative_path)) {
             $basedir = array(DOKU_INC);


### PR DESCRIPTION
I reuse the css parser for another view of the site as well. However I would like to have a different relative path, so overriding getRelativePath() would be welcome.
