### PR TITLE
Secure Private Dokuwiki

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -310,8 +310,10 @@ function act_permcheck($act){
         }else{
             $permneed = AUTH_CREATE;
         }
-    }elseif(in_array($act,array('login','search','recent','profile','profile_delete','index', 'sitemap'))){
+    }elseif(in_array($act,array('login','search','recent','profile','profile_delete', 'sitemap'))){
         $permneed = AUTH_NONE;
+    }elseif($act == 'index'){
+        $permneed = AUTH_READ;
     }elseif($act == 'revert'){
         $permneed = AUTH_ADMIN;
         if($INFO['ismanager']) $permneed = AUTH_EDIT;


### PR DESCRIPTION
When a Wiki is private, you may need to hide index as well, so that people can't guess any content. To do so, index should be available only if minimum access right is READ.