### PR TITLE
make PHP_CodeSniffer rules compatible with v2

### DIFF
--- a/_cs/DokuWiki/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/_cs/DokuWiki/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -39,7 +39,7 @@ class DokuWiki_Sniffs_PHP_DeprecatedFunctionsSniff extends Generic_Sniffs_PHP_Fo
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
         'setCorrectLocale'     => null,
         'html_attbuild'        => 'buildAttributes',
         'io_runcmd'            => null,

--- a/_cs/DokuWiki/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/_cs/DokuWiki/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -39,7 +39,7 @@ class DokuWiki_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_F
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                      'date' => 'dformat',
                                      'strftime'   => 'dformat',
                                     );


### PR DESCRIPTION
Due to changes in PHP_CodeSniffer version 2, running phpcs with the DokuWiki standard did not work anymore. It fails with errors such as:
```Fatal error: Access level to DokuWiki_Sniffs_PHP_DiscouragedFunctionsSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in /home/tim/dev/simple/dokuwiki/_cs/DokuWiki/Sniffs/PHP/DiscouragedFunctionsSniff.php on line 54```

The fix should be backwards-compatible to phpcs v1.

(Other projects encountered the same issue, see e.g., magento-ecg/coding-standard#9 )