### PR TITLE
indexer.php: slow page loads on lighttpd due to missing ob_flush()

### DIFF
--- a/lib/exe/indexer.php
+++ b/lib/exe/indexer.php
@@ -199,6 +199,7 @@ function sendGIF(){
     header('Content-Length: '.strlen($img));
     header('Connection: Close');
     print $img;
+    ob_flush();
     flush();
     // Browser should drop connection after this
     // Thinks it's got the whole image

--- a/lib/exe/indexer.php
+++ b/lib/exe/indexer.php
@@ -199,8 +199,7 @@ function sendGIF(){
     header('Content-Length: '.strlen($img));
     header('Connection: Close');
     print $img;
-    ob_flush();
-    flush();
+    tpl_flush();
     // Browser should drop connection after this
     // Thinks it's got the whole image
 }


### PR DESCRIPTION
I'm running this dokuwiki docker container: https://registry.hub.docker.com/u/mprasil/dokuwiki/

It uses lighttpd and fastcgi. For some reason, the ignore_user_abort() feature where the browser should close the connection after the GIF has been received is not working on lighty. The browser keeps loading the page until the indexer run is complete, which leads to extremely slow load times with a larger page index.

Adding ob_flush() to sendGIF fixes the issue.