### PR TITLE
Optimise dokuwiki template for larger screens

### DIFF
--- a/lib/tpl/dokuwiki/css/largescreens.less
+++ b/lib/tpl/dokuwiki/css/largescreens.less
@@ -1,0 +1,103 @@
+/**
+ * This file provides styles for larger screens.
+ *
+ * @author Anika Henke <anika@selfthinker.org>
+ */
+
+/* for large screen widths
+********************************************************************/
+@media only screen and (min-width: 1500px) {
+
+#dokuwiki__site {
+    max-width: 100%;
+}
+
+#dokuwiki__header + div.wrapper {
+    max-width: @ini_site_width;
+}
+
+#dokuwiki__site > .site {
+    display: flex;
+    justify-content: center;
+    padding: 0 2em;
+}
+
+#dokuwiki__header,
+#dokuwiki__header + div.wrapper,
+#dokuwiki__footer {
+    padding: 2em 0 0;
+}
+
+#dokuwiki__header,
+#dokuwiki__footer {
+    width: 18em;
+}
+
+#dokuwiki__header {
+    .pad {
+        padding: 0 40px 0 0;
+    }
+
+    .headings,
+    .tools {
+        float: none;
+        text-align: left;
+        width: auto;
+
+        li {
+            display: inline-block;
+            margin: 0 1em 0 0;
+        }
+    }
+    .tools {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+
+    form.search {
+        input.edit {
+            width: 100%;
+        }
+        div.ajax_qsearch {
+            left: 0;
+            top: 2.4em;
+        }
+    }
+}
+
+#dokuwiki__usertools,
+#dokuwiki__sitetools {
+    text-align: left;
+    padding-bottom: 1.5em;
+}
+#dokuwiki__usertools {
+    position: static;
+}
+
+#dokuwiki__pagetools {
+    top: 4em;
+}
+
+#dokuwiki__aside {
+    padding-top: .5em;
+}
+
+#dokuwiki__footer {
+    padding-left: 1em;
+    .pad {
+        padding: 0 0 0 40px;
+    }
+}
+
+} /* /@media */
+
+
+/* for even larger screen widths
+********************************************************************/
+@media only screen and (min-width: 1800px) {
+
+body {
+    font-size: 100%;
+}
+
+} /* /@media */

--- a/lib/tpl/dokuwiki/style.ini
+++ b/lib/tpl/dokuwiki/style.ini
@@ -40,6 +40,7 @@ css/pagetools.less        = screen
 css/content.less          = screen
 
 css/mobile.less           = all
+css/largescreens.less     = all
 css/print.css             = print
 
 


### PR DESCRIPTION
This is only a first draft and not ready yet. I'd just like to have others discuss and test as early as possible.

This implements one possible way to optimise the dokuwiki template for larger screens. There are two more snap points (both of which are debatable and up for discussion):

* At 1500px the header gets moved to the left and the footer gets moved to the right of the main content. Furthermore the header gets rearranged (search input under logo, user tools below site tools).
* At 1800px the general font size gets increased so that everything goes bigger (because everything is based on `em`).

Especially because I'm an atypical user (I don't often use large screens) I'd like to get some feedback on:

* Is the general approach okay? Are the snap points fitting?
* Is the weighting of the various header and footer elements okay (positioning, spacing, font size, backgrounds, whitespace, ...)?
* Where should the breadcrumbs go? (I left them where they naturally sit without changing anything, but that is obviously not an good position.)

Here is a screenshot of how it currently looks:
![dokuwiki-larger-screen](https://cloud.githubusercontent.com/assets/108893/7551117/0737d760-f675-11e4-98eb-a13fdc0b1b7b.png)

There are still things left to do which I didn't do yet because I first wanted to get the general approach right. So, these task will need to be done when everyone is happy:

* [ ] optimise for RTL languages
* [ ] because this solution uses flexbox and that is not supported in IE9 and under, there needs to be a solution to exclude IE9 (IE8 and under is fine because they don't support these types of `@media` queries), maybe another conditional comment
