### PR TITLE
Add missing tbody to renderer

### DIFF
--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -708,6 +708,18 @@ class Doku_Renderer extends DokuWiki_Plugin {
     }
 
     /**
+     * Open a table body
+     */
+    function tabletbody_open() {
+    }
+
+    /**
+     * Close a table body
+     */
+    function tabletbody_close() {
+    }
+
+    /**
      * Open a table row
      */
     function tablerow_open() {

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1290,6 +1290,20 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
     }
 
     /**
+     * Open a table body
+     */
+    function tabletbody_open() {
+        $this->doc .= DOKU_TAB.'<tbody>'.DOKU_LF;
+    }
+
+    /**
+     * Close a table body
+     */
+    function tabletbody_close() {
+        $this->doc .= DOKU_TAB.'</tbody>'.DOKU_LF;
+    }
+
+    /**
      * Open a table row
      */
     function tablerow_open() {
@@ -1753,7 +1767,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $out .= '</audio>'.NL;
         return $out;
     }
-    
+
     /**
      * _getLastMediaRevisionAt is a helperfunction to internalmedia() and _media()
      * which returns an existing media revision less or equal to rev or date_at


### PR DESCRIPTION
Add missing `tabletbody_open()` and `tabletbody_open()` to renderer.
(Ideally it should also be fixed that tables have a thead but not a tbody. I'll open a bug report for that later.)