### PR TITLE
TEMPLATE_SITETOOLS_DISPLAY and TEMPLATE_USERTOOLS_DISPLAY

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1982,5 +1982,27 @@ function tpl_classes() {
     return join(' ', $classes);
 }
 
+/**
+ * Create event for tools menues
+ *
+ * @author Anika Henke <anika@selfthinker.org>
+ * @param string $toolsname name of menu
+ * @param array $items
+ * @param string $view e.g. 'main', 'detail', ...
+ */
+function tpl_toolsevent($toolsname, $items, $view = 'main') {
+    $data = array(
+        'view' => $view,
+        'items' => $items
+    );
+
+    $hook = 'TEMPLATE_' . strtoupper($toolsname) . '_DISPLAY';
+    $evt = new Doku_Event($hook, $data);
+    if($evt->advise_before()) {
+        foreach($evt->data['items'] as $k => $html) echo $html;
+    }
+    $evt->advise_after();
+}
+
 //Setup VIM: ex: et ts=4 :
 

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -46,10 +46,12 @@ if (!defined('DOKU_INC')) die();
                             tpl_userinfo(); /* 'Logged in as ...' */
                             echo '</li>';
                         }
-                        tpl_action('admin', true, 'li');
-                        tpl_action('profile', true, 'li');
-                        tpl_action('register', true, 'li');
-                        tpl_action('login', true, 'li');
+                        tpl_toolsevent('usertools', array(
+                            tpl_action('admin', true, 'li', true),
+                            tpl_action('profile', true, 'li', true),
+                            tpl_action('register', true, 'li', true),
+                            tpl_action('login', true, 'li', true)
+                        ));
                     ?>
                 </ul>
             </div>
@@ -64,9 +66,11 @@ if (!defined('DOKU_INC')) die();
             </div>
             <ul>
                 <?php
-                    tpl_action('recent', true, 'li');
-                    tpl_action('media', true, 'li');
-                    tpl_action('index', true, 'li');
+                    tpl_toolsevent('sitetools', array(
+                        tpl_action('recent', true, 'li', true),
+                        tpl_action('media', true, 'li', true),
+                        tpl_action('bds', true, 'li', true)
+                    ));
                 ?>
             </ul>
         </div>


### PR DESCRIPTION
re-add PR #470 again.

Edit:
Add event triggers that allow plugins to add buttons/links to the site tools or usertools (if supported by a template).

This pull request re-does an accidentally revert of the previous commit merged via #470
