### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,19 @@
 ; http://editorconfig.org/
 
+root = true
+
 [*]
 indent_style = space
 indent_size = 4
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[inc/{geshi,phpseclib}/**]
+[{vendor,inc/phpseclib}/**]
 ; Use editor default (possible autodetection).
 indent_style =
 indent_size =
-trim_trailing_whitespace = false
-insert_final_newline = false
+end_of_line =
+trim_trailing_whitespace =
+insert_final_newline =


### PR DESCRIPTION
Since we have the new "vendor" folder for composer stuff (since #1152) and GeSHi has been moved there, the `.editorconfig` needs to be updated to reflect the move and include the whole "vendor" folder.

I am not 100% sure about the syntax. Does anyone know if `[{vendor,inc/phpseclib}/**]` is correct?

I also added `root` and `end_of_line` settings and removed some values for the vendor stuff I believe were wrong. (Setting them to empty means the editor shouldn't care, while setting them to `false` might make the editor change the initial coding style.)