### PR TITLE
Add pipe to end of link pasted without title

### DIFF
--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -244,9 +244,10 @@ var dw_linkwiz = {
                 so += dw_linkwiz.val.open.length;
                 link = dw_linkwiz.val.open+link;
             }
+            link += '|';
+            so += 1;
             if(stxt) {
-                link += '|'+stxt;
-                so += 1;
+                link += stxt;
             }
             if(dw_linkwiz.val.close) {
                 link += dw_linkwiz.val.close;


### PR DESCRIPTION
It is helpful if the pipe is still inserted by the linkwizard when there is no title. This increases usability for beginners.