### PR TITLE
Changed all input buttons to button buttons

### DIFF
--- a/_test/tests/inc/form_form.test.php
+++ b/_test/tests/inc/form_form.test.php
@@ -30,9 +30,9 @@ class form_test extends DokuWikiTest {
     $realoutput .= '<input type="checkbox" id="check__id" name="r" value="1" /> ';
     $realoutput .= '<span>Check</span></label>';
     $realoutput .= "\n";
-    $realoutput .= '<input name="do[save]" type="submit" value="Save" class="button" accesskey="s" title="Save [S]" />';
+    $realoutput .= '<button name="do[save]" type="submit" accesskey="s" title="Save [S]">Save</button>';
     $realoutput .= "\n";
-    $realoutput .= '<input name="do[cancel]" type="submit" value="Cancel" class="button" />';
+    $realoutput .= '<button name="do[cancel]" type="submit">Cancel</button>';
     $realoutput .= "\n";
     $realoutput .= "</fieldset>\n</div></form>\n";
     return $realoutput;

--- a/inc/form.php
+++ b/inc/form.php
@@ -400,7 +400,7 @@ function form_makeWikiText($text, $attrs=array()) {
 function form_makeButton($type, $act, $value='', $attrs=array()) {
     if ($value == '') $value = $act;
     $elem = array('_elem'=>'button', 'type'=>$type, '_action'=>$act,
-                        'value'=>$value, 'class'=>'button');
+                        'value'=>$value);
     if (!empty($attrs['accesskey']) && empty($attrs['title'])) {
         $attrs['title'] = $value . ' ['.strtoupper($attrs['accesskey']).']';
     }
@@ -761,7 +761,9 @@ function form_wikitext($attrs) {
  */
 function form_button($attrs) {
     $p = (!empty($attrs['_action'])) ? 'name="do['.$attrs['_action'].']" ' : '';
-    return '<input '.$p.buildAttributes($attrs,true).' />';
+    $value = $attrs['value'];
+    unset($attrs['value']);
+    return '<button '.$p.buildAttributes($attrs,true).'>'.$value.'</button>';
 }
 
 /**

--- a/inc/html.php
+++ b/inc/html.php
@@ -183,7 +183,7 @@ function html_topbtn(){
  * @param bool|string    $label  label text, false: lookup btn_$name in localization
  * @return string
  */
-function html_btn($name,$id,$akey,$params,$method='get',$tooltip='',$label=false){
+function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label=false){
     global $conf;
     global $lang;
 
@@ -221,13 +221,15 @@ function html_btn($name,$id,$akey,$params,$method='get',$tooltip='',$label=false
         $tip = htmlspecialchars($label);
     }
 
-    $ret .= '<input type="submit" value="'.hsc($label).'" class="button" ';
+    $ret .= '<button type="submit" ';
     if($akey){
         $tip .= ' ['.strtoupper($akey).']';
         $ret .= 'accesskey="'.$akey.'" ';
     }
     $ret .= 'title="'.$tip.'" ';
     $ret .= '/>';
+    $ret .= hsc($label);
+    $ret .= '</button>';
     $ret .= '</div></form>';
 
     return $ret;
@@ -856,26 +858,28 @@ function html_recent($first=0, $show_changes='both'){
         $first -= $conf['recent'];
         if ($first < 0) $first = 0;
         $form->addElement(form_makeOpenTag('div', array('class' => 'pagenav-prev')));
-        $form->addElement(form_makeTag('input', array(
+        $form->addElement(form_makeOpenTag('button', array(
                     'type'  => 'submit',
                     'name'  => 'first['.$first.']',
-                    'value' => $lang['btn_newer'],
                     'accesskey' => 'n',
                     'title' => $lang['btn_newer'].' [N]',
                     'class' => 'button show'
                     )));
+        $form->addElement($lang['btn_newer']);
+        $form->addElement(form_makeCloseTag('button'));
         $form->addElement(form_makeCloseTag('div'));
     }
     if ($hasNext) {
         $form->addElement(form_makeOpenTag('div', array('class' => 'pagenav-next')));
-        $form->addElement(form_makeTag('input', array(
+        $form->addElement(form_makeOpenTag('button', array(
                         'type'  => 'submit',
                         'name'  => 'first['.$last.']',
-                        'value' => $lang['btn_older'],
                         'accesskey' => 'p',
                         'title' => $lang['btn_older'].' [P]',
                         'class' => 'button show'
                         )));
+        $form->addElement($lang['btn_older']);
+        $form->addElement(form_makeCloseTag('button'));
         $form->addElement(form_makeCloseTag('div'));
     }
     $form->addElement(form_makeCloseTag('div'));
@@ -1005,7 +1009,7 @@ function html_li_default($item){
  * @param callable $func  callback to print an list item
  * @param callable $lifunc callback to the opening li tag
  * @param bool     $forcewrapper Trigger building a wrapper ul if the first level is
-                                 0 (we have a root object) or 1 (just the root content)
+ *                               0 (we have a root object) or 1 (just the root content)
  * @return string html of an unordered list
  */
 function html_buildlist($data,$class,$func,$lifunc='html_li_default',$forcewrapper=false){

--- a/inc/template.php
+++ b/inc/template.php
@@ -834,7 +834,7 @@ function tpl_searchform($ajax = true, $autocomplete = true) {
     print 'placeholder="'.$lang['btn_search'].'" ';
     if(!$autocomplete) print 'autocomplete="off" ';
     print 'id="qsearch__in" accesskey="f" name="id" class="edit" title="[F]" />';
-    print '<input type="submit" value="'.$lang['btn_search'].'" class="button" title="'.$lang['btn_search'].'" />';
+    print '<button type="submit" title="'.$lang['btn_search'].'">'.$lang['btn_search'].'</button>';
     if($ajax) print '<div id="qsearch__out" class="ajax_qsearch JSpopup"></div>';
     print '</div></form>';
     return true;
@@ -1667,7 +1667,7 @@ function tpl_actiondropdown($empty = '', $button = '&gt;') {
     echo '</optgroup>';
 
     echo '</select>';
-    echo '<input type="submit" value="'.$button.'" />';
+    echo '<button type="submit">'.$button.'</button>';
     echo '</div>';
     echo '</form>';
 }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1613,6 +1613,12 @@ function tpl_actiondropdown($empty = '', $button = '&gt;') {
     /** @var Input $INPUT */
     global $INPUT;
 
+    $action_structure = array(
+        'page_tools' => array('edit', 'revert', 'revisions', 'backlink', 'subscribe'),
+        'site_tools' => array('recent', 'media', 'index'),
+        'user_tools' => array('login', 'register', 'profile', 'admin'),
+    );
+
     echo '<form action="'.script().'" method="get" accept-charset="utf-8">';
     echo '<div class="no">';
     echo '<input type="hidden" name="id" value="'.$ID.'" />';
@@ -1624,47 +1630,14 @@ function tpl_actiondropdown($empty = '', $button = '&gt;') {
     echo '<select name="do" class="edit quickselect" title="'.$lang['tools'].'">';
     echo '<option value="">'.$empty.'</option>';
 
-    echo '<optgroup label="'.$lang['page_tools'].'">';
-    $act = tpl_get_action('edit');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('revert');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('revisions');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('backlink');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('subscribe');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-    echo '</optgroup>';
-
-    echo '<optgroup label="'.$lang['site_tools'].'">';
-    $act = tpl_get_action('recent');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('media');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('index');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-    echo '</optgroup>';
-
-    echo '<optgroup label="'.$lang['user_tools'].'">';
-    $act = tpl_get_action('login');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('register');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('profile');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-
-    $act = tpl_get_action('admin');
-    if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
-    echo '</optgroup>';
+    foreach($action_structure as $tools => $actions) {
+        echo '<optgroup label="'.$lang[$tools].'">';
+        foreach($actions as $action) {
+            $act = tpl_get_action($action);
+            if($act) echo '<option value="'.$act['params']['do'].'">'.$lang['btn_'.$act['type']].'</option>';
+        }
+        echo '</optgroup>';
+    }
 
     echo '</select>';
     echo '<button type="submit">'.$button.'</button>';

--- a/install.php
+++ b/install.php
@@ -243,7 +243,7 @@ function print_form($d){
 
     </fieldset>
     <fieldset id="process">
-        <input class="button" type="submit" name="submit" value="<?php echo $lang['btn_save']?>" />
+        <button type="submit" name="submit"><?php echo $lang['btn_save']?></button>
     </fieldset>
     </form>
     <?php
@@ -256,7 +256,7 @@ function print_retry() {
     <form action="" method="get">
       <fieldset>
         <input type="hidden" name="l" value="<?php echo $LC ?>" />
-        <input class="button" type="submit" value="<?php echo $lang['i_retry'];?>" />
+        <button type="submit"><?php echo $lang['i_retry'];?></button>
       </fieldset>
     </form>
     <?php
@@ -619,7 +619,7 @@ function langsel(){
         echo '<option value="'.$l.'" '.$sel.'>'.$l.'</option>';
     }
     echo '</select> ';
-    echo '<input type="submit" value="'.$lang['btn_update'].'" />';
+    echo '<button type="submit">'.$lang['btn_update'].'</button>';
     echo '</form>';
 }
 

--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -332,7 +332,7 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
         echo $this->getLang('acl_perms').' ';
         $inl =  $this->_html_select();
         echo '<input type="text" name="acl_w" class="edit" value="'.(($inl)?'':hsc(ltrim($this->who,'@'))).'" />'.NL;
-        echo '<input type="submit" value="'.$this->getLang('btn_select').'" class="button" />'.NL;
+        echo '<button type="submit">'.$this->getLang('btn_select').'</button>'.NL;
         echo '</div>'.NL;
 
         echo '<div id="acl__info">';
@@ -391,10 +391,10 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
         echo $this->_html_checkboxes($current,empty($this->ns),'acl');
 
         if(is_null($current)){
-            echo '<input type="submit" name="cmd[save]" class="button" value="'.$lang['btn_save'].'" />'.NL;
+            echo '<button type="submit" name="cmd[save]">'.$lang['btn_save'].'</button>'.NL;
         }else{
-            echo '<input type="submit" name="cmd[save]" class="button" value="'.$lang['btn_update'].'" />'.NL;
-            echo '<input type="submit" name="cmd[del]" class="button" value="'.$lang['btn_delete'].'" />'.NL;
+            echo '<button type="submit" name="cmd[save]">'.$lang['btn_update'].'</button>'.NL;
+            echo '<button type="submit" name="cmd[del]">'.$lang['btn_delete'].'</button>'.NL;
         }
 
         echo '</fieldset>';
@@ -641,7 +641,7 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
 
         echo '<tr>';
         echo '<th class="action" colspan="4">';
-        echo '<input type="submit" value="'.$lang['btn_update'].'" name="cmd[update]" class="button" />';
+        echo '<button type="submit" name="cmd[update]">'.$lang['btn_update'].'</button>';
         echo '</th>';
         echo '</tr>';
         echo '</table>';

--- a/lib/plugins/acl/script.js
+++ b/lib/plugins/acl/script.js
@@ -16,7 +16,7 @@ var dw_acl = {
         }
 
         jQuery('#acl__user select').change(dw_acl.userselhandler);
-        jQuery('#acl__user input[type=submit]').click(dw_acl.loadinfo);
+        jQuery('#acl__user button').click(dw_acl.loadinfo);
 
         $tree = jQuery('#acl__tree');
         $tree.dw_tree({toggle_selector: 'img',

--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -212,8 +212,8 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
 
         if (!$this->_config->locked) {
             ptln('  <input type="hidden" name="save"   value="1" />');
-            ptln('  <input type="submit" name="submit" class="button" value="'.$lang['btn_save'].'" accesskey="s" />');
-            ptln('  <input type="reset" class="button" value="'.$lang['btn_reset'].'" />');
+            ptln('  <button type="submit" name="submit" accesskey="s">'.$lang['btn_save'].'</button>');
+            ptln('  <button type="reset">'.$lang['btn_reset'].'</button>');
         }
 
         ptln('</p>');

--- a/lib/plugins/extension/helper/list.php
+++ b/lib/plugins/extension/helper/list.php
@@ -535,7 +535,7 @@ class helper_plugin_extension_list extends DokuWiki_Plugin {
         $classes = 'button '.$action;
         $name    = 'fn['.$action.']['.hsc($extension->getID()).']';
 
-        return '<input class="'.$classes.'" name="'.$name.'" type="submit" value="'.$this->getLang('btn_'.$action).'" '.$title.' />';
+        return '<button class="'.$classes.'" name="'.$name.'" type="submit" '.$title.'>'.$this->getLang('btn_'.$action).'</button> ';
     }
 
     /**

--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -5,7 +5,7 @@ jQuery(function(){
     /**
      * Confirm uninstalling
      */
-    $extmgr.find('input.uninstall').click(function(e){
+    $extmgr.find('button.uninstall').click(function(e){
         if(!window.confirm(LANG.plugins.extension.reallydel)){
             e.preventDefault();
             return false;
@@ -46,7 +46,7 @@ jQuery(function(){
     /**
      * Enable/Disable extension via AJAX
      */
-    $extmgr.find('input.disable, input.enable').click(function (e) {
+    $extmgr.find('button.disable, button.enable').click(function (e) {
         e.preventDefault();
         var $btn = jQuery(this);
 

--- a/lib/plugins/extension/style.less
+++ b/lib/plugins/extension/style.less
@@ -80,8 +80,8 @@
         overflow: hidden;
     }
 
-    input.button {
-        margin: 0 .3em .3em 0;
+    button {
+        margin-bottom: .3em;
     }
 }
 

--- a/lib/plugins/popularity/admin.php
+++ b/lib/plugins/popularity/admin.php
@@ -144,7 +144,7 @@ class admin_plugin_popularity extends DokuWiki_Admin_Plugin {
                 .'<input type="hidden" name="do" value="admin" />'
                 .'<input type="hidden" name="page" value="popularity" />';
         }
-        $form .= '<input type="submit" class="button" value="'.$this->getLang('submit').'"/>'
+        $form .= '<button type="submit">'.$this->getLang('submit').'</button>'
             .'</fieldset>'
             .'</form>';
         return $form;

--- a/lib/plugins/revert/admin.php
+++ b/lib/plugins/revert/admin.php
@@ -64,9 +64,9 @@ class admin_plugin_revert extends DokuWiki_Admin_Plugin {
         global $lang, $INPUT;
         echo '<form action="" method="post"><div class="no">';
         echo '<label>'.$this->getLang('filter').': </label>';
-        echo '<input type="text" name="filter" class="edit" value="'.hsc($INPUT->str('filter')).'" />';
-        echo ' <input type="submit" class="button" value="'.$lang['btn_search'].'" />';
-        echo ' <span>'.$this->getLang('note1').'</span>';
+        echo '<input type="text" name="filter" class="edit" value="'.hsc($INPUT->str('filter')).'" /> ';
+        echo '<button type="submit">'.$lang['btn_search'].'</button> ';
+        echo '<span>'.$this->getLang('note1').'</span>';
         echo '</div></form><br /><br />';
     }
 
@@ -173,7 +173,7 @@ class admin_plugin_revert extends DokuWiki_Admin_Plugin {
         echo '</ul>';
 
         echo '<p>';
-        echo '<input type="submit" class="button" value="'.$this->getLang('revert').'" /> ';
+        echo '<button type="submit">'.$this->getLang('revert').'</button> ';
         printf($this->getLang('note2'),hsc($filter));
         echo '</p>';
 

--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -241,18 +241,18 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         ptln("    <tbody>");
         ptln("      <tr><td colspan=\"5\" class=\"centeralign\">");
         ptln("        <span class=\"medialeft\">");
-        ptln("          <input type=\"submit\" name=\"fn[delete]\" ".$delete_disable." class=\"button\" value=\"".$this->lang['delete_selected']."\" id=\"usrmgr__del\" />");
-        ptln("        </span>");
+        ptln("          <button type=\"submit\" name=\"fn[delete]\" id=\"usrmgr__del\" ".$delete_disable.">".$this->lang['delete_selected']."</button>");
+        ptln("        ");
         ptln("        <span class=\"mediaright\">");
-        ptln("          <input type=\"submit\" name=\"fn[start]\" ".$page_buttons['start']." class=\"button\" value=\"".$this->lang['start']."\" />");
-        ptln("          <input type=\"submit\" name=\"fn[prev]\" ".$page_buttons['prev']." class=\"button\" value=\"".$this->lang['prev']."\" />");
-        ptln("          <input type=\"submit\" name=\"fn[next]\" ".$page_buttons['next']." class=\"button\" value=\"".$this->lang['next']."\" />");
-        ptln("          <input type=\"submit\" name=\"fn[last]\" ".$page_buttons['last']." class=\"button\" value=\"".$this->lang['last']."\" />");
+        ptln("          <button type=\"submit\" name=\"fn[start]\" ".$page_buttons['start'].">".$this->lang['start']."</button>");
+        ptln("          <button type=\"submit\" name=\"fn[prev]\" ".$page_buttons['prev'].">".$this->lang['prev']."</button>");
+        ptln("          <button type=\"submit\" name=\"fn[next]\" ".$page_buttons['next'].">".$this->lang['next']."</button>");
+        ptln("          <button type=\"submit\" name=\"fn[last]\" ".$page_buttons['last'].">".$this->lang['last']."</button>");
         ptln("        </span>");
         if (!empty($this->_filter)) {
-            ptln("    <input type=\"submit\" name=\"fn[search][clear]\" class=\"button\" value=\"".$this->lang['clear']."\" />");
+            ptln("    <button type=\"submit\" name=\"fn[search][clear]\">".$this->lang['clear']."</button>");
         }
-        ptln("        <input type=\"submit\" name=\"fn[export]\" class=\"button\" value=\"".$export_label."\" />");
+        ptln("        <button type=\"submit\" name=\"fn[export]\">".$export_label."</button>");
         ptln("        <input type=\"hidden\" name=\"do\"    value=\"admin\" />");
         ptln("        <input type=\"hidden\" name=\"page\"  value=\"usermanager\" />");
 
@@ -360,7 +360,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
 
         $this->_htmlFilterSettings($indent+10);
 
-        ptln("          <input type=\"submit\" name=\"fn[".$cmd."]\" class=\"button\" value=\"".$this->lang[$cmd]."\" />",$indent);
+        ptln("          <button type=\"submit\" name=\"fn[".$cmd."]\">".$this->lang[$cmd]."</button>",$indent);
         ptln("        </td>",$indent);
         ptln("      </tr>",$indent);
         ptln("    </tbody>",$indent);
@@ -369,7 +369,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         if ($notes) {
             ptln("    <ul class=\"notes\">");
             foreach ($notes as $note) {
-                ptln("      <li><span class=\"li\">".$note."</span></li>",$indent);
+                ptln("      <li><span class=\"li\">".$note."</li>",$indent);
             }
             ptln("    </ul>");
         }
@@ -456,7 +456,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         ptln('  <form action="'.wl($ID).'" method="post" enctype="multipart/form-data">',$indent);
         formSecurityToken();
         ptln('    <label>'.$this->lang['import_userlistcsv'].'<input type="file" name="import" /></label>',$indent);
-        ptln('    <input type="submit" name="fn[import]" value="'.$this->lang['import'].'" />',$indent);
+        ptln('    <button type="submit" name="fn[import]">'.$this->lang['import'].'</button>',$indent);
         ptln('    <input type="hidden" name="do"    value="admin" />',$indent);
         ptln('    <input type="hidden" name="page"  value="usermanager" />',$indent);
 

--- a/lib/plugins/usermanager/style.css
+++ b/lib/plugins/usermanager/style.css
@@ -17,7 +17,7 @@
   padding-left: 0;
   padding-right: 1.4em;
 }
-#user__manager input.button[disabled] {
+#user__manager button[disabled] {
   color: #ccc!important;
   border-color: #ccc!important;
 }

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -107,7 +107,7 @@ var dw_behaviour = {
     quickSelect: function(){
         jQuery('select.quickselect')
             .change(function(e){ e.target.form.submit(); })
-            .closest('form').find('input[type=submit]').not('.show').hide();
+            .closest('form').find(':button').not('.show').hide();
     },
 
     /**
@@ -171,10 +171,10 @@ var dw_behaviour = {
 
         if($checked.length < 2){
             $all.attr('disabled',false);
-            jQuery('#page__revisions input[type=submit]').attr('disabled',true);
+            jQuery('#page__revisions button').attr('disabled',true);
         }else{
             $all.attr('disabled',true);
-            jQuery('#page__revisions input[type=submit]').attr('disabled',false);
+            jQuery('#page__revisions button').attr('disabled',false);
             for(var i=0; i<$checked.length; i++){
                 $checked[i].disabled = false;
                 if(i>1){

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -146,7 +146,7 @@ var dw_editor = {
 
         if((e.keyCode == 13 || e.keyCode == 10) && e.ctrlKey) { // Ctrl-Enter (With Chrome workaround)
             // Submit current edit
-            jQuery('input#edbtn__save').click();
+            jQuery('#edbtn__save').click();
             e.preventDefault(); // prevent enter key
             return false;
         }else if(e.keyCode == 13){ // Enter

--- a/lib/scripts/fileuploaderextended.js
+++ b/lib/scripts/fileuploaderextended.js
@@ -82,7 +82,7 @@ qq.FileUploaderExtended = function(o){
             '<div class="qq-upload-button">' + LANG.media_select + '</div>' +
             '<ul class="qq-upload-list"></ul>' +
             '<div class="qq-action-container">' +
-            '  <input class="qq-upload-action button" type="submit" value="' + LANG.media_upload_btn + '" id="mediamanager__upload_button">' +
+            '  <button class="qq-upload-action" type="submit" id="mediamanager__upload_button">' + LANG.media_upload_btn + '</button>' +
             '  <label class="qq-overwrite-check"><input type="checkbox" value="1" name="ow" class="dw__ow"> <span>' + LANG.media_overwrt + '</span></label>' +
             '</div>' +
             '</div>',
@@ -189,7 +189,7 @@ qq.extend(qq.FileUploaderExtended.prototype, {
             var button = '<form method="post" action="' + action + '" id="mediamanager__done_form"><div>';
             button += '<input type="hidden" value="' + result.ns + '" name="ns">';
             button += '<input type="hidden" value="1" name="recent">';
-            button += '<input class="button" type="submit" value="' + LANG.media_done_btn + '"></div></form>';
+            button += '<button type="submit">' + LANG.media_done_btn + '</button></div></form>';
             jQuery('#mediamanager__uploader').append(button);
         }
     }

--- a/lib/scripts/hotkeys.js
+++ b/lib/scripts/hotkeys.js
@@ -26,7 +26,7 @@ function Hotkeys() {
      * Initialization
      *
      * This function looks up all the accesskeys used in the current page
-     * (at anchor elements and input elements [type="submit"]) and registers
+     * (at anchor elements and button elements [type="submit"]) and registers
      * appropriate shortcuts.
      *
      * Secondly, initialization registers listeners on document to catch all
@@ -59,10 +59,10 @@ function Hotkeys() {
         });
 
         /**
-         * Lookup all input [type="submit"] with accesskey and register event -
+         * Lookup all button [type="submit"] with accesskey and register event -
          * perform "click" on a button.
          */
-        var inputs = document.getElementsByTagName("input");
+        var inputs = document.getElementsByTagName("button");
         t.each(inputs, function(i) {
             if (i.type == "submit" && i.accessKey != "") {
                 t.addShortcut(t.modifier + '+' + i.accessKey, function() {

--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -119,7 +119,7 @@ var dw_mediamanager = {
         $both = $listType.add($sortBy);
 
         // Remove the submit button
-        $options.find('input[type=submit]').parent().hide();
+        $options.find('button[type=submit]').parent().hide();
 
         // Prepare HTML for jQuery UI buttonset
         $both.find('label').each(function () {
@@ -435,7 +435,7 @@ var dw_mediamanager = {
                 dw_mediamanager.$resizables().resizable('destroy');
 
                 if (update_list) {
-                    dw_mediamanager.list.call(jQuery('#mediamanager__page form.options input[type="submit"]')[0]);
+                    dw_mediamanager.list.call(jQuery('#mediamanager__page form.options button[type="submit"]')[0]);
                 }
 
                 $content.html(data);

--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -88,7 +88,7 @@ div.picker button.toolbutton {
     margin-right: 0;
     margin-left: 1em;
 }
-.dokuwiki .editBar .editButtons input {
+.dokuwiki .editBar .editButtons button {
 }
 
 /* summary input and minor changes checkbox */
@@ -130,7 +130,7 @@ div.picker button.toolbutton {
 [dir=rtl] .dokuwiki .secedit {
     float: left;
 }
-.dokuwiki .secedit input.button {
+.dokuwiki .secedit button {
     font-size: 75%;
 }
 

--- a/lib/tpl/dokuwiki/css/_forms.css
+++ b/lib/tpl/dokuwiki/css/_forms.css
@@ -62,8 +62,7 @@
 }
 
 
-.dokuwiki input.button,
-.dokuwiki button.button {
+.dokuwiki button {
     vertical-align: middle;
 }
 /**

--- a/lib/tpl/dokuwiki/css/_media_fullscreen.css
+++ b/lib/tpl/dokuwiki/css/_media_fullscreen.css
@@ -394,7 +394,7 @@
     width: 50%;
 }
 
-#mediamanager__page form.meta input.button {
+#mediamanager__page form.meta button {
     width: auto;
 }
 

--- a/lib/tpl/dokuwiki/css/_media_popup.css
+++ b/lib/tpl/dokuwiki/css/_media_popup.css
@@ -204,7 +204,7 @@ html.popup {
 }
 #dw__mediasearch input.edit {
 }
-#dw__mediasearch input.button {
+#dw__mediasearch button {
 }
 
 

--- a/lib/tpl/dokuwiki/css/_modal.css
+++ b/lib/tpl/dokuwiki/css/_modal.css
@@ -88,7 +88,7 @@
     cursor: default;
 }
 
-#media__popup_content .button {
+#media__popup_content button {
     margin-right: 1px;
     cursor: pointer;
 }

--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -207,12 +207,12 @@ form.search {
     position: relative;
     margin-bottom: 0.5em;
 
-    input.edit {
+    input {
         width: 18em;
         padding: .35em 22px .35em .1em;
     }
 
-    input.button {
+    button {
         background: transparent url(images/search.png) no-repeat 0 0;
         border-width: 0;
         width: 19px;
@@ -225,11 +225,11 @@ form.search {
 }
 
 [dir=rtl] form.search {
-    input.edit {
+    input {
         padding: .35em .1em .35em 22px;
     }
 
-    input.button {
+    button {
         background-position: 5px 0;
         margin-left: 0;
         margin-right: -20px;

--- a/lib/tpl/dokuwiki/css/mobile.less
+++ b/lib/tpl/dokuwiki/css/mobile.less
@@ -237,7 +237,7 @@ body {
     margin: 0 0 .2em .2em;
 }
 
-#dokuwiki__sitetools form.search input.edit {
+#dokuwiki__sitetools form.search input {
     width: 100% !important;
 }
 .dokuwiki form.search div.ajax_qsearch {
@@ -261,7 +261,7 @@ body {
 }
 
 /* force same height on search input and tools select */
-#dokuwiki__sitetools form.search input.edit,
+#dokuwiki__sitetools form.search input,
 #dokuwiki__header .mobileTools select {
     height: 2.1em;
     line-height: 2.1em;


### PR DESCRIPTION
Input buttons (i.e. of the type `<input type="submit" value="Text" />`) are quite hard to style, especially when you'd like to make use of icon fonts. Because input buttons do not have any content, they are not stylable via `:before{}` and `:after{}`.
Therefore I changed all the input buttons to "button buttons" (`<button type="submit">Text</button>`).

I am not 100% sure if I might have overlooked a case. I adjusted necessary CSS and JS accordingly but it's hard to look for these buttons.

Please note: This might have an effect on plugin or templates as the core `form_makeButton()`, `html_btn()`, `tpl_searchform()` and `tpl_actiondropdown()` have been changed. It is possible to make changes backwards-compatible in extensions simply by adding both varieties, e.g.
```
.dokuwiki .secedit input.button, /* old version */
.dokuwiki .secedit button { /* new version */
}
```
... or in JS by addressing all buttons with `jQuery(':button')`.