### PR TITLE
Remove IE7 support

### DIFF
--- a/lib/plugins/acl/style.css
+++ b/lib/plugins/acl/style.css
@@ -81,7 +81,6 @@
 [dir=rtl] #acl_manager .aclgroup {
     background: transparent url(pix/group.png) right 1px no-repeat;
     padding: 1px 18px 1px 0px;
-    display: inline-block; /* needed for IE7 */
 }
 
 #acl_manager .acluser {
@@ -91,7 +90,6 @@
 [dir=rtl] #acl_manager .acluser {
     background: transparent url(pix/user.png) right 1px no-repeat;
     padding: 1px 18px 1px 0px;
-    display: inline-block; /* needed for IE7 */
 }
 
 #acl_manager .aclpage {
@@ -101,7 +99,6 @@
 [dir=rtl] #acl_manager .aclpage {
     background: transparent url(pix/page.png) right 1px no-repeat;
     padding: 1px 18px 1px 0px;
-    display: inline-block; /* needed for IE7 */
 }
 
 #acl_manager .aclns {
@@ -111,7 +108,6 @@
 [dir=rtl] #acl_manager .aclns {
     background: transparent url(pix/ns.png) right 1px no-repeat;
     padding: 1px 18px 1px 0px;
-    display: inline-block; /* needed for IE7 */
 }
 
 #acl_manager label.disabled {

--- a/lib/tpl/dokuwiki/css/_links.css
+++ b/lib/tpl/dokuwiki/css/_links.css
@@ -66,5 +66,4 @@
 [dir=rtl] .dokuwiki a.mediafile {
     background-position: right center;
     padding: 0 18px 0 0;
-    display: inline-block; /* needed for IE7 */
 }

--- a/lib/tpl/dokuwiki/css/basic.less
+++ b/lib/tpl/dokuwiki/css/basic.less
@@ -228,7 +228,6 @@ video,
 audio {
     max-width: 100%;
 }
-#IE7 img,
 #IE8 img,
 button img {
     max-width: none;
@@ -413,11 +412,6 @@ button,
     border-radius: 2px;
     padding: .1em .5em;
     cursor: pointer;
-}
-#IE7 input.button,
-#IE7 button {
-    line-height: 1.4;
-    overflow: visible;
 }
 
 input[type=submit]:hover,

--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -140,7 +140,6 @@
     dd {
         margin: 0;
         clear: left;
-        min-height: 1px; /* for IE7 */
     }
 
     pre {

--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -117,10 +117,6 @@
     padding-right: 20px;
 }
 
-[dir=rtl] #IE7 #dokuwiki__usertools a.action {
-    display: inline-block;
-}
-
 #dokuwiki__header .mobileTools {
     display: none; /* hide mobile tools dropdown to only show in mobile view */
 }
@@ -237,11 +233,6 @@ form.search {
     }
 }
 
-#IE7 form.search {
-    min-height: 1px;
-    z-index: 21;
-}
-
 /*____________ breadcrumbs ____________*/
 
 .dokuwiki div.breadcrumbs {
@@ -273,7 +264,6 @@ form.search {
     }
 }
 
-#IE7 .dokuwiki div.breadcrumbs div,
 #IE8 .dokuwiki div.breadcrumbs div {
     border-bottom: 1px solid @ini_border;
 }

--- a/lib/tpl/dokuwiki/css/pagetools.less
+++ b/lib/tpl/dokuwiki/css/pagetools.less
@@ -133,25 +133,6 @@
     padding: 5px 5px 5px 40px;
 }
 
-/* IE7 fixes, doesn't work without images */
-
-#IE7 #dokuwiki__pagetools ul li a {
-    background-image: url(images/pagetools-sprite.png?v=2);
-}
-
-#IE7 #dokuwiki__pagetools:hover ul li a span,
-#IE7 #dokuwiki__pagetools ul li a:focus span,
-#IE7 #dokuwiki__pagetools ul li a:active span {
-    clip: auto;
-    display: inline;
-    position: static;
-}
-
-#IE7 #dokuwiki__pagetools ul li a span {
-    clip: rect(0 0 0 0);
-    position: absolute;
-}
-
 #dokuwiki__pagetools ul li a:hover,
 #dokuwiki__pagetools ul li a:active,
 #dokuwiki__pagetools ul li a:focus {

--- a/lib/tpl/dokuwiki/detail.php
+++ b/lib/tpl/dokuwiki/detail.php
@@ -27,7 +27,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 </head>
 
 <body>
-    <!--[if lte IE 7 ]><div id="IE7"><![endif]--><!--[if IE 8 ]><div id="IE8"><![endif]-->
+    <!--[if lte IE 8 ]><div id="IE8"><![endif]-->
     <div id="dokuwiki__site"><div id="dokuwiki__top" class="site <?php echo tpl_classes(); ?>">
 
         <?php include('tpl_header.php') ?>
@@ -120,6 +120,6 @@ header('X-UA-Compatible: IE=edge,chrome=1');
         <?php include('tpl_footer.php') ?>
     </div></div><!-- /site -->
 
-    <!--[if ( lte IE 7 | IE 8 ) ]></div><![endif]-->
+    <!--[if lte IE 8 ]></div><![endif]-->
 </body>
 </html>

--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -26,7 +26,7 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 </head>
 
 <body>
-    <!--[if lte IE 7 ]><div id="IE7"><![endif]--><!--[if IE 8 ]><div id="IE8"><![endif]-->
+    <!--[if lte IE 8 ]><div id="IE8"><![endif]-->
     <div id="dokuwiki__site"><div id="dokuwiki__top" class="site <?php echo tpl_classes(); ?> <?php
         echo ($showSidebar) ? 'showSidebar' : ''; ?> <?php echo ($hasSidebar) ? 'hasSidebar' : ''; ?>">
 
@@ -106,6 +106,6 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 
     <div class="no"><?php tpl_indexerWebBug() /* provide DokuWiki housekeeping, required in all templates */ ?></div>
     <div id="screen__mode" class="no"></div><?php /* helper to detect CSS media query in script.js */ ?>
-    <!--[if ( lte IE 7 | IE 8 ) ]></div><![endif]-->
+    <!--[if lte IE 8 ]></div><![endif]-->
 </body>
 </html>

--- a/lib/tpl/dokuwiki/mediamanager.php
+++ b/lib/tpl/dokuwiki/mediamanager.php
@@ -25,7 +25,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 </head>
 
 <body>
-    <!--[if lte IE 7 ]><div id="IE7"><![endif]--><!--[if IE 8 ]><div id="IE8"><![endif]-->
+    <!--[if lte IE 8 ]><div id="IE8"><![endif]-->
     <div id="media__manager" class="dokuwiki">
         <?php html_msgarea() ?>
         <div id="mediamgr__aside"><div class="pad">
@@ -41,6 +41,6 @@ header('X-UA-Compatible: IE=edge,chrome=1');
             <?php tpl_mediaContent() ?>
         </div></div>
     </div>
-    <!--[if ( lte IE 7 | IE 8 ) ]></div><![endif]-->
+    <!--[if lte IE 8 ]></div><![endif]-->
 </body>
 </html>


### PR DESCRIPTION
It's time!
We had actually decided a while ago (maybe two years?) that we wanted to drop support for IE7 but somehow no-one did anything. By now global usage has dropped to about 0.07%.

I removed everything that was clearly related to IE7. If there is anything in the JavaScript (but foolishly undeclared) I wouldn't have found it. If anyone knows/remembers if there is anything else IE7-related, please report it here.