### PR TITLE
Add two config options to authldap

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -359,8 +359,9 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
             $sr          = ldap_search($this->con, $this->getConf('usertree'), $all_filter);
             $entries     = ldap_get_entries($this->con, $sr);
             $users_array = array();
+            $userkey     = $this->getConf('userkey');
             for($i = 0; $i < $entries["count"]; $i++) {
-                array_push($users_array, $entries[$i]["uid"][0]);
+                array_push($users_array, $entries[$i][$userkey][0]);
             }
             asort($users_array);
             $result = $users_array;

--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -37,7 +37,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
         }
 
         // Add the capabilities to change the password
-        $this->cando['modPass'] = true;
+        $this->cando['modPass'] = $this->getConf('modPass');
     }
 
     /**

--- a/lib/plugins/authldap/conf/default.php
+++ b/lib/plugins/authldap/conf/default.php
@@ -16,5 +16,6 @@ $conf['bindpw']      = '';
 //$conf['mapping']['grps']  unsupported in config manager
 $conf['userscope']  = 'sub';
 $conf['groupscope'] = 'sub';
+$conf['userkey']    = 'uid';
 $conf['groupkey']   = 'cn';
 $conf['debug']      = 0;

--- a/lib/plugins/authldap/conf/default.php
+++ b/lib/plugins/authldap/conf/default.php
@@ -19,3 +19,4 @@ $conf['groupscope'] = 'sub';
 $conf['userkey']    = 'uid';
 $conf['groupkey']   = 'cn';
 $conf['debug']      = 0;
+$conf['modPass']    = 1;

--- a/lib/plugins/authldap/conf/metadata.php
+++ b/lib/plugins/authldap/conf/metadata.php
@@ -18,3 +18,4 @@ $meta['groupscope']  = array('multichoice','_choices' => array('sub','one','base
 $meta['userkey']     = array('string','_caution' => 'danger');
 $meta['groupkey']    = array('string','_caution' => 'danger');
 $meta['debug']       = array('onoff','_caution' => 'security');
+$meta['modPass']     = array('onoff');

--- a/lib/plugins/authldap/conf/metadata.php
+++ b/lib/plugins/authldap/conf/metadata.php
@@ -15,5 +15,6 @@ $meta['bindpw']      = array('password','_caution' => 'danger');
 //$meta['mapping']['grps']  unsupported in config manager
 $meta['userscope']   = array('multichoice','_choices' => array('sub','one','base'),'_caution' => 'danger');
 $meta['groupscope']  = array('multichoice','_choices' => array('sub','one','base'),'_caution' => 'danger');
+$meta['userkey']     = array('string','_caution' => 'danger');
 $meta['groupkey']    = array('string','_caution' => 'danger');
 $meta['debug']       = array('onoff','_caution' => 'security');

--- a/lib/plugins/authldap/lang/de/settings.php
+++ b/lib/plugins/authldap/lang/de/settings.php
@@ -20,6 +20,7 @@ $lang['binddn']                = 'DN eines optionalen Benutzers, wenn der anonym
 $lang['bindpw']                = 'Passwort des angegebenen Benutzers.';
 $lang['userscope']             = 'Die Suchweite nach Benutzeraccounts.';
 $lang['groupscope']            = 'Die Suchweite nach Benutzergruppen.';
+$lang['userkey']               = 'Attribut, das den Benutzernamen enthält; muss konsistent zum userfilter sein.';
 $lang['groupkey']              = 'Gruppieren der Benutzeraccounts anhand eines beliebigen Benutzerattributes z. B. Telefonnummer oder Abteilung, anstelle der Standard-Gruppen).';
 $lang['debug']                 = 'Debug-Informationen beim Auftreten von Fehlern anzeigen?';
 $lang['deref_o_0']             = 'LDAP_DEREF_NEVER';


### PR DESCRIPTION
I added two config options to authldap: 'modPass' allows to disable password changing via dokuwiki, 'userkey' denotes the ldap attribute that holds the username, so that retrieveUsers works as expected