### PR TITLE
Optionally render RSS unsorted.

### DIFF
--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -526,6 +526,7 @@ class Doku_Handler {
         $p['author']  = (preg_match('/\b(by|author)/',$params));
         $p['date']    = (preg_match('/\b(date)/',$params));
         $p['details'] = (preg_match('/\b(desc|detail)/',$params));
+        $p['nosort']  = (preg_match('/\b(nosort)\b/',$params));
 
         if (preg_match('/\b(\d+)([dhm])\b/',$params,$match)) {
             $period = array('d' => 86400, 'h' => 3600, 'm' => 60);

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1178,6 +1178,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             error_reporting($elvl);
         }
 
+        if($params['nosort']) $feed->enable_order_by_date(false);
+
         //decide on start and end
         if($params['reverse']) {
             $mod   = -1;


### PR DESCRIPTION
By default, SimplePie sorts RSS entries by the the date on each entry.

If some cases, mostly where RSS is used as a input format for another
service, rendering the order as-is is better than having it sorted.

This patch adds a new parameter for the rss keyword, 'nosort', which can
be used to disable SimplePie's sorting.

This makes it possible to correctly display RSS feeds from "Remember The
Milk", which have a complex order from the system.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>