### PR TITLE
Cache JavaScript per template

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -402,7 +402,7 @@ function tpl_metaheaders($alt = true) {
     // load stylesheets
     $head['link'][] = array(
         'rel' => 'stylesheet', 'type'=> 'text/css',
-        'href'=> DOKU_BASE.'lib/exe/css.php?t='.$conf['template'].'&tseed='.$tseed
+        'href'=> DOKU_BASE.'lib/exe/css.php?t='.rawurlencode($conf['template']).'&tseed='.$tseed
     );
 
     // make $INFO and other vars available to JavaScripts
@@ -417,7 +417,7 @@ function tpl_metaheaders($alt = true) {
     // load external javascript
     $head['script'][] = array(
         'type'=> 'text/javascript', 'charset'=> 'utf-8', '_data'=> '',
-        'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.$conf['template'].'&tseed='.$tseed
+        'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed
     );
 
     // trigger event here

--- a/inc/template.php
+++ b/inc/template.php
@@ -417,7 +417,7 @@ function tpl_metaheaders($alt = true) {
     // load external javascript
     $head['script'][] = array(
         'type'=> 'text/javascript', 'charset'=> 'utf-8', '_data'=> '',
-        'src' => DOKU_BASE.'lib/exe/js.php'.'?tseed='.$tseed
+        'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.$conf['template'].'&tseed='.$tseed
     );
 
     // trigger event here

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -30,9 +30,14 @@ function js_out(){
     global $conf;
     global $lang;
     global $config_cascade;
+    global $INPUT;
+
+    // decide from where to get the template
+    $tpl = trim(preg_replace('/[^\w-]+/','',$INPUT->str('t')));
+    if(!$tpl) $tpl = $conf['template'];
 
     // The generated script depends on some dynamic options
-    $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'],'.js');
+    $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl,'.js');
     $cache->_event = 'JS_CACHE_USE';
 
     // load minified version for some files
@@ -67,7 +72,7 @@ function js_out(){
 # disabled for FS#1958                DOKU_INC.'lib/scripts/hotkeys.js',
                 DOKU_INC.'lib/scripts/behaviour.js',
                 DOKU_INC.'lib/scripts/page.js',
-                tpl_incdir().'script.js',
+                tpl_incdir($tpl).'script.js',
             );
 
     // add possible plugin scripts and userscript
@@ -92,7 +97,7 @@ function js_out(){
     $json = new JSON();
     // add some global variables
     print "var DOKU_BASE   = '".DOKU_BASE."';";
-    print "var DOKU_TPL    = '".tpl_basedir()."';";
+    print "var DOKU_TPL    = '".tpl_basedir($tpl)."';";
     print "var DOKU_COOKIE_PARAM = " . $json->encode(
             array(
                  'path' => empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'],
@@ -104,7 +109,7 @@ function js_out(){
 
     // load JS specific translations
     $lang['js']['plugins'] = js_pluginstrings();
-    $templatestrings = js_templatestrings();
+    $templatestrings = js_templatestrings($tpl);
     if(!empty($templatestrings)) {
         $lang['js']['template'] = $templatestrings;
     }
@@ -240,19 +245,20 @@ function js_pluginstrings() {
  * - $lang['js'] must be an array.
  * - Nothing is returned for template without an entry for $lang['js']
  *
+ * @param string $tpl
  * @return array
  */
-function js_templatestrings() {
+function js_templatestrings($tpl) {
     global $conf;
     $templatestrings = array();
-    if (file_exists(tpl_incdir()."lang/en/lang.php")) {
-        include tpl_incdir()."lang/en/lang.php";
+    if (file_exists(tpl_incdir($tpl)."lang/en/lang.php")) {
+        include tpl_incdir($tpl)."lang/en/lang.php";
     }
-    if (isset($conf['lang']) && $conf['lang']!='en' && file_exists(tpl_incdir()."lang/".$conf['lang']."/lang.php")) {
-        include tpl_incdir()."lang/".$conf['lang']."/lang.php";
+    if (isset($conf['lang']) && $conf['lang']!='en' && file_exists(tpl_incdir($tpl)."lang/".$conf['lang']."/lang.php")) {
+        include tpl_incdir($tpl)."lang/".$conf['lang']."/lang.php";
     }
     if (isset($lang['js'])) {
-        $templatestrings[$conf['template']] = $lang['js'];
+        $templatestrings[$tpl] = $lang['js'];
     }
     return $templatestrings;
 }


### PR DESCRIPTION
Whenever a wiki can have multiple templates, the JavaScript can only include one template's script.js. That causes issues like selfthinker/dokuwiki-plugin-loadskin#3.

These changes give lib/exe/js.php the same additional parameter as lib/exe/css.php, i.e. `t`, and uses it in a similar way to ensure caching of the JS is done per template.

This is a bit of a selfish change but other template switching plugins will have the same issue.