### PR TITLE
Linkwizard: Move cursor to the end of the text in input

### DIFF
--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -299,6 +299,9 @@ var dw_linkwiz = {
         dw_linkwiz.$wiz.show();
         dw_linkwiz.$entry.focus();
         dw_linkwiz.autocomplete();
+        var temp = dw_linkwiz.$entry.val();
+        dw_linkwiz.$entry.val('');
+        dw_linkwiz.$entry.val(temp);
     },
 
     /**

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -299,6 +299,8 @@ var dw_linkwiz = {
         dw_linkwiz.$wiz.show();
         dw_linkwiz.$entry.focus();
         dw_linkwiz.autocomplete();
+
+        // Move the cursor to the end of the input
         var temp = dw_linkwiz.$entry.val();
         dw_linkwiz.$entry.val('');
         dw_linkwiz.$entry.val(temp);


### PR DESCRIPTION
When the wizard is first opened and the input field is filled by autocomplete, the cursor is still at the beginning of the input-field, instead of the end. This pull request fixes this.

It is tested with Firefox 32 and Chrome 42 on Ubuntu/xfce 4.10