### PR TITLE
Plugins can send usage data

### DIFF
--- a/lib/plugins/popularity/helper.php
+++ b/lib/plugins/popularity/helper.php
@@ -253,7 +253,24 @@ class helper_plugin_popularity extends Dokuwiki_Plugin {
         $data['php_exectime'] = $phptime;
         $data['php_extension'] = get_loaded_extensions();
 
+        // plugin usage data
+        $this->_add_plugin_usage_data($data);
+
         return $data;
+    }
+
+    protected function _add_plugin_usage_data(&$data){
+        $pluginsData = array();
+        trigger_event('PLUGIN_POPULARITY_DATA_SETUP', $pluginsData);
+        foreach($pluginsData as $plugin => $d){
+           if ( is_array($d) ) {
+               foreach($d as $key => $value){
+                   $data['plugin_' . $plugin . '_' . $key] = $value;
+               }
+           } else {
+               $data['plugin_' . $plugin] = $d;
+           }
+        }
     }
 
     /**


### PR DESCRIPTION
They just need to register to the PLUGIN_USAGE_DATA event, and then to add
either a simple string, or an array of key / value. For example:

    function register(Doku_Event_Handler $controller) {
      $controller->register_hook('PLUGIN_USAGE_DATA', 'AFTER', $this, 'usage_data');
    }

    function usage_data(&$event){
      $event->data['my_plugin_name'] = 'my usage data';

      //or: $event->data['my_plugin_name'] = array ('k1' => 'v1', 'k2' => 'v2');
    }