### PR TITLE
Fixed issue 'User manager enhancement: detailed error message for mis…

### DIFF
--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -500,6 +500,43 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
     }
 
     /**
+     * Build detailed error message for missing fields
+     * for the add user function.
+     *
+     * @return string error message text
+     */
+    protected function _buildAddUserEmptyFieldsErrorMsg ($user,$pass,$name,$mail) {
+        $msg = $this->lang['add_fail'];
+        $fields = '';
+        if ( empty($user) === true ) {
+            $fields .= '"'.$this->lang['user_id'].'"';
+        }
+        if ( empty($pass) === true ) {
+            if ( empty($fields) === false ) {
+                $fields .= ', ';
+            }
+            $fields .= '"'.$this->lang['user_pass'].'"';
+        }
+        if ( empty($name) === true ) {
+            if ( empty($fields) === false ) {
+                $fields .= ', ';
+            }
+            $fields .= '"'.$this->lang['user_name'].'"';
+        }
+        if ( empty($mail) === true ) {
+            if ( empty($fields) === false ) {
+                $fields .= ', ';
+            }
+            $fields .= '"'.$this->lang['user_mail'].'"';
+        }
+        
+        if ( empty($fields) === false ) {
+            $msg .= $this->lang['enter_missing_fields'].$fields;
+        }
+        return $msg;
+    }
+
+    /**
      * Add an user to auth backend
      *
      * @return bool whether succesful
@@ -510,14 +547,17 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         if (!$this->_auth->canDo('addUser')) return false;
 
         list($user,$pass,$name,$mail,$grps,$passconfirm) = $this->_retrieveUser();
-        if (empty($user)) return false;
+        if (empty($user)){
+            msg($this->_buildAddUserEmptyFieldsErrorMsg ($user,$pass,$name,$mail), -1);
+            return false;
+        }
 
         if ($this->_auth->canDo('modPass')){
             if (empty($pass)){
                 if($INPUT->has('usernotify')){
                     $pass = auth_pwgen($user);
                 } else {
-                    msg($this->lang['add_fail'], -1);
+                    msg($this->_buildAddUserEmptyFieldsErrorMsg ($user,$pass,$name,$mail), -1);
                     return false;
                 }
             } else {
@@ -534,7 +574,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
 
         if ($this->_auth->canDo('modName')){
             if (empty($name)){
-                msg($this->lang['add_fail'], -1);
+                msg($this->_buildAddUserEmptyFieldsErrorMsg ($user,$pass,$name,$mail), -1);
                 return false;
             }
         } else {
@@ -545,7 +585,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
 
         if ($this->_auth->canDo('modMail')){
             if (empty($mail)){
-                msg($this->lang['add_fail'], -1);
+                msg($this->_buildAddUserEmptyFieldsErrorMsg ($user,$pass,$name,$mail), -1);
                 return false;
             }
         } else {

--- a/lib/plugins/usermanager/lang/de-informal/lang.php
+++ b/lib/plugins/usermanager/lang/de-informal/lang.php
@@ -59,6 +59,7 @@ $lang['add_ok']                = 'Benutzer erfolgreich hinzugefügt';
 $lang['add_fail']              = 'Hinzufügen des Benutzers fehlgeschlagen';
 $lang['notify_ok']             = 'Benachrichtigungsmail wurde versendet';
 $lang['notify_fail']           = 'Benachrichtigungsemail konnte nicht gesendet werden';
+$lang['enter_missing_fields']  = '. Bitte geben Sie einen Wert in folgende Felder ein: ';
 $lang['import_success_count']  = 'Benutzerimport: %d Benutzer gefunden, %d erfolgreich importiert.';
 $lang['import_failure_count']  = 'Benutzerimport: %d Benutzerimporte fehlgeschalten. Alle Fehler werden unten angezeigt.';
 $lang['import_error_fields']   = 'Falsche Anzahl Felder. Gefunden: %d. Benötigt: 4.';

--- a/lib/plugins/usermanager/lang/de/lang.php
+++ b/lib/plugins/usermanager/lang/de/lang.php
@@ -69,6 +69,7 @@ $lang['add_ok']                = 'Nutzer erfolgreich angelegt';
 $lang['add_fail']              = 'Nutzer konnte nicht angelegt werden';
 $lang['notify_ok']             = 'Benachrichtigungsmail wurde versandt';
 $lang['notify_fail']           = 'Benachrichtigungsmail konnte nicht versandt werden';
+$lang['enter_missing_fields']  = '. Bitte geben Sie einen Wert in folgende Felder ein: ';
 $lang['import_userlistcsv']    = 'Benutzerliste (CSV-Datei):';
 $lang['import_header']         = 'Letzte Fehler bei Import';
 $lang['import_success_count']  = 'User-Import: %d User gefunden, %d erfolgreich importiert.';
@@ -82,3 +83,4 @@ $lang['import_error_readfail'] = 'Import fehlgeschlagen. Die hochgeladene Datei 
 $lang['import_error_create']   = 'User konnte nicht angelegt werden';
 $lang['import_notify_fail']    = 'Notifikation konnte nicht an den importierten Benutzer %s (E-Mail: %s) gesendet werden.';
 $lang['import_downloadfailures'] = 'Fehler als CSV-Datei zur Korrektur herunterladen';
+

--- a/lib/plugins/usermanager/lang/en/lang.php
+++ b/lib/plugins/usermanager/lang/en/lang.php
@@ -60,6 +60,7 @@ $lang['add_ok'] = 'User added successfully';
 $lang['add_fail'] = 'User addition failed';
 $lang['notify_ok'] = 'Notification email sent';
 $lang['notify_fail'] = 'Notification email could not be sent';
+$lang['enter_missing_fields'] = '. Please enter a value in the following fields: ';
 
 // import & errors
 $lang['import_userlistcsv'] = 'User list file (CSV):  ';


### PR DESCRIPTION
…sing fields on add user #1172'.

An new language string 'enter_missing_fields' has been added to 'de', 'de-informal' and 'en'.
Other languages need translation.

This will for example create the following error message if the fields 'Real Name' and 'Email' are missing:
**User addition failed. Please enter a value in the following fields: "Real Name", "Email"**
