### PR TITLE
error message in the Extension manager for the auth plugin in-use

### DIFF
--- a/lib/plugins/extension/helper/list.php
+++ b/lib/plugins/extension/helper/list.php
@@ -492,7 +492,7 @@ class helper_plugin_extension_list extends DokuWiki_Plugin {
                 $errors .= '<p class="permerror">'.$this->getLang('git').'</p>';
             }
 
-            if ($extension->isEnabled() && in_array('Auth', $extension->getTypes()) && $conf['auth'] != $extension->getID()) {
+            if ($extension->isEnabled() && in_array('Auth', $extension->getTypes()) && $conf['authtype'] == $extension->getID()) {
                 $errors .= '<p class="permerror">'.$this->getLang('auth').'</p>';
             }
 

--- a/lib/plugins/extension/lang/en/lang.php
+++ b/lib/plugins/extension/lang/en/lang.php
@@ -95,7 +95,7 @@ $lang['noperms']                      = 'Extension directory is not writable';
 $lang['notplperms']                   = 'Template directory is not writable';
 $lang['nopluginperms']                = 'Plugin directory is not writable';
 $lang['git']                          = 'This extension was installed via git, you may not want to update it here.';
-$lang['auth']                         = 'This auth plugin is not enabled in configuration, consider disabling it.';
+$lang['auth']                         = 'Any action prohibited for current authentication backend set in Configuration Setting: authtype.';
 
 $lang['install_url']                  = 'Install from URL:';
 $lang['install_upload']               = 'Upload Extension:';


### PR DESCRIPTION
When testing the development snaphot, warning text is displayed for the auth plugin in-use at the Extension manager. The text appears when authplain plugin set in config, but it does not when changed to other auth type plugin. The text says *"This auth plugin is not enabled in configuration, consider disabling it."*

I think that `$conf['auth']` should be `$conf['authtype']`, and the some text should be displayed for the auth plugin specified as `$conf['authtype']` to prevent any action such as uninstall and disable. If I understand correctly, more sensible text might be helpful for admins.
 