### PR TITLE
Reuse CSS and less files for different modes

### DIFF
--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -277,7 +277,9 @@ function css_styleini($tpl) {
 
         // stylesheets
         if(is_array($data['stylesheets'])) foreach($data['stylesheets'] as $file => $mode){
-            $stylesheets[$mode][$incbase.$file] = $webbase;
+            foreach(explode(',', $mode) as $innerMode) {
+                $stylesheets[$innerMode][$incbase.$file] = $webbase;
+            }
         }
 
         // replacements


### PR DESCRIPTION
This allows to specify multiple comma separated modes for the same
css/less file.

Since DW-Styles can be made of compiled less it will be good to have
common files with config for each mode. The style.ini is one point but
if it comes to e.g. mixins or constants that are not defined in
style.ini.
