### PR TITLE
authad new features

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -123,6 +123,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
 
     }
 
+	
     /**
      * Load domain config on capability check
      *
@@ -785,9 +786,9 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
 					($this->cando[$feature] && $override !== false)	// default value not explicitly disabled
 				);
 			case 'external': 
-				return false;	// authad does not use externals by default
+				return (bool)$opts['doku_signin'];	// external is used for auto-signin
 			case 'logout':
-				return !(bool)$opts['sso'];	// logout is disabled for sso
+				return !((bool)$opts['sso'] || (bool) $opts['doku_signin']);	// logout is disabled for sso or auto-signin
 			default:	// don't care for different stuff.
 				return parent::canDo($feature);
 		}

--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -775,7 +775,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
 			case 'getUsers':
 			case 'getGroups':
 				return (
-					($this->cando[$feature] && $override !== false)	// default value not explicitly disabled
+					($override !== false)	// default value not explicitly disabled
 				);
 			case 'addUser': 
 			case 'delUser':

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -18,3 +18,5 @@ $conf['doku_signin']        = 0;
 $conf['user_caching']       = 0;
 $conf['user_caching_ttl']   = 3600;
 $conf['user_map']			= '';
+$conf['try_controller']		= 0;
+$conf['random_controller']		= 1;

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -17,3 +17,4 @@ $conf['admin_features']     = '';
 $conf['doku_signin']        = 0;
 $conf['user_caching']       = 0;
 $conf['user_caching_ttl']   = 3600;
+$conf['user_map']			= '';

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -15,3 +15,4 @@ $conf['expirywarn']         = 0;
 $conf['additional']         = '';
 
 $conf['admin_features']              = '';
+$conf['doku_signin']              = 0;

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -13,6 +13,7 @@ $conf['use_tls']            = 0;
 $conf['debug']              = 0;
 $conf['expirywarn']         = 0;
 $conf['additional']         = '';
-
-$conf['admin_features']              = '';
-$conf['doku_signin']              = 0;
+$conf['admin_features']     = '';
+$conf['doku_signin']        = 0;
+$conf['user_caching']       = 0;
+$conf['user_caching_ttl']   = 3600;

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -20,3 +20,5 @@ $conf['user_caching_ttl']   = 3600;
 $conf['user_map']			= '';
 $conf['try_controller']		= 0;
 $conf['random_controller']		= 1;
+$conf['auto_domain']		= 0;
+$conf['auto_controller_lookup']		= 0;

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -13,3 +13,5 @@ $conf['use_tls']            = 0;
 $conf['debug']              = 0;
 $conf['expirywarn']         = 0;
 $conf['additional']         = '';
+
+$conf['admin_features']              = '';

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -20,3 +20,5 @@ $meta['user_caching_ttl']   = array('numeric', '_min'=>0,'_caution' => 'danger')
 $meta['user_map']         	= array('string');
 $meta['try_controller']		= array('onoff');
 $meta['random_controller']	= array('onoff');
+$meta['auto_domain']		= array('onoff','_caution' => 'danger');
+$meta['auto_controller_lookup']		= array('onoff','_caution' => 'danger');

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -13,3 +13,5 @@ $meta['use_tls']            = array('onoff','_caution' => 'danger');
 $meta['debug']              = array('onoff','_caution' => 'security');
 $meta['expirywarn']         = array('numeric', '_min'=>0,'_caution' => 'danger');
 $meta['additional']         = array('string','_caution' => 'danger');
+
+$meta['admin_features'] = array('string','_caution' => 'danger');

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -17,3 +17,4 @@ $meta['admin_features'] 	= array('string','_caution' => 'danger');
 $meta['doku_signin']      	= array('onoff','_caution' => 'danger');
 $meta['user_caching']      	= array('onoff');
 $meta['user_caching_ttl']   = array('numeric', '_min'=>0,'_caution' => 'danger');
+$meta['user_map']         	= array('string');

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -18,3 +18,5 @@ $meta['doku_signin']      	= array('onoff','_caution' => 'danger');
 $meta['user_caching']      	= array('onoff');
 $meta['user_caching_ttl']   = array('numeric', '_min'=>0,'_caution' => 'danger');
 $meta['user_map']         	= array('string');
+$meta['try_controller']		= array('onoff');
+$meta['random_controller']	= array('onoff');

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -14,4 +14,5 @@ $meta['debug']              = array('onoff','_caution' => 'security');
 $meta['expirywarn']         = array('numeric', '_min'=>0,'_caution' => 'danger');
 $meta['additional']         = array('string','_caution' => 'danger');
 
-$meta['admin_features'] = array('string','_caution' => 'danger');
+$meta['admin_features'] 	= array('string','_caution' => 'danger');
+$meta['doku_signin']      = array('onoff','_caution' => 'security');

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -13,6 +13,7 @@ $meta['use_tls']            = array('onoff','_caution' => 'danger');
 $meta['debug']              = array('onoff','_caution' => 'security');
 $meta['expirywarn']         = array('numeric', '_min'=>0,'_caution' => 'danger');
 $meta['additional']         = array('string','_caution' => 'danger');
-
 $meta['admin_features'] 	= array('string','_caution' => 'danger');
-$meta['doku_signin']      = array('onoff','_caution' => 'security');
+$meta['doku_signin']      	= array('onoff','_caution' => 'danger');
+$meta['user_caching']      	= array('onoff');
+$meta['user_caching_ttl']   = array('numeric', '_min'=>0,'_caution' => 'danger');

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -21,3 +21,4 @@ $lang['admin_features']     = 'A comma separated list of administration feature 
 $lang['doku_signin']		= 'Automatically sign in users authed by HTTP NTML/kerberos negotiation. Alternative to "sso".';
 $lang['user_caching']		= 'Enable user caching using cachewrapper plugin.';
 $lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not recommended for AD).';
+$lang['user_map']			= 'Set users to be mapped to AD users. Coma separated list of arrow separated pairs: <code>{user} => {AD user}</code> E.g. <code>admin=>myuser@mydomain, olddomain\\oldtest => "test domain with spaces\\testuser" </code>';

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -19,5 +19,5 @@ $lang['admin_features']     = 'A comma separated list of administration feature 
 	'Some settings should not be changed (marked with **) others depend on environment settings (marked with *).<br/>'.
 	'Use "+" and "-" to enable/disable features e. g. <code>+modPass, -modName, -modMail</code>';
 $lang['doku_signin']		= 'Automatically sign in users authed by HTTP NTML/kerberos negotiation. Alternative to "sso".';
-$lang['user_caching']		= 'Enable user caching using cachewrapper plugin.'
-$lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not recommended for AD).'
+$lang['user_caching']		= 'Enable user caching using cachewrapper plugin.';
+$lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not recommended for AD).';

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -14,8 +14,10 @@ $lang['debug']              = 'Display additional debugging output on errors?';
 $lang['expirywarn']         = 'Days in advance to warn user about expiring password. 0 to disable.';
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
 
-$lang['admin_features']     = 'A comma separated list of administration feature overrides. Allowed settings: '.
+$lang['admin_features']     = 'A comma separated list of administration feature overrides.<br/> Allowed settings: '.
 	'<code>addUser (-**), delUser (-**), modLogin (-), modPass (+*), modName (+), modMail (+), modGroups (-*), getUsers (+**), getUserCount (+*), getGroups (+**), external (-*), logout (-*)</code>,'.
-	'all case sensitive (defaults as "+"/"-").'.
-	'Some settings should not be changed (marked with **) others depend on environment settings (marked with *).'.
+	'all case sensitive (defaults as "+"/"-").<br/>'.
+	'Some settings should not be changed (marked with **) others depend on environment settings (marked with *).<br/>'.
 	'Use "+" and "-" to enable/disable features e. g. <code>+modPass, -modName, -modMail</code>';
+
+$lang['doku_signin']		= 'Automatically sign in users authed by HTTP NTML/kerberos negotiation. Alternative to "sso".';

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -13,11 +13,11 @@ $lang['use_tls']            = 'Use TLS connection? If used, do not enable SSL ab
 $lang['debug']              = 'Display additional debugging output on errors?';
 $lang['expirywarn']         = 'Days in advance to warn user about expiring password. 0 to disable.';
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
-
 $lang['admin_features']     = 'A comma separated list of administration feature overrides.<br/> Allowed settings: '.
 	'<code>addUser (-**), delUser (-**), modLogin (-), modPass (+*), modName (+), modMail (+), modGroups (-*), getUsers (+**), getUserCount (+*), getGroups (+**), external (-*), logout (-*)</code>,'.
 	'all case sensitive (defaults as "+"/"-").<br/>'.
 	'Some settings should not be changed (marked with **) others depend on environment settings (marked with *).<br/>'.
 	'Use "+" and "-" to enable/disable features e. g. <code>+modPass, -modName, -modMail</code>';
-
 $lang['doku_signin']		= 'Automatically sign in users authed by HTTP NTML/kerberos negotiation. Alternative to "sso".';
+$lang['user_caching']		= 'Enable user caching using cachewrapper plugin.'
+$lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not recommended for AD).'

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -24,3 +24,5 @@ $lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not
 $lang['user_map']			= 'Set users to be mapped to AD users. Coma separated list of arrow separated pairs: <code>{user} => {AD user}</code> E.g. <code>admin=>myuser@mydomain, olddomain\\oldtest => "test domain with spaces\\testuser" </code>';
 $lang['try_controller']		= 'Ping each controller to ensure they are alive (useful for dynamic AD forests)';
 $lang['random_controller']	= "Pick random controller. Disable this, if the controllers in the <code>domain_controllers</code> setting are ordered by priority (e.g. by latency).";
+$lang['auto_domain']		= "Automatically add user's domain to the base_dn.";
+$lang['auto_controller_lookup']		= "Automatically look up controllers for the user's domain: dns lookup to find domain controllers named according to base_dn.";

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -13,3 +13,9 @@ $lang['use_tls']            = 'Use TLS connection? If used, do not enable SSL ab
 $lang['debug']              = 'Display additional debugging output on errors?';
 $lang['expirywarn']         = 'Days in advance to warn user about expiring password. 0 to disable.';
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
+
+$lang['admin_features']     = 'A comma separated list of administration feature overrides. Allowed settings: '.
+	'<code>addUser (-**), delUser (-**), modLogin (-), modPass (+*), modName (+), modMail (+), modGroups (-*), getUsers (+**), getUserCount (+*), getGroups (+**), external (-*), logout (-*)</code>,'.
+	'all case sensitive (defaults as "+"/"-").'.
+	'Some settings should not be changed (marked with **) others depend on environment settings (marked with *).'.
+	'Use "+" and "-" to enable/disable features e. g. <code>+modPass, -modName, -modMail</code>';

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -22,3 +22,5 @@ $lang['doku_signin']		= 'Automatically sign in users authed by HTTP NTML/kerbero
 $lang['user_caching']		= 'Enable user caching using cachewrapper plugin.';
 $lang['user_caching_ttl']	= 'Cache TTL in seconds.  Set to 0 to disable TTL (not recommended for AD).';
 $lang['user_map']			= 'Set users to be mapped to AD users. Coma separated list of arrow separated pairs: <code>{user} => {AD user}</code> E.g. <code>admin=>myuser@mydomain, olddomain\\oldtest => "test domain with spaces\\testuser" </code>';
+$lang['try_controller']		= 'Ping each controller to ensure they are alive (useful for dynamic AD forests)';
+$lang['random_controller']	= "Pick random controller. Disable this, if the controllers in the <code>domain_controllers</code> setting are ordered by priority (e.g. by latency).";


### PR DESCRIPTION
- minor fixes
- adjustable auth features by config
- alternative sso: auto_signin (sso is for both dokuwiki and adldap, auto_signin is only for dokuwiki)
- user caching with config (depends on memcache plugin)
- support for remapping users.
- updates for adldap for picking domain controllers (with config options)
- alternative config: automatic base_dn generation and controller lookup 