### PR TITLE
Reimplement utf8_deaccent() using intl's Transliterator

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -129,7 +129,7 @@ function cleanID($raw_id,$ascii=false){
     }
 
     if($conf['deaccent'] == 2 || $ascii) $id = utf8_romanize($id);
-    if($conf['deaccent'] || $ascii) $id = utf8_deaccent($id,-1);
+    if($conf['deaccent'] || $ascii) $id = utf8_deaccent($id);
 
     //remove specials
     $id = utf8_stripspecials($id,$sepchar,'\*');

--- a/inc/utf8.php
+++ b/inc/utf8.php
@@ -454,25 +454,13 @@ if(!function_exists('utf8_deaccent')){
     /**
      * Replace accented UTF-8 characters by unaccented ASCII-7 equivalents
      *
-     * Use the optional parameter to just deaccent lower ($case = -1) or upper ($case = 1)
-     * letters. Default is to deaccent both cases ($case = 0)
-     *
      * @author Andreas Gohr <andi@splitbrain.org>
      *
      * @param string $string
-     * @param int $case
      * @return string
      */
-    function utf8_deaccent($string,$case=0){
-        if($case <= 0){
-            global $UTF8_LOWER_ACCENTS;
-            $string = strtr($string,$UTF8_LOWER_ACCENTS);
-        }
-        if($case >= 0){
-            global $UTF8_UPPER_ACCENTS;
-            $string = strtr($string,$UTF8_UPPER_ACCENTS);
-        }
-        return $string;
+    function utf8_deaccent($string){
+        return transliterator_transliterate("Latin-ASCII",$string);
     }
 }
 
@@ -1216,61 +1204,6 @@ if(!UTF8_MBSTRING){
                 );
 }; // end of case lookup tables
 
