### PR TITLE
Add a 'returnonly' option to all xhtml link types

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -761,27 +761,40 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
     /**
      * Render a CamelCase link
      *
-     * @param string $link The link name
+     * @param string $link       The link name
+     * @param bool   $returnonly whether to return html or write to doc attribute
      * @see http://en.wikipedia.org/wiki/CamelCase
      */
-    function camelcaselink($link) {
-        $this->internallink($link, $link);
+    function camelcaselink($link, $returnonly = false) {
+        if($returnonly) {
+          return $this->internallink($link, $link, null, true);
+        } else {
+          $this->internallink($link, $link);
+        }
     }
 
     /**
      * Render a page local link
      *
-     * @param string $hash hash link identifier
-     * @param string $name name for the link
+     * @param string $hash       hash link identifier
+     * @param string $name       name for the link
+     * @param bool   $returnonly whether to return html or write to doc attribute
      */
-    function locallink($hash, $name = null) {
+    function locallink($hash, $name = null, $returnonly = false) {
         global $ID;
         $name  = $this->_getLinkTitle($name, $hash, $isImage);
         $hash  = $this->_headerToLink($hash);
         $title = $ID.' ↵';
-        $this->doc .= '<a href="#'.$hash.'" title="'.$title.'" class="wikilink1">';
-        $this->doc .= $name;
-        $this->doc .= '</a>';
+
+        $doc = '<a href="#'.$hash.'" title="'.$title.'" class="wikilink1">';
+        $doc .= $name;
+        $doc .= '</a>';
+
+        if($returnonly) {
+          return $doc;
+        } else {
+          $this->doc .= $doc;
+        }
     }
 
     /**
@@ -884,10 +897,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
     /**
      * Render an external link
      *
-     * @param string       $url  full URL with scheme
-     * @param string|array $name name for the link, array for media file
+     * @param string       $url        full URL with scheme
+     * @param string|array $name       name for the link, array for media file
+     * @param bool         $returnonly whether to return html or write to doc attribute
      */
-    function externallink($url, $name = null) {
+    function externallink($url, $name = null, $returnonly = false) {
         global $conf;
 
         $name = $this->_getLinkTitle($name, $url, $isImage);
@@ -926,7 +940,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         if($conf['relnofollow']) $link['more'] .= ' rel="nofollow"';
 
         //output formatted
-        $this->doc .= $this->_formatLink($link);
+        if($returnonly) {
+            return $this->_formatLink($link);
+        } else {
+            $this->doc .= $this->_formatLink($link);
+        }
     }
 
     /**
@@ -934,12 +952,13 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      *
      * You may want to use $this->_resolveInterWiki() here
      *
-     * @param string       $match     original link - probably not much use
-     * @param string|array $name      name for the link, array for media file
-     * @param string       $wikiName  indentifier (shortcut) for the remote wiki
-     * @param string       $wikiUri   the fragment parsed from the original link
+     * @param string       $match      original link - probably not much use
+     * @param string|array $name       name for the link, array for media file
+     * @param string       $wikiName   indentifier (shortcut) for the remote wiki
+     * @param string       $wikiUri    the fragment parsed from the original link
+     * @param bool         $returnonly whether to return html or write to doc attribute
      */
-    function interwikilink($match, $name = null, $wikiName, $wikiUri) {
+    function interwikilink($match, $name = null, $wikiName, $wikiUri, $returnonly = false) {
         global $conf;
 
         $link           = array();
@@ -977,16 +996,21 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['title'] = htmlspecialchars($link['url']);
 
         //output formatted
-        $this->doc .= $this->_formatLink($link);
+        if($returnonly) {
+            return $this->_formatLink($link);
+        } else {
+            $this->doc .= $this->_formatLink($link);
+        }
     }
 
     /**
      * Link to windows share
      *
-     * @param string       $url  the link
-     * @param string|array $name name for the link, array for media file
+     * @param string       $url        the link
+     * @param string|array $name       name for the link, array for media file
+     * @param bool         $returnonly whether to return html or write to doc attribute
      */
-    function windowssharelink($url, $name = null) {
+    function windowssharelink($url, $name = null, $returnonly = false) {
         global $conf;
 
         //simple setup
@@ -1010,7 +1034,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['url']   = $url;
 
         //output formatted
-        $this->doc .= $this->_formatLink($link);
+        if($returnonly) {
+            return $this->_formatLink($link);
+        } else {
+            $this->doc .= $this->_formatLink($link);
+        }
     }
 
     /**
@@ -1018,10 +1046,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      *
      * Honors $conf['mailguard'] setting
      *
-     * @param string       $address Email-Address
-     * @param string|array $name    name for the link, array for media file
+     * @param string       $address    Email-Address
+     * @param string|array $name       name for the link, array for media file
+     * @param bool         $returnonly whether to return html or write to doc attribute
      */
-    function emaillink($address, $name = null) {
+    function emaillink($address, $name = null, $returnonly = false) {
         global $conf;
         //simple setup
         $link           = array();
@@ -1053,7 +1082,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['title'] = $title;
 
         //output formatted
-        $this->doc .= $this->_formatLink($link);
+        if($returnonly) {
+            return $this->_formatLink($link);
+        } else {
+            $this->doc .= $this->_formatLink($link);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds a returnonly option to all xhtml link types, not just to internallink. In order to support different renderers in the data plugin, this is required.