### PR TITLE
Interwiki fixes

### DIFF
--- a/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
+++ b/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
@@ -17,18 +17,18 @@ class Test_resolveInterwiki extends DokuWikiTest {
 
         $tests = array(
             // shortcut, reference and expected
-            array('wp', 'foo [\\]^`{|}~@+#%?/#txt', 'https://en.wikipedia.org/wiki/foo %7E%5B%5C%5D%5E%60%7B%7C%7D%7E@+%23%25%3F/#txt'),
-            array('amazon', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.amazon.com/exec/obidos/ASIN/foo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F/splitbrain-20/#txt'),
-            array('doku', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.dokuwiki.org/foo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F#txt'),
+            array('wp', 'foo [\\]^`{|}~@+#%?/#txt', 'https://en.wikipedia.org/wiki/foo %5B%5C%5D%5E%60%7B%7C%7D~@+%23%25?/#txt'),
+            array('amazon', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.amazon.com/exec/obidos/ASIN/foo%20%5B%5C%5D%5E%60%7B%7C%7D~%40%2B%23%25%3F%2F/splitbrain-20/#txt'),
+            array('doku', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.dokuwiki.org/foo%20%5B%5C%5D%5E%60%7B%7C%7D~%40%2B%23%25%3F%2F#txt'),
             array('coral', 'http://example.com:83/path/naar/?query=foo%20%40%2B%25%3F%2F', 'http://example.com.83.nyud.net:8090/path/naar/?query=foo%20%40%2B%25%3F%2F'),
             array('scheme', 'ftp://foo @+%/#txt', 'ftp://example.com#txt'),
             //relative url
-            array('withslash', 'foo [\\]^`{|}~@+#%?/#txt', '/testfoo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F#txt'),
-            array('skype',  'foo [\\]^`{|}~@+#%?/#txt', 'skype:foo %7E%5B%5C%5D%5E%60%7B%7C%7D%7E@+%23%25?/#txt'),
+            array('withslash', 'foo [\\]^`{|}~@+#%?/#txt', '/testfoo%20%5B%5C%5D%5E%60%7B%7C%7D~%40%2B%23%25%3F%2F#txt'),
+            array('skype',  'foo [\\]^`{|}~@+#%?/#txt', 'skype:foo %5B%5C%5D%5E%60%7B%7C%7D~@+%23%25?/#txt'),
             //dokuwiki id's
-            array('onlytext', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=onlytextfoo#txt'),
-            array('user', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=user:foo#txt'),
-            array('withquery', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=anyns:foo&amp;do=edit#txt')
+            array('onlytext', 'foo [\\]^`{|}~@+#%/#txt', DOKU_BASE.'doku.php?id=onlytextfoo#txt'),
+            array('user', 'foo [\\]^`{|}~@+#%/#txt', DOKU_BASE.'doku.php?id=user:foo#txt'),
+            array('withquery', 'foo [\\]^`{|}~@+#%/#txt', DOKU_BASE.'doku.php?id=anyns:foo&amp;do=edit#txt')
         );
 
         foreach($tests as $test) {

--- a/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
+++ b/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
@@ -17,18 +17,18 @@ class Test_resolveInterwiki extends DokuWikiTest {
 
         $tests = array(
             // shortcut, reference and expected
-            array('wp', 'foo @+%/#txt', 'http://en.wikipedia.org/wiki/foo @+%/#txt'),
-            array('amazon', 'foo @+%/#txt', 'http://www.amazon.com/exec/obidos/ASIN/foo%20%40%2B%25%2F/splitbrain-20/#txt'),
-            array('doku', 'foo @+%/#txt', 'http://www.dokuwiki.org/foo%20%40%2B%25%2F#txt'),
-            array('coral', 'http://example.com:83/path/naar/?query=foo%20%40%2B%25%2F', 'http://example.com.83.nyud.net:8090/path/naar/?query=foo%20%40%2B%25%2F'),
+            array('wp', 'foo [\\]^`{|}~@+#%?/#txt', 'https://en.wikipedia.org/wiki/foo %7E%5B%5C%5D%5E%60%7B%7C%7D%7E@+%23%25%3F/#txt'),
+            array('amazon', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.amazon.com/exec/obidos/ASIN/foo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F/splitbrain-20/#txt'),
+            array('doku', 'foo [\\]^`{|}~@+#%?/#txt', 'https://www.dokuwiki.org/foo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F#txt'),
+            array('coral', 'http://example.com:83/path/naar/?query=foo%20%40%2B%25%3F%2F', 'http://example.com.83.nyud.net:8090/path/naar/?query=foo%20%40%2B%25%3F%2F'),
             array('scheme', 'ftp://foo @+%/#txt', 'ftp://example.com#txt'),
             //relative url
-            array('withslash', 'foo @+%/#txt', '/testfoo%20%40%2B%25%2F#txt'),
-            array('skype',  'foo @+%/#txt', 'skype:foo @+%/#txt'),
+            array('withslash', 'foo [\\]^`{|}~@+#%?/#txt', '/testfoo%20%7E%5B%5C%5D%5E%60%7B%7C%7D%7E%40%2B%23%25%3F%2F#txt'),
+            array('skype',  'foo [\\]^`{|}~@+#%?/#txt', 'skype:foo %7E%5B%5C%5D%5E%60%7B%7C%7D%7E@+%23%25?/#txt'),
             //dokuwiki id's
-            array('onlytext', 'foo @+%#txt', DOKU_BASE.'doku.php?id=onlytextfoo#txt'),
-            array('user', 'foo @+%#txt', DOKU_BASE.'doku.php?id=user:foo#txt'),
-            array('withquery', 'foo @+%#txt', DOKU_BASE.'doku.php?id=anyns:foo&amp;do=edit#txt')
+            array('onlytext', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=onlytextfoo#txt'),
+            array('user', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=user:foo#txt'),
+            array('withquery', 'foo [\\]^`{|}~@+#%?/#txt', DOKU_BASE.'doku.php?id=anyns:foo&amp;do=edit#txt')
         );
 
         foreach($tests as $test) {
@@ -45,7 +45,7 @@ class Test_resolveInterwiki extends DokuWikiTest {
         $shortcut = 'nonexisting';
         $reference = 'foo @+%/';
         $url = $Renderer->_resolveInterWiki($shortcut, $reference);
-        $expected = 'http://www.google.com/search?q=foo%20%40%2B%25%2F&amp;btnI=lucky';
+        $expected = 'https://www.google.com/search?q=foo%20%40%2B%25%2F&amp;btnI=lucky';
 
         $this->assertEquals($expected, $url);
     }

--- a/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
+++ b/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
@@ -14,6 +14,8 @@ class Test_resolveInterwiki extends DokuWikiTest {
         $Renderer->interwiki['withslash'] = '/test';
         $Renderer->interwiki['onlytext'] = ':onlytext{NAME}'; //with {URL} double urlencoded
         $Renderer->interwiki['withquery'] = ':anyns:{NAME}?do=edit';
+        //this was the only link with host/port/path/query. Keep it here for regression
+        $Renderer->interwiki['coral'] = 'http://{HOST}.{PORT}.nyud.net:8090{PATH}?{QUERY}';
 
         $tests = array(
             // shortcut, reference and expected

--- a/conf/interwiki.conf
+++ b/conf/interwiki.conf
@@ -1,8 +1,16 @@
-# Each URL may contain one of the placeholders {URL} or {NAME}
+# Each URL may contain one of these placeholders
 # {URL}  is replaced by the URL encoded representation of the wikiname
 #        this is the right thing to do in most cases
 # {NAME} this is replaced by the wikiname as given in the document
-#        no further encoding is done
+#        only mandatory encoded is done, urlencoding if the link
+#        is an external URL, or encoding as a wikiname if it is an
+#        internal link (begins with a colon)
+# {SCHEME}
+# {HOST}
+# {PORT}
+# {PATH}
+# {QUERY} these placeholders will be replaced with the appropriate part
+#         of the link when parsed as a URL
 # If no placeholder is defined the urlencoded name is appended to the URL
 
 # To prevent losing your added InterWiki shortcuts after an upgrade,

--- a/conf/interwiki.conf
+++ b/conf/interwiki.conf
@@ -8,28 +8,29 @@
 # To prevent losing your added InterWiki shortcuts after an upgrade,
 # you should add new ones to interwiki.local.conf
 
-wp        http://en.wikipedia.org/wiki/{NAME}
-wpfr      http://fr.wikipedia.org/wiki/{NAME}
-wpde      http://de.wikipedia.org/wiki/{NAME}
-wpes      http://es.wikipedia.org/wiki/{NAME}
-wppl      http://pl.wikipedia.org/wiki/{NAME}
-wpjp      http://ja.wikipedia.org/wiki/{NAME}
-wpmeta    http://meta.wikipedia.org/wiki/{NAME}
-doku      http://www.dokuwiki.org/
-dokubug   http://bugs.dokuwiki.org/index.php?do=details&amp;task_id=
-rfc       http://tools.ietf.org/html/rfc
+wp        https://en.wikipedia.org/wiki/{NAME}
+wpfr      https://fr.wikipedia.org/wiki/{NAME}
+wpde      https://de.wikipedia.org/wiki/{NAME}
+wpes      https://es.wikipedia.org/wiki/{NAME}
+wppl      https://pl.wikipedia.org/wiki/{NAME}
+wpjp      https://ja.wikipedia.org/wiki/{NAME}
+wpmeta    https://meta.wikipedia.org/wiki/{NAME}
+doku      https://www.dokuwiki.org/
+dokubug   https://bugs.dokuwiki.org/index.php?do=details&amp;task_id=
+dokugit   https://github.com/splitbrain/dokuwiki/issues/
+rfc       https://tools.ietf.org/html/rfc
 man       http://man.cx/
 amazon    http://www.amazon.com/exec/obidos/ASIN/{URL}/splitbrain-20/
-amazon.de http://www.amazon.de/exec/obidos/ASIN/{URL}/splitbrain-21/
-amazon.uk http://www.amazon.co.uk/exec/obidos/ASIN/
+amazon.de https://www.amazon.de/exec/obidos/ASIN/{URL}/splitbrain-21/
+amazon.uk https://www.amazon.co.uk/exec/obidos/ASIN/
 paypal    https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=
-phpfn     http://www.php.net/{NAME}
+phpfn     https://www.php.net/{NAME}
 coral     http://{HOST}.{PORT}.nyud.net:8090{PATH}?{QUERY}
 freecache http://freecache.org/{NAME}
 sb        http://www.splitbrain.org/go/
 skype     skype:{NAME}
-google.de http://www.google.de/search?q=
-go        http://www.google.com/search?q={URL}&amp;btnI=lucky
+google.de https://www.google.de/search?q=
+go        https://www.google.com/search?q={URL}&amp;btnI=lucky
 user      :user:{NAME}
 
 # To support VoIP/SIP/TEL links

--- a/conf/interwiki.conf
+++ b/conf/interwiki.conf
@@ -20,7 +20,7 @@ dokubug   https://bugs.dokuwiki.org/index.php?do=details&amp;task_id=
 dokugit   https://github.com/splitbrain/dokuwiki/issues/
 rfc       https://tools.ietf.org/html/rfc
 man       http://man.cx/
-amazon    http://www.amazon.com/exec/obidos/ASIN/{URL}/splitbrain-20/
+amazon    https://www.amazon.com/exec/obidos/ASIN/{URL}/splitbrain-20/
 amazon.de https://www.amazon.de/exec/obidos/ASIN/{URL}/splitbrain-21/
 amazon.uk https://www.amazon.co.uk/exec/obidos/ASIN/
 paypal    https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=

--- a/conf/interwiki.conf
+++ b/conf/interwiki.conf
@@ -16,8 +16,6 @@ wppl      https://pl.wikipedia.org/wiki/{NAME}
 wpjp      https://ja.wikipedia.org/wiki/{NAME}
 wpmeta    https://meta.wikipedia.org/wiki/{NAME}
 doku      https://www.dokuwiki.org/
-dokubug   https://bugs.dokuwiki.org/index.php?do=details&amp;task_id=
-dokugit   https://github.com/splitbrain/dokuwiki/issues/
 rfc       https://tools.ietf.org/html/rfc
 man       http://man.cx/
 amazon    https://www.amazon.com/exec/obidos/ASIN/{URL}/splitbrain-20/
@@ -25,8 +23,6 @@ amazon.de https://www.amazon.de/exec/obidos/ASIN/{URL}/splitbrain-21/
 amazon.uk https://www.amazon.co.uk/exec/obidos/ASIN/
 paypal    https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=
 phpfn     https://www.php.net/{NAME}
-coral     http://{HOST}.{PORT}.nyud.net:8090{PATH}?{QUERY}
-freecache http://freecache.org/{NAME}
 sb        http://www.splitbrain.org/go/
 skype     skype:{NAME}
 google.de https://www.google.de/search?q=

--- a/conf/interwiki.conf
+++ b/conf/interwiki.conf
@@ -31,7 +31,6 @@ amazon.de https://www.amazon.de/exec/obidos/ASIN/{URL}/splitbrain-21/
 amazon.uk https://www.amazon.co.uk/exec/obidos/ASIN/
 paypal    https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=
 phpfn     https://www.php.net/{NAME}
-sb        http://www.splitbrain.org/go/
 skype     skype:{NAME}
 google.de https://www.google.de/search?q=
 go        https://www.google.com/search?q={URL}&amp;btnI=lucky

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -811,13 +811,21 @@ class Doku_Renderer extends DokuWiki_Plugin {
         }
 
         //split into hash and url part
-        @list($reference, $hash) = explode('#', $reference, 2);
+        $hash = strrchr($reference, '#');
+        if($hash) {
+            $reference = substr($reference, 0, -strlen($hash));
+            $hash = substr($hash, 1);
+        }
 
         //replace placeholder
         if(preg_match('#\{(URL|NAME|SCHEME|HOST|PORT|PATH|QUERY)\}#', $url)) {
             //use placeholders
             $url    = str_replace('{URL}', rawurlencode($reference), $url);
-            $url    = str_replace('{NAME}', $reference, $url);
+            //wiki names will be cleaned next, otherwise urlencode unsafe chars
+            $url    = str_replace('{NAME}', ($url{0} === ':') ? $reference :
+                                  preg_replace_callback('/[[\\\\\]^`{|}#%]/', function($match) {
+                                    return rawurlencode($match[0]);
+                                  }, $reference), $url);
             $parsed = parse_url($reference);
             if(!$parsed['port']) $parsed['port'] = 80;
             $url = str_replace('{SCHEME}', $parsed['scheme'], $url);

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -806,7 +806,7 @@ class Doku_Renderer extends DokuWiki_Plugin {
             $url = $this->interwiki[$shortcut];
         } else {
             // Default to Google I'm feeling lucky
-            $url      = 'http://www.google.com/search?q={URL}&amp;btnI=lucky';
+            $url      = 'https://www.google.com/search?q={URL}&amp;btnI=lucky';
             $shortcut = 'go';
         }
 


### PR DESCRIPTION
Fixes issues #1220 and #1226 

- External links need to always have reserved characters encoded.
- Non-working and DokuWiki specific InterWiki links have been removed.
- InterWiki links are HTTPS for those servers that support it (nearly all of them).