### PR TITLE
Add deprecated tag to mail_send, _mail_send_action, mail_encode_address

### DIFF
--- a/inc/mail.php
+++ b/inc/mail.php
@@ -96,15 +96,23 @@ function mail_setup(){
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  * @see    mail()
+ *
+ * @deprecated User the Mailer:: class instead
  */
 function mail_send($to, $subject, $body, $from='', $cc='', $bcc='', $headers=null, $params=null){
-
+    dbg_deprecated('class Mailer::');
     $message = compact('to','subject','body','from','cc','bcc','headers','params');
     return trigger_event('MAIL_MESSAGE_SEND',$message,'_mail_send_action');
 }
 
+/**
+ * @param $data
+ * @return bool
+ *
+ * @deprecated User the Mailer:: class instead
+ */
 function _mail_send_action($data) {
-
+    dbg_deprecated('class Mailer::');
     // retrieve parameters from event data, $to, $subject, $body, $from, $cc, $bcc, $headers, $params
     $to = $data['to'];
     $subject = $data['subject'];
@@ -177,8 +185,11 @@ function _mail_send_action($data) {
  * @param string  $string Multiple adresses separated by commas
  * @param string  $header Name of the header (To,Bcc,Cc,...)
  * @param boolean $names  Allow named Recipients?
+ *
+ * @deprecated User the Mailer:: class instead
  */
 function mail_encode_address($string,$header='',$names=true){
+    dbg_deprecated('class Mailer::');
     $headers = '';
     $parts = explode(',',$string);
     foreach ($parts as $part){


### PR DESCRIPTION
These functions are already deprecated and replaced by the Mailer::
class. The deprecated tag was simply missing.