### PR TITLE
Handles CTRL-Enter event to save in the editor

### DIFF
--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -124,14 +124,15 @@ var dw_editor = {
      * Listens to all key inputs and handle indentions
      * of lists and code blocks
      *
-     * Currently handles space, backspce and enter presses
+     * Currently handles space, backspace, enter and
+     * ctrl-enter presses
      *
      * @author Andreas Gohr <andi@splitbrain.org>
      * @fixme handle tabs
      * @param event e - the key press event object
      */
     keyHandler: function(e){
-        if(jQuery.inArray(e.keyCode,[8, 13, 32]) === -1) {
+        if(jQuery.inArray(e.keyCode,[8, 10, 13, 32]) === -1) {
             return;
         }
         var selection = DWgetSelection(this);
@@ -143,7 +144,12 @@ var dw_editor = {
                                  search.lastIndexOf("\r")); //IE workaround
         search = search.substr(linestart);
 
-        if(e.keyCode == 13){ // Enter
+        if((e.keyCode == 13 || e.keyCode == 10) && e.ctrlKey) { // Ctrl-Enter (With Chrome workaround)
+            // Submit current edit
+            jQuery('input#edbtn__save').click();
+            e.preventDefault(); // prevent enter key
+            return false;
+        }else if(e.keyCode == 13){ // Enter
             // keep current indention for lists and code
             var match = search.match(/(\n  +([\*-] ?)?)/);
             if(match){


### PR DESCRIPTION
Many webapplications (Github for example) use CTRL-Enter as a short cut to submit the current form. This pull request adds that functionality to DokuWiki: Press CTRL-Enter in the editor and editor.js clicks for you on the #edbtn__save-button.

It should be compatible with all themes which don't change to id of the save button. And shouldn't interfere with those that did change the id.

Tested on Mac OS X Yosemite 10.10 with Chrome 38 and Safari 8 and on Windows 7 with Internet Explorer 11, Chrome 38 and Firefox 33.