### PR TITLE
Trim unnecessary / at start of windowssharelink

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -999,6 +999,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         $link['title'] = $this->_xmlEntities($url);
         $url           = str_replace('\\', '/', $url);
+        $url           = ltrim($url,'/');
         $url           = 'file:///'.$url;
         $link['url']   = $url;
 


### PR DESCRIPTION
Some urls handed to the function `windowssharelink($url, $name = null)` at inc/parser/xhtml.php start like //server/share/... Together with the line `$url           = 'file:///'.$url;` the resulting html had 5 slash instead of three, i.e. file://///server/share/.

This pull-request trims those unnecessary `/`, so that the resulting link has reliably three slashes.
