### PR TITLE
Refactor error messages from auth plugins.

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -1006,7 +1006,7 @@ function register() {
 
     //okay try to create the user
     if(!$auth->triggerUserMod('create', array($login, $pass, $fullname, $email))) {
-        msg($lang['reguexists'], -1);
+        msg($lang['regfail'], -1);
         return false;
     }
 
@@ -1098,17 +1098,18 @@ function updateprofile() {
         }
     }
 
-    if($result = $auth->triggerUserMod('modify', array($INPUT->server->str('REMOTE_USER'), &$changes))) {
-        // update cookie and session with the changed data
-        if($changes['pass']) {
-            list( /*user*/, $sticky, /*pass*/) = auth_getCookie();
-            $pass = auth_encrypt($changes['pass'], auth_cookiesalt(!$sticky, true));
-            auth_setCookie($INPUT->server->str('REMOTE_USER'), $pass, (bool) $sticky);
-        }
-        return true;
+    if(!($result = $auth->triggerUserMod('modify', array($INPUT->server->str('REMOTE_USER'), &$changes)))) {
+        msg($lang['proffail'], -1);
+        return false;
     }
 
-    return false;
+    // update cookie and session with the changed data
+    if($changes['pass']) {
+        list( /*user*/, $sticky, /*pass*/) = auth_getCookie();
+        $pass = auth_encrypt($changes['pass'], auth_cookiesalt(!$sticky, true));
+        auth_setCookie($INPUT->server->str('REMOTE_USER'), $pass, (bool) $sticky);
+    }
+    return true;
 }
 
 /**
@@ -1221,7 +1222,7 @@ function act_resendpwd() {
 
             // change it
             if(!$auth->triggerUserMod('modify', array($user, array('pass' => $pass)))) {
-                msg('error modifying user data', -1);
+                msg($lang['proffail'], -1);
                 return false;
             }
 
@@ -1229,7 +1230,7 @@ function act_resendpwd() {
 
             $pass = auth_pwgen($user);
             if(!$auth->triggerUserMod('modify', array($user, array('pass' => $pass)))) {
-                msg('error modifying user data', -1);
+                msg($lang['proffail'], -1);
                 return false;
             }
 

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -1098,7 +1098,7 @@ function updateprofile() {
         }
     }
 
-    if(!($result = $auth->triggerUserMod('modify', array($INPUT->server->str('REMOTE_USER'), &$changes)))) {
+    if(!$auth->triggerUserMod('modify', array($INPUT->server->str('REMOTE_USER'), &$changes))) {
         msg($lang['proffail'], -1);
         return false;
     }

--- a/inc/lang/en/lang.php
+++ b/inc/lang/en/lang.php
@@ -75,6 +75,7 @@ $lang['regmissing']            = 'Sorry, you must fill in all fields.';
 $lang['reguexists']            = 'Sorry, a user with this login already exists.';
 $lang['regsuccess']            = 'The user has been created and the password was sent by email.';
 $lang['regsuccess2']           = 'The user has been created.';
+$lang['regfail']               = 'The user could not be created.';
 $lang['regmailfail']           = 'Looks like there was an error on sending the password mail. Please contact the admin!';
 $lang['regbadmail']            = 'The given email address looks invalid - if you think this is an error, contact the admin';
 $lang['regbadpass']            = 'The two given passwords are not identical, please try again.';
@@ -90,6 +91,7 @@ $lang['profdeleteuser']        = 'Delete Account';
 $lang['profdeleted']           = 'Your user account has been deleted from this wiki';
 $lang['profconfdelete']        = 'I wish to remove my account from this wiki. <br/> This action can not be undone.';
 $lang['profconfdeletemissing'] = 'Confirmation check box not ticked';
+$lang['proffail']              = 'User profile was not updated.';
 
 $lang['pwdforget']             = 'Forgotten your password? Get a new one';
 $lang['resendna']              = 'This wiki does not support password resending.';

--- a/lib/plugins/auth.php
+++ b/lib/plugins/auth.php
@@ -295,7 +295,7 @@ class DokuWiki_Auth_Plugin extends DokuWiki_Plugin {
      */
     public function deleteUsers($users) {
         msg("authorisation method does not allow deleting of users", -1);
-        return false;
+        return 0;
     }
 
     /**

--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -522,7 +522,10 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
     public function modifyUser($user, $changes) {
         $return = true;
         $adldap = $this->_adldap($this->_userDomain($user));
-        if(!$adldap) return false;
+        if(!$adldap) {
+            msg($this->getLang('connectfail'), -1);
+            return false;
+        }
 
         // password changing
         if(isset($changes['pass'])) {
@@ -532,7 +535,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
                 if ($this->conf['debug']) msg('AD Auth: '.$e->getMessage(), -1);
                 $return = false;
             }
-            if(!$return) msg('AD Auth: failed to change the password. Maybe the password policy was not met?', -1);
+            if(!$return) msg($this->getLang('passchangefail'), -1);
         }
 
         // changing user data
@@ -554,6 +557,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
                 if ($this->conf['debug']) msg('AD Auth: '.$e->getMessage(), -1);
                 $return = false;
             }
+            if(!$return) msg($this->getLang('userchangefail'), -1);
         }
 
         return $return;

--- a/lib/plugins/authad/lang/en/lang.php
+++ b/lib/plugins/authad/lang/en/lang.php
@@ -6,7 +6,9 @@
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
 
-$lang['domain'] = 'Logon Domain';
-$lang['authpwdexpire']         = 'Your password will expire in %d days, you should change it soon.';
+$lang['domain']          = 'Logon Domain';
+$lang['authpwdexpire']   = 'Your password will expire in %d days, you should change it soon.';
+$lang['passchangefail']  = 'Failed to change the password. Maybe the password policy was not met?';
+$lang['connectfail']     = 'Failed to connect to Active Directory server.';
 
 //Setup VIM: ex: et ts=4 :

--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -281,14 +281,14 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
 
         // open the connection to the ldap
         if(!$this->_openLDAP()){
-            msg('LDAP cannot connect: '. htmlspecialchars(ldap_error($this->con)));
+            $this->_debug('LDAP cannot connect: '. htmlspecialchars(ldap_error($this->con)), 0, __LINE__, __FILE__);
             return false;
         }
 
         // find the information about the user, in particular the "dn"
         $info = $this->getUserData($user,true);
         if(empty($info['dn'])) {
-            msg('LDAP cannot find your user dn');
+            $this->_debug('LDAP cannot find your user dn', 0, __LINE__, __FILE__);
             return false;
         }
         $dn = $info['dn'];
@@ -301,7 +301,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
 
             // bind with the ldap
             if(!@ldap_bind($this->con, $dn, $pass)){
-                msg('LDAP user bind failed: '. htmlspecialchars($dn) .': '.htmlspecialchars(ldap_error($this->con)), 0, __LINE__, __FILE__);
+                $this->_debug('LDAP user bind failed: '. htmlspecialchars($dn) .': '.htmlspecialchars(ldap_error($this->con)), 0, __LINE__, __FILE__);
                 return false;
             }
         } elseif ($this->getConf('binddn') && $this->getConf('bindpw')) {
@@ -322,7 +322,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
 
         // change the password
         if(!@ldap_mod_replace($this->con, $dn,array('userpassword' => $hash))){
-            msg('LDAP mod replace failed: '. htmlspecialchars($dn) .': '.htmlspecialchars(ldap_error($this->con)));
+            $this->_debug('LDAP mod replace failed: '. htmlspecialchars($dn) .': '.htmlspecialchars(ldap_error($this->con)), 0, __LINE__, __FILE__);
             return false;
         }
 

--- a/lib/plugins/authldap/lang/en/lang.php
+++ b/lib/plugins/authldap/lang/en/lang.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * English language file for authldap plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+
+$lang['connectfail']     = 'LDAP cannot connect: %s';
+$lang['domainfail'       = 'LDAP cannot find your user dn';
+
+//Setup VIM: ex: et ts=4 :

--- a/lib/plugins/authldap/lang/en/lang.php
+++ b/lib/plugins/authldap/lang/en/lang.php
@@ -6,6 +6,6 @@
  */
 
 $lang['connectfail']     = 'LDAP cannot connect: %s';