-/**
- * UTF-8 lookup table for lower case accented letters
- *
- * This lookuptable defines replacements for accented characters from the ASCII-7
- * range. This are lower case letters only.
- *
- * @author Andreas Gohr <andi@splitbrain.org>
- * @see    utf8_deaccent()
- */
-global $UTF8_LOWER_ACCENTS;
-if(empty($UTF8_LOWER_ACCENTS)) $UTF8_LOWER_ACCENTS = array(
-  'à' => 'a', 'ô' => 'o', 'ď' => 'd', 'ḟ' => 'f', 'ë' => 'e', 'š' => 's', 'ơ' => 'o',
-  'ß' => 'ss', 'ă' => 'a', 'ř' => 'r', 'ț' => 't', 'ň' => 'n', 'ā' => 'a', 'ķ' => 'k',
-  'ŝ' => 's', 'ỳ' => 'y', 'ņ' => 'n', 'ĺ' => 'l', 'ħ' => 'h', 'ṗ' => 'p', 'ó' => 'o',
-  'ú' => 'u', 'ě' => 'e', 'é' => 'e', 'ç' => 'c', 'ẁ' => 'w', 'ċ' => 'c', 'õ' => 'o',
-  'ṡ' => 's', 'ø' => 'o', 'ģ' => 'g', 'ŧ' => 't', 'ș' => 's', 'ė' => 'e', 'ĉ' => 'c',
-  'ś' => 's', 'î' => 'i', 'ű' => 'u', 'ć' => 'c', 'ę' => 'e', 'ŵ' => 'w', 'ṫ' => 't',
-  'ū' => 'u', 'č' => 'c', 'ö' => 'oe', 'è' => 'e', 'ŷ' => 'y', 'ą' => 'a', 'ł' => 'l',
-  'ų' => 'u', 'ů' => 'u', 'ş' => 's', 'ğ' => 'g', 'ļ' => 'l', 'ƒ' => 'f', 'ž' => 'z',
-  'ẃ' => 'w', 'ḃ' => 'b', 'å' => 'a', 'ì' => 'i', 'ï' => 'i', 'ḋ' => 'd', 'ť' => 't',
-  'ŗ' => 'r', 'ä' => 'ae', 'í' => 'i', 'ŕ' => 'r', 'ê' => 'e', 'ü' => 'ue', 'ò' => 'o',
-  'ē' => 'e', 'ñ' => 'n', 'ń' => 'n', 'ĥ' => 'h', 'ĝ' => 'g', 'đ' => 'd', 'ĵ' => 'j',
-  'ÿ' => 'y', 'ũ' => 'u', 'ŭ' => 'u', 'ư' => 'u', 'ţ' => 't', 'ý' => 'y', 'ő' => 'o',
-  'â' => 'a', 'ľ' => 'l', 'ẅ' => 'w', 'ż' => 'z', 'ī' => 'i', 'ã' => 'a', 'ġ' => 'g',
-  'ṁ' => 'm', 'ō' => 'o', 'ĩ' => 'i', 'ù' => 'u', 'į' => 'i', 'ź' => 'z', 'á' => 'a',
-  'û' => 'u', 'þ' => 'th', 'ð' => 'dh', 'æ' => 'ae', 'µ' => 'u', 'ĕ' => 'e',
-);
-
-/**
- * UTF-8 lookup table for upper case accented letters
- *
- * This lookuptable defines replacements for accented characters from the ASCII-7
- * range. This are upper case letters only.
- *
- * @author Andreas Gohr <andi@splitbrain.org>
- * @see    utf8_deaccent()
- */
-global $UTF8_UPPER_ACCENTS;
-if(empty($UTF8_UPPER_ACCENTS)) $UTF8_UPPER_ACCENTS = array(
-  'À' => 'A', 'Ô' => 'O', 'Ď' => 'D', 'Ḟ' => 'F', 'Ë' => 'E', 'Š' => 'S', 'Ơ' => 'O',
-  'Ă' => 'A', 'Ř' => 'R', 'Ț' => 'T', 'Ň' => 'N', 'Ā' => 'A', 'Ķ' => 'K',
-  'Ŝ' => 'S', 'Ỳ' => 'Y', 'Ņ' => 'N', 'Ĺ' => 'L', 'Ħ' => 'H', 'Ṗ' => 'P', 'Ó' => 'O',
-  'Ú' => 'U', 'Ě' => 'E', 'É' => 'E', 'Ç' => 'C', 'Ẁ' => 'W', 'Ċ' => 'C', 'Õ' => 'O',
-  'Ṡ' => 'S', 'Ø' => 'O', 'Ģ' => 'G', 'Ŧ' => 'T', 'Ș' => 'S', 'Ė' => 'E', 'Ĉ' => 'C',
-  'Ś' => 'S', 'Î' => 'I', 'Ű' => 'U', 'Ć' => 'C', 'Ę' => 'E', 'Ŵ' => 'W', 'Ṫ' => 'T',
-  'Ū' => 'U', 'Č' => 'C', 'Ö' => 'Oe', 'È' => 'E', 'Ŷ' => 'Y', 'Ą' => 'A', 'Ł' => 'L',
-  'Ų' => 'U', 'Ů' => 'U', 'Ş' => 'S', 'Ğ' => 'G', 'Ļ' => 'L', 'Ƒ' => 'F', 'Ž' => 'Z',
-  'Ẃ' => 'W', 'Ḃ' => 'B', 'Å' => 'A', 'Ì' => 'I', 'Ï' => 'I', 'Ḋ' => 'D', 'Ť' => 'T',
-  'Ŗ' => 'R', 'Ä' => 'Ae', 'Í' => 'I', 'Ŕ' => 'R', 'Ê' => 'E', 'Ü' => 'Ue', 'Ò' => 'O',
-  'Ē' => 'E', 'Ñ' => 'N', 'Ń' => 'N', 'Ĥ' => 'H', 'Ĝ' => 'G', 'Đ' => 'D', 'Ĵ' => 'J',
-  'Ÿ' => 'Y', 'Ũ' => 'U', 'Ŭ' => 'U', 'Ư' => 'U', 'Ţ' => 'T', 'Ý' => 'Y', 'Ő' => 'O',
-  'Â' => 'A', 'Ľ' => 'L', 'Ẅ' => 'W', 'Ż' => 'Z', 'Ī' => 'I', 'Ã' => 'A', 'Ġ' => 'G',
-  'Ṁ' => 'M', 'Ō' => 'O', 'Ĩ' => 'I', 'Ù' => 'U', 'Į' => 'I', 'Ź' => 'Z', 'Á' => 'A',
-  'Û' => 'U', 'Þ' => 'Th', 'Ð' => 'Dh', 'Æ' => 'Ae', 'Ĕ' => 'E',
-);
 
 /**
  * UTF-8 array of common special characters


### PR DESCRIPTION
The current utf8_deaccent() function uses a simplistic translation table, which doesn't handle a lot of edge cases like the Vietnamese alphabet (try a page name like "Gõ tiếng Việt"). On the other hand, this is a solved problem with the `intl` extension (using the ICU library).

This PR requires the php-intl extension.