### PR TITLE
Extension manager fixes

### DIFF
--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -127,7 +127,7 @@ jQuery(function(){
         jQuery(['enabled', 'disabled', 'updatable']).each(function(index, chkName){
             var $label = jQuery( '<label></label>' ).appendTo($displayOpts);
             jQuery( '<input />', { type: 'checkbox', name: chkName }).change(displayOptionsHandler).appendTo($label).click();
-            jQuery( '<span/>' ).append(LANG.plugins.extension['display_'+chkName]).appendTo($label);
+            jQuery( '<span/>' ).append(' '+LANG.plugins.extension['display_'+chkName]).appendTo($label);
         });
     }
 });

--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -114,16 +114,17 @@ jQuery(function(){
         Create section for enabling/disabling viewing options
      */
     if ( $extmgr.find('.plugins, .templates').hasClass('active') ) {
+        var $extlist = jQuery('#extension__list');
+        $extlist.addClass('hasDisplayOptions');
         var $displayOpts = jQuery('<p>', { id: 'extension__viewoptions'} ).appendTo($extmgr.find( '.panelHeader' ));
 
         $displayOpts.append(LANG.plugins.extension.display_viewoptions);
-    
+
         var displayOptionsHandler = function(){
-            jQuery('#extension__list').toggleClass( this.name );
+            $extlist.toggleClass( this.name );
         };
-    
+
         jQuery(['enabled', 'disabled', 'updatable']).each(function(index, chkName){
-        
             var $label = jQuery( '<label></label>' ).appendTo($displayOpts);
             jQuery( '<input />', { type: 'checkbox', name: chkName }).change(displayOptionsHandler).appendTo($label).click();
             jQuery( '<span/>' ).append(LANG.plugins.extension['display_'+chkName]).appendTo($label);

--- a/lib/plugins/extension/style.less
+++ b/lib/plugins/extension/style.less
@@ -281,18 +281,21 @@
  * Enabled/Disabled overrides
  */
 #extension__list {
-    
-    .enabled, .disabled,
-    .updatable {
-        display: none;
+
+    &.hasDisplayOptions {
+        .enabled,
+        .disabled,
+        .updatable {
+            display: none;
+        }
+
+        &.enabled .enabled,
+        &.disabled .disabled,
+        &.updatable .updatable {
+            display: block;
+        }
     }
-    
-    &.enabled .enabled,
-    &.disabled .disabled,
-    &.updatable .updatable {
-        display: block;
-    }
-    
+
     .enabled div.screenshot span {
         background: transparent url(images/enabled.png) no-repeat 2px 2px;
     }

--- a/lib/plugins/extension/style.less
+++ b/lib/plugins/extension/style.less
@@ -379,4 +379,5 @@
 
 #extension__viewoptions label {
     margin-left: 1em;
+    vertical-align: baseline;
 }


### PR DESCRIPTION
The extension manager currently doesn't work without JavaScript, i.e. none of the installed extensions are displayed. This was introduced in #1113.
This also includes a minor fix of some spacing/alignment issues around the display options and some trailing whitespace issues.