-$lang['domainfail'       = 'LDAP cannot find your user dn';
+$lang['domainfail']       = 'LDAP cannot find your user dn';
 
 //Setup VIM: ex: et ts=4 :

--- a/lib/plugins/authmysql/auth.php
+++ b/lib/plugins/authmysql/auth.php
@@ -222,6 +222,7 @@ class auth_plugin_authmysql extends DokuWiki_Auth_Plugin {
 
         if($this->_openDB()) {
             if(($info = $this->_getUserInfo($user)) !== false) {
+                msg($this->getLang('userexists'), -1);
                 return false; // user already exists
             }
 
@@ -235,7 +236,13 @@ class auth_plugin_authmysql extends DokuWiki_Auth_Plugin {
             $rc  = $this->_addUser($user, $pwd, $name, $mail, $grps);
             $this->_unlockTables();
             $this->_closeDB();
-            if($rc) return true;
+            if(!$rc) {
+                msg($this->getLang('writefail'));
+                return null;
+            }
+            return true;
+        } else {
+            msg($this->getLang('connectfail'), -1);
         }
         return null; // return error
     }
@@ -279,7 +286,9 @@ class auth_plugin_authmysql extends DokuWiki_Auth_Plugin {
 
             $rc = $this->_updateUserInfo($user, $changes);
 
-            if($rc && isset($changes['grps']) && $this->cando['modGroups']) {
+            if(!$rc) {
+                msg($this->getLang('usernotexists'), -1);
+            } elseif(isset($changes['grps']) && $this->cando['modGroups']) {
                 $groups = $this->_getGroups($user);
                 $grpadd = array_diff($changes['grps'], $groups);
                 $grpdel = array_diff($groups, $changes['grps']);
@@ -295,10 +304,14 @@ class auth_plugin_authmysql extends DokuWiki_Auth_Plugin {
                         $rc = false;
                     }
                 }
+
+                if(!$rc) msg($this->getLang('writefail'));
             }
 
             $this->_unlockTables();
             $this->_closeDB();
+        } else {
+            msg($this->getLang('connectfail'), -1);
         }
         return $rc;
     }
@@ -328,6 +341,8 @@ class auth_plugin_authmysql extends DokuWiki_Auth_Plugin {
                 $this->_unlockTables();
             }
             $this->_closeDB();
+        } else {
+            msg($this->getLang('connectfail'), -1);
         }
         return $count;
     }

