### PR TITLE
Update acronyms.conf

### DIFF
--- a/conf/acronyms.conf
+++ b/conf/acronyms.conf
@@ -59,3 +59,9 @@ W3C          World Wide Web Consortium
 WTF?         What the f***
 WYSIWYG      What You See Is What You Get
 YMMV         Your mileage may vary
+
+UTP          Unshielded Twisted Pair          # Normal UTP cable
+F/UTP        Foiled Unshielded Twisted Pair   # cable with foil around all pairs
+U/FTP        Unshielded Foiled Twisted Pair   # cable with foil around each pair
+F/FTP        Foiled Foiled Twisted Pair       # cable with foil around each pair and all pairs
+S/FTP        Shielded Foiled Twisted Pair     # cable with foil round each pair and a shield around all pairs


### PR DESCRIPTION
I was working on a page discussing some UTP-cables and I found some overlap with FTP.  
E.g. U/FTP (Unshielded Foiled Twisted Pair) was shown as *U/File Transfer Protocol*