### PR TITLE
Add 'returnonly' option even if no valid url is given (XHTML renderer)

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -914,7 +914,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         // is there still an URL?
         if(!$url) {
-            $this->doc .= $name;
+            if($returnonly) {
+                return $name;
+            } else {
+                $this->doc .= $name;
+            }
             return;
         }
 


### PR DESCRIPTION
This is a followup to PR splitbrain/dokuwiki/pull/1239 where the function externallink still wrote directly to $R->doc if no valid URL was given, ignoring the returnonly option. 