### PR TITLE
mysqlauth: bcrypt hash is indicated by 2a or 2y

### DIFF
--- a/inc/PassHash.class.php
+++ b/inc/PassHash.class.php
@@ -50,7 +50,7 @@ class PassHash {
         } elseif(preg_match('/^md5\$(.{5})\$/', $hash, $m)) {
             $method = 'djangomd5';
             $salt   = $m[1];
-        } elseif(preg_match('/^\$2a\$(.{2})\$/', $hash, $m)) {
+        } elseif(preg_match('/^\$2(a|y)\$(.{2})\$/', $hash, $m)) {
             $method = 'bcrypt';
             $salt   = $hash;
         } elseif(substr($hash, 0, 6) == '{SSHA}') {


### PR DESCRIPTION
Hi,

a bcrypt hash starts with `$2a` **or** `$2y`. phpbb3.1 uses `$2y`, so without this fix, mysqlauth will not work.

Tested with hrun and phpbb3.1. Untested with the current git versions.
