### PR TITLE
avoid messages pushing down page tools. fixes #1011

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -11,7 +11,7 @@
 ********************************************************************/
 
 #dokuwiki__header {
-    padding: 2em 0 1.5em;
+    padding: 2em 0 0;
 
     .headings,
     .tools {
@@ -349,11 +349,11 @@ form.search {
 ********************************************************************/
 
 .dokuwiki .pageId {
-    position: absolute;
-    top: -2.3em;
-    right: -1em;
+    float: right;
+    margin-right: -1em;
+    margin-bottom: -1px;
     overflow: hidden;
-    padding: 1em 1em 0;
+    padding: 0.5em 1em 0;
 
     span {
         font-size: 0.875em;
@@ -370,6 +370,7 @@ form.search {
 }
 
 .dokuwiki div.page {
+    clear: both;
     background: @ini_background;
     color: inherit;
     border: 1px solid @ini_background_alt;
@@ -396,8 +397,9 @@ form.search {
 }
 
 [dir=rtl] .dokuwiki .pageId {
-    right: auto;
-    left: -1em;
+    float: left;
+    margin-left: -1em;
+    margin-right: 0;
 }
 
 /* footer

--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -11,7 +11,7 @@
 ********************************************************************/
 
 #dokuwiki__header {
-    padding: 2em 0 0;
+    padding: 2em 0 1.5em;
 
     .headings,
     .tools {
@@ -352,6 +352,7 @@ form.search {
     float: right;
     margin-right: -1em;
     margin-bottom: -1px;
+    margin-top: -1.5em;
     overflow: hidden;
     padding: 0.5em 1em 0;
 

--- a/lib/tpl/dokuwiki/detail.php
+++ b/lib/tpl/dokuwiki/detail.php
@@ -36,6 +36,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 
             <!-- ********** CONTENT ********** -->
             <div id="dokuwiki__content"><div class="pad group">
+                <?php html_msgarea() ?>
 
                 <?php if(!$ERROR): ?>
                     <div class="pageId"><span><?php echo hsc(tpl_img_getTag('IPTC.Headline',$IMG)); ?></span></div>

--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -49,6 +49,7 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 
             <!-- ********** CONTENT ********** -->
             <div id="dokuwiki__content"><div class="pad group">
+                <?php html_msgarea() ?>
 
                 <div class="pageId"><span><?php echo hsc($ID) ?></span></div>
 

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -85,7 +85,7 @@ if (!defined('DOKU_INC')) die();
         </div>
     <?php endif ?>
 
-    <?php html_msgarea() ?>
+
 
     <hr class="a11y" />
 </div></div><!-- /header -->


### PR DESCRIPTION
This moves the message area into content div. The pageid is now aligned by floating instead of absolute positioning.

@selfthinker this seems to work for me, but I'm not sure if I didn't break anything. Could you have a look and give a thumbs up if it's okay?