--- a/lib/plugins/authmysql/lang/en/lang.php
+++ b/lib/plugins/authmysql/lang/en/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * English language file for authmysql plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+
+$lang['connectfail']    = 'Failed to connect to database.';
+$lang['userexists']     = 'Sorry, a user with this login already exists.';
+$lang['usernotexists']  = 'Sorry, that user doesn\'t exist.';
+$lang['writefail']      = 'Unable to modify user data. Please inform the Wiki-Admin';
+
+//Setup VIM: ex: et ts=4 :

--- a/lib/plugins/authplain/auth.php
+++ b/lib/plugins/authplain/auth.php
@@ -134,7 +134,10 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
         global $config_cascade;
 
         // user mustn't already exist
-        if($this->getUserData($user) !== false) return false;
+        if($this->getUserData($user) !== false) {
+            msg($this->getLang('userexists'), -1);
+            return false;
+        }
 
         $pass = auth_cryptPassword($pwd);
 
@@ -144,16 +147,13 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
         // prepare user line
         $userline = $this->_createUserLine($user, $pass, $name, $mail, $grps);
 
-        if(io_saveFile($config_cascade['plainauth.users']['default'], $userline, true)) {
-            $this->users[$user] = compact('pass', 'name', 'mail', 'grps');
-            return $pwd;
+        if(!io_saveFile($config_cascade['plainauth.users']['default'], $userline, true)) {
+            msg($this->getLang('writefail'), -1);
+            return null;
         }
 
-        msg(
-            'The '.$config_cascade['plainauth.users']['default'].
-                ' file is not writable. Please inform the Wiki-Admin', -1
-        );
-        return null;
+        $this->users[$user] = compact('pass', 'name', 'mail', 'grps');
+        return $pwd;
     }
 
     /**
@@ -169,7 +169,10 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
         global $config_cascade;
 
         // sanity checks, user must already exist and there must be something to change
-        if(($userinfo = $this->getUserData($user)) === false) return false;
+        if(($userinfo = $this->getUserData($user)) === false) {
+            msg($this->getLang('usernotexists'), -1);
+            return false;
+        }
         if(!is_array($changes) || !count($changes)) return true;
 
         // update userinfo with new data, remembering to encrypt any password
@@ -186,13 +189,14 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
         $userline = $this->_createUserLine($newuser, $userinfo['pass'], $userinfo['name'], $userinfo['mail'], $userinfo['grps']);
 
         if(!$this->deleteUsers(array($user))) {
-            msg('Unable to modify user data. Please inform the Wiki-Admin', -1);
+            msg($this->getLang('writefail'), -1);
             return false;
         }
 
         if(!io_saveFile($config_cascade['plainauth.users']['default'], $userline, true)) {
             msg('There was an error modifying your user data. You should register again.', -1);
             // FIXME, user has been deleted but not recreated, should force a logout and redirect to login page
+            // Should replace the delete/save hybrid modify with an atomic io_replaceInFile
             $ACT = 'register';
             return false;
         }
@@ -223,7 +227,10 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
         if(empty($deleted)) return 0;
 
         $pattern = '/^('.join('|', $deleted).'):/';
-        io_deleteFromFile($config_cascade['plainauth.users']['default'], $pattern, true);
+        if (!io_deleteFromFile($config_cascade['plainauth.users']['default'], $pattern, true)) {
+            msg($this->getLang('writefail'), -1);
+            return 0;
+        }
 
         // reload the user list and count the difference
         $count = count($this->users);

--- a/lib/plugins/authplain/lang/af/lang.php
+++ b/lib/plugins/authplain/lang/af/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Die gebruikersnaam wat jy gebruik het, is alreeds gebruik. Kies asseblief \'n ander gebruikersnaam.';

--- a/lib/plugins/authplain/lang/ar/lang.php
+++ b/lib/plugins/authplain/lang/ar/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'عذرا، يوجد مشترك بنفس الاسم.';

--- a/lib/plugins/authplain/lang/az/lang.php
+++ b/lib/plugins/authplain/lang/az/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Təssüf ki bu ad ilə istifadəçi artıq mövcuddur.';

--- a/lib/plugins/authplain/lang/bg/lang.php
+++ b/lib/plugins/authplain/lang/bg/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Вече съществува потребител с избраното име.';

--- a/lib/plugins/authplain/lang/bn/lang.php
+++ b/lib/plugins/authplain/lang/bn/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'দুঃখিত, এই লগইন সঙ্গে একটি ব্যবহারকারী ইতিমধ্যেই বিদ্যমান.';

--- a/lib/plugins/authplain/lang/ca-valencia/lang.php
+++ b/lib/plugins/authplain/lang/ca-valencia/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Disculpe, pero ya existix un usuari en este nom.';

--- a/lib/plugins/authplain/lang/ca/lang.php
+++ b/lib/plugins/authplain/lang/ca/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Ja existeix un altre usuari amb aquest nom.';

--- a/lib/plugins/authplain/lang/cs/lang.php
+++ b/lib/plugins/authplain/lang/cs/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Uživatel se stejným jménem už je zaregistrován.';

--- a/lib/plugins/authplain/lang/da/lang.php
+++ b/lib/plugins/authplain/lang/da/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Dette brugernavn er allerede i brug.';

--- a/lib/plugins/authplain/lang/de-informal/lang.php
+++ b/lib/plugins/authplain/lang/de-informal/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Der Benutzername existiert leider schon.';

--- a/lib/plugins/authplain/lang/de/lang.php
+++ b/lib/plugins/authplain/lang/de/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Der Benutzername existiert leider schon.';

--- a/lib/plugins/authplain/lang/el/lang.php
+++ b/lib/plugins/authplain/lang/el/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Αυτός ο λογαριασμός υπάρχει ήδη.';

--- a/lib/plugins/authplain/lang/en/lang.php
+++ b/lib/plugins/authplain/lang/en/lang.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Sorry, a user with this login already exists.';
+$lang['usernotexists']  = 'Sorry, that user doesn\'t exist.';
+$lang['writefail']      = 'Unable to modify user data. Please inform the Wiki-Admin';

--- a/lib/plugins/authplain/lang/eo/lang.php
+++ b/lib/plugins/authplain/lang/eo/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Pardonu, ĉi tiu uzanto-nomo jam ekzistas.';

--- a/lib/plugins/authplain/lang/es/lang.php
+++ b/lib/plugins/authplain/lang/es/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Lo siento, ya existe un usuario con este nombre.';

--- a/lib/plugins/authplain/lang/et/lang.php
+++ b/lib/plugins/authplain/lang/et/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Tegelikult on sellise nimega kasutaja juba olemas.';

--- a/lib/plugins/authplain/lang/eu/lang.php
+++ b/lib/plugins/authplain/lang/eu/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Barkatu, izen bereko erabiltzailea existitzen da.';

--- a/lib/plugins/authplain/lang/fa/lang.php
+++ b/lib/plugins/authplain/lang/fa/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'نام کاربری‌ای که وارد کردید قبلن استفاده شده است. خواهشمندیم یک نام دیگر انتخاب کنید.';

--- a/lib/plugins/authplain/lang/fi/lang.php
+++ b/lib/plugins/authplain/lang/fi/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Käyttäjä tällä käyttäjänimellä on jo olemassa.';

--- a/lib/plugins/authplain/lang/fo/lang.php
+++ b/lib/plugins/authplain/lang/fo/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Hetta brúkaranavn er upptiki.';

--- a/lib/plugins/authplain/lang/fr/lang.php
+++ b/lib/plugins/authplain/lang/fr/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Désolé, ce nom d\'utilisateur est déjà pris.';

--- a/lib/plugins/authplain/lang/gl/lang.php
+++ b/lib/plugins/authplain/lang/gl/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Sentímolo, mais xa existe un usuario con ese nome.';

--- a/lib/plugins/authplain/lang/he/lang.php
+++ b/lib/plugins/authplain/lang/he/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'משתמש בשם זה כבר נרשם, עמך הסליחה.';

--- a/lib/plugins/authplain/lang/hr/lang.php
+++ b/lib/plugins/authplain/lang/hr/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Korisnik s tim korisničkim imenom već postoji.';

--- a/lib/plugins/authplain/lang/hu/lang.php
+++ b/lib/plugins/authplain/lang/hu/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Sajnáljuk, ilyen azonosítójú felhasználónk már van.';

--- a/lib/plugins/authplain/lang/ia/lang.php
+++ b/lib/plugins/authplain/lang/ia/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Regrettabilemente, un usator con iste nomine ja existe.';

--- a/lib/plugins/authplain/lang/id-ni/lang.php
+++ b/lib/plugins/authplain/lang/id-ni/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Bologö dödöu, no so zangoguna\'ö töi da\'a.';

--- a/lib/plugins/authplain/lang/id/lang.php
+++ b/lib/plugins/authplain/lang/id/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Maaf, user dengan user login ini telah ada.';

--- a/lib/plugins/authplain/lang/is/lang.php
+++ b/lib/plugins/authplain/lang/is/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Afsakið, notandi með þessu nafni er þegar skráður inn.';

--- a/lib/plugins/authplain/lang/it/lang.php
+++ b/lib/plugins/authplain/lang/it/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Il nome utente inserito esiste già.';

--- a/lib/plugins/authplain/lang/ja/lang.php
+++ b/lib/plugins/authplain/lang/ja/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'このユーザー名は既に存在しています。';

--- a/lib/plugins/authplain/lang/ka/lang.php
+++ b/lib/plugins/authplain/lang/ka/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'მსგავსი ლოგინი უკვე არსებობს';

--- a/lib/plugins/authplain/lang/kk/lang.php
+++ b/lib/plugins/authplain/lang/kk/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Кешіріңіз, бұл түпнұскамен де пайдаланушы бар.';

--- a/lib/plugins/authplain/lang/km/lang.php
+++ b/lib/plugins/authplain/lang/km/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'សុំអាទោស​ នាមប្រើនេះមានរួចហើ។';

--- a/lib/plugins/authplain/lang/ko/lang.php
+++ b/lib/plugins/authplain/lang/ko/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = '죄송하지만 같은 이름을 사용하는 사용자가 있습니다.';

--- a/lib/plugins/authplain/lang/ku/lang.php
+++ b/lib/plugins/authplain/lang/ku/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Sorry, a user with this login already exists.';

--- a/lib/plugins/authplain/lang/la/lang.php
+++ b/lib/plugins/authplain/lang/la/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Nomen Sodalis ab aliquo iam elegitur.';

--- a/lib/plugins/authplain/lang/lb/lang.php
+++ b/lib/plugins/authplain/lang/lb/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Et get schonn e Benotzer mat deem Numm.';

--- a/lib/plugins/authplain/lang/lt/lang.php
+++ b/lib/plugins/authplain/lang/lt/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Vartotojas su pasirinktu prisijungimo vardu jau egzistuoja.';

--- a/lib/plugins/authplain/lang/lv/lang.php
+++ b/lib/plugins/authplain/lang/lv/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Atvaino, tāds lietotājs jau ir.';

--- a/lib/plugins/authplain/lang/mg/lang.php
+++ b/lib/plugins/authplain/lang/mg/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Indrisy fa efa nisy namandrika io anarana io.';

--- a/lib/plugins/authplain/lang/mk/lang.php
+++ b/lib/plugins/authplain/lang/mk/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Жалам, корисник со ова корисничко име веќе постои.';

--- a/lib/plugins/authplain/lang/mr/lang.php
+++ b/lib/plugins/authplain/lang/mr/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'या नावाने सदस्याची नोंदणी झालेली आहे, कृपया दुसरे सदस्य नाव निवडा.';

--- a/lib/plugins/authplain/lang/ms/lang.php
+++ b/lib/plugins/authplain/lang/ms/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Maaf, nama pengguna yang dimasukkan telah diguna. Sila pilih nama yang lain.';

--- a/lib/plugins/authplain/lang/ne/lang.php
+++ b/lib/plugins/authplain/lang/ne/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'यो नामको प्रयोगकर्ता पहिले देखि रहेको छ।';

--- a/lib/plugins/authplain/lang/nl/lang.php
+++ b/lib/plugins/authplain/lang/nl/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Er bestaat al een gebruiker met deze loginnaam.';

--- a/lib/plugins/authplain/lang/no/lang.php
+++ b/lib/plugins/authplain/lang/no/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Det finnes allerede en konto med dette brukernavnet.';

--- a/lib/plugins/authplain/lang/pl/lang.php
+++ b/lib/plugins/authplain/lang/pl/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Użytkownik o tej nazwie już istnieje.';

--- a/lib/plugins/authplain/lang/pt-br/lang.php
+++ b/lib/plugins/authplain/lang/pt-br/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Desculpe, mas já existe um usuário com esse nome.';

--- a/lib/plugins/authplain/lang/pt/lang.php
+++ b/lib/plugins/authplain/lang/pt/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Este utilizador já está inscrito. Por favor escolha outro nome de utilizador.';

--- a/lib/plugins/authplain/lang/ro/lang.php
+++ b/lib/plugins/authplain/lang/ro/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Ne pare rău, un utilizator cu acest nume este deja autentificat.';

--- a/lib/plugins/authplain/lang/ru/lang.php
+++ b/lib/plugins/authplain/lang/ru/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Извините, пользователь с таким логином уже существует.';

--- a/lib/plugins/authplain/lang/sk/lang.php
+++ b/lib/plugins/authplain/lang/sk/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Užívateľ s rovnakým menom je už zaregistrovaný.';

--- a/lib/plugins/authplain/lang/sl/lang.php
+++ b/lib/plugins/authplain/lang/sl/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Uporabnik s tem imenom že obstaja.';

--- a/lib/plugins/authplain/lang/sq/lang.php
+++ b/lib/plugins/authplain/lang/sq/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Na vjen keq, ekziston një përdorues tjetër me të njëjtin emër.';

--- a/lib/plugins/authplain/lang/sr/lang.php
+++ b/lib/plugins/authplain/lang/sr/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Извините, корисник са истим именом већ постоји.';

--- a/lib/plugins/authplain/lang/sv/lang.php
+++ b/lib/plugins/authplain/lang/sv/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Det finns redan en användare med det användarnamnet.';

--- a/lib/plugins/authplain/lang/th/lang.php
+++ b/lib/plugins/authplain/lang/th/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'ชื่อบัญชีที่ใส่นั้นมีผู้อื่นได้ใช้แล้ว กรุณาเลือกชื่อผู้ใช้อื่น';

--- a/lib/plugins/authplain/lang/tr/lang.php
+++ b/lib/plugins/authplain/lang/tr/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Üzgünüz, bu isime sahip bir kullanıcı zaten mevcut.';

--- a/lib/plugins/authplain/lang/uk/lang.php
+++ b/lib/plugins/authplain/lang/uk/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Користувач з таким іменем вже існує.';

--- a/lib/plugins/authplain/lang/vi/lang.php
+++ b/lib/plugins/authplain/lang/vi/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = 'Bạn khác đã dùng username này rồi.';

--- a/lib/plugins/authplain/lang/zh-tw/lang.php
+++ b/lib/plugins/authplain/lang/zh-tw/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = '很抱歉，有人已使用了這個帳號。';

--- a/lib/plugins/authplain/lang/zh/lang.php
+++ b/lib/plugins/authplain/lang/zh/lang.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ */
+$lang['userexists']     = '对不起，该用户名已经存在。';


### PR DESCRIPTION
Auth plugins are responsible for reporting error messages. The core still provides a generic failure message, but details such as trying to create a user name that already exists, using a poor password, or not being able to connect to the database are reported by the plugin.