### PR TITLE
Local configuration negation

### DIFF
--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -49,6 +49,7 @@ function getMimeTypes() {
     static $mime = null;
     if ( !$mime ) {
         $mime = retrieveConfig('mime','confToHash');
+        $mime = array_filter($mime);
     }
     return $mime;
 }
@@ -62,6 +63,7 @@ function getAcronyms() {
     static $acronyms = null;
     if ( !$acronyms ) {
         $acronyms = retrieveConfig('acronyms','confToHash');
+        $acronyms = array_filter($acronyms);
     }
     return $acronyms;
 }
@@ -75,6 +77,7 @@ function getSmileys() {
     static $smileys = null;
     if ( !$smileys ) {
         $smileys = retrieveConfig('smileys','confToHash');
+        $smileys = array_filter($smileys);
     }
     return $smileys;
 }
@@ -88,6 +91,7 @@ function getEntities() {
     static $entities = null;
     if ( !$entities ) {
         $entities = retrieveConfig('entities','confToHash');
+        $entities = array_filter($entities);
     }
     return $entities;
 }
@@ -101,9 +105,11 @@ function getInterwiki() {
     static $wikis = null;
     if ( !$wikis ) {
         $wikis = retrieveConfig('interwiki','confToHash',array(true));
+        $wikis = array_filter($wikis);
+
+        //add sepecial case 'this'
+        $wikis['this'] = DOKU_URL.'{NAME}';
     }
-    //add sepecial case 'this'
-    $wikis['this'] = DOKU_URL.'{NAME}';
     return $wikis;
 }
 

--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -6,6 +6,12 @@
  * @author     Harry Fuecks <hfuecks@gmail.com>
  */
 
+/*
+ * line prefix used to negate single value config items
+ * (scheme.conf & stopwords.conf), e.g.
+ * !gopher
+ */
+const DOKU_CONF_NEGATION = '!';
 
 /**
  * Returns the (known) extension and mimetype of a given filename
@@ -364,7 +370,7 @@ function conf_decodeString($str) {
  */
 function array_merge_with_removal($current, $new) {
     foreach ($new as $val) {
-        if (substr($val,0,1) == '!') {
+        if (substr($val,0,1) == DOKU_CONF_NEGATION) {
             $idx = array_search(trim(substr($val,1)),$current);
             if ($idx !== false) {
                 unset($current[$idx]);

--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -63,7 +63,7 @@ function getAcronyms() {
     static $acronyms = null;
     if ( !$acronyms ) {
         $acronyms = retrieveConfig('acronyms','confToHash');
-        $acronyms = array_filter($acronyms);
+        $acronyms = array_filter($acronyms, 'strlen');
     }
     return $acronyms;
 }
@@ -77,7 +77,7 @@ function getSmileys() {
     static $smileys = null;
     if ( !$smileys ) {
         $smileys = retrieveConfig('smileys','confToHash');
-        $smileys = array_filter($smileys);
+        $smileys = array_filter($smileys, 'strlen');
     }
     return $smileys;
 }
@@ -91,7 +91,7 @@ function getEntities() {
     static $entities = null;
     if ( !$entities ) {
         $entities = retrieveConfig('entities','confToHash');
-        $entities = array_filter($entities);
+        $entities = array_filter($entities, 'strlen');
     }
     return $entities;
 }
@@ -105,7 +105,7 @@ function getInterwiki() {
     static $wikis = null;
     if ( !$wikis ) {
         $wikis = retrieveConfig('interwiki','confToHash',array(true));
-        $wikis = array_filter($wikis);
+        $wikis = array_filter($wikis, 'strlen');
 
         //add sepecial case 'this'
         $wikis['this'] = DOKU_URL.'{NAME}';

--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -365,12 +365,12 @@ function conf_decodeString($str) {
 function array_merge_with_removal($current, $new) {
     foreach ($new as $val) {
         if (substr($val,0,1) == '!') {
-            $idx = array_search(substr($val,1),$current);
+            $idx = array_search(trim(substr($val,1)),$current);
             if ($idx !== false) {
                 unset($current[$idx]);
             }
         } else {
-            $current[] = $val;
+            $current[] = trim($val);
         }
     }
 


### PR DESCRIPTION
Allows (non-php) configuration values set earlier in the config cascade to be reversed.  E.g. to counter a default configuration value.  

For key/value config files (e.g. acronyms), include a key with no value
```
# to set a value
HTML      hypertext markup language
# to unset a value
HTML
```

For value only config files (e.g. scheme, stopwords), prefix the value with an exclamation mark, '!'.
```
# to set a value
gopher
# to unset a value
!gopher
```