### PR TITLE
Add two config options to authldap

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -37,7 +37,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
         }
 
         // Add the capabilities to change the password
-        $this->cando['modPass'] = true;
+        $this->cando['modPass'] = $this->getConf('modPass');
     }
 
     /**
@@ -360,8 +360,9 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
             $sr          = ldap_search($this->con, $this->getConf('usertree'), $all_filter);
             $entries     = ldap_get_entries($this->con, $sr);
             $users_array = array();
+            $userkey     = $this->getConf('userkey');
             for($i = 0; $i < $entries["count"]; $i++) {
-                array_push($users_array, $entries[$i]["uid"][0]);
+                array_push($users_array, $entries[$i][$userkey][0]);
             }
             asort($users_array);
             $result = $users_array;

--- a/lib/plugins/authldap/conf/default.php
+++ b/lib/plugins/authldap/conf/default.php
@@ -16,5 +16,7 @@ $conf['bindpw']      = '';
 //$conf['mapping']['grps']  unsupported in config manager
 $conf['userscope']  = 'sub';
 $conf['groupscope'] = 'sub';
+$conf['userkey']    = 'uid';
 $conf['groupkey']   = 'cn';
 $conf['debug']      = 0;
+$conf['modPass']    = 1;

--- a/lib/plugins/authldap/conf/metadata.php
+++ b/lib/plugins/authldap/conf/metadata.php
@@ -15,5 +15,7 @@ $meta['bindpw']      = array('password','_caution' => 'danger');
 //$meta['mapping']['grps']  unsupported in config manager
 $meta['userscope']   = array('multichoice','_choices' => array('sub','one','base'),'_caution' => 'danger');
 $meta['groupscope']  = array('multichoice','_choices' => array('sub','one','base'),'_caution' => 'danger');
+$meta['userkey']     = array('string','_caution' => 'danger');
 $meta['groupkey']    = array('string','_caution' => 'danger');
 $meta['debug']       = array('onoff','_caution' => 'security');
+$meta['modPass']     = array('onoff');

--- a/lib/plugins/authldap/lang/de/settings.php
+++ b/lib/plugins/authldap/lang/de/settings.php
@@ -22,6 +22,7 @@ $lang['userscope']             = 'Die Suchweite nach Benutzeraccounts.';
 $lang['groupscope']            = 'Die Suchweite nach Benutzergruppen.';
 $lang['userkey']               = 'Attribut, das den Benutzernamen enthält; muss konsistent zum userfilter sein.';
 $lang['groupkey']              = 'Gruppieren der Benutzeraccounts anhand eines beliebigen Benutzerattributes z. B. Telefonnummer oder Abteilung, anstelle der Standard-Gruppen).';
+$lang['modPass']               = 'Darf über Dokuwiki das LDAP-Passwort geändert werden?';
 $lang['debug']                 = 'Debug-Informationen beim Auftreten von Fehlern anzeigen?';
 $lang['deref_o_0']             = 'LDAP_DEREF_NEVER';
 $lang['deref_o_1']             = 'LDAP_DEREF_SEARCHING';

--- a/lib/plugins/authldap/lang/de/settings.php
+++ b/lib/plugins/authldap/lang/de/settings.php
@@ -20,6 +20,7 @@ $lang['binddn']                = 'DN eines optionalen Benutzers, wenn der anonym
 $lang['bindpw']                = 'Passwort des angegebenen Benutzers.';
 $lang['userscope']             = 'Die Suchweite nach Benutzeraccounts.';
 $lang['groupscope']            = 'Die Suchweite nach Benutzergruppen.';
+$lang['userkey']               = 'Attribut, das den Benutzernamen enthält; muss konsistent zum userfilter sein.';
 $lang['groupkey']              = 'Gruppieren der Benutzeraccounts anhand eines beliebigen Benutzerattributes z. B. Telefonnummer oder Abteilung, anstelle der Standard-Gruppen).';
 $lang['debug']                 = 'Debug-Informationen beim Auftreten von Fehlern anzeigen?';
 $lang['deref_o_0']             = 'LDAP_DEREF_NEVER';

--- a/lib/plugins/authldap/lang/en/settings.php
+++ b/lib/plugins/authldap/lang/en/settings.php
@@ -13,7 +13,9 @@ $lang['binddn']      = 'DN of an optional bind user if anonymous bind is not suf
 $lang['bindpw']      = 'Password of above user';
 $lang['userscope']   = 'Limit search scope for user search';
 $lang['groupscope']  = 'Limit search scope for group search';
+$lang['userkey']     = 'Attribute denoting the username; must be consistent to userfilter.';
 $lang['groupkey']    = 'Group membership from any user attribute (instead of standard AD groups) e.g. group from department or telephone number';
+$lang['modPass']     = 'Can the LDAP password be changed via dokuwiki?';
 $lang['debug']       = 'Display additional debug information on errors';
 
 


### PR DESCRIPTION
I added two new config options to authldap: 'modPass' may switch off the ability to change the user password, 'userkey' denotes the ldap attribute that holds the username, to enable correct function of retrieveUsers.