### PR TITLE
simple fix for pageID clash with sidebar in mobile view

### DIFF
--- a/lib/tpl/dokuwiki/css/mobile.less
+++ b/lib/tpl/dokuwiki/css/mobile.less
@@ -23,6 +23,7 @@
 #dokuwiki__aside {
     width: 100%;
     float: none;
+    margin-bottom: 1.5em;
 }
 
 #dokuwiki__aside > .pad,

--- a/lib/tpl/dokuwiki/css/mobile.less
+++ b/lib/tpl/dokuwiki/css/mobile.less
@@ -159,6 +159,11 @@ body {
         padding: 0 .5em;
     }
 }
+
+#dokuwiki__aside {
+    margin-bottom: 0;
+}
+
 #dokuwiki__header {
     padding: .5em 0;
 }


### PR DESCRIPTION
Since the pageid is no longer positioned absolute it clashed with the
sidebar since #1027. this introduces a very simplisitc fix.
![nomessages](https://cloud.githubusercontent.com/assets/86426/6347929/0c07b3a2-bc1c-11e4-82b9-fb04a4ad4997.png)
![messages](https://cloud.githubusercontent.com/assets/86426/6347930/0c1e120a-bc1c-11e4-9393-b7ab1e831357.png)

Moving the pageid back up above the sidebar will need some more work.