### PR TITLE
TPL_ACTION_UNKNOWN event for building action/button links

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -779,7 +779,7 @@ function tpl_get_action($type) {
 
     $data = compact('accesskey', 'type', 'id', 'method', 'params', 'nofollow', 'replacement');
 
-    $evt = new Doku_Event('TPL_ACTION_UNKNOWN', $data);
+    $evt = new Doku_Event('TPL_ACTION_GET', $data);
     if($evt->advise_before()) {
         //handle unknown types
         if($unknown) {

--- a/inc/template.php
+++ b/inc/template.php
@@ -783,7 +783,7 @@ function tpl_get_action($type) {
     if($evt->advise_before()) {
         //handle unknown types
         if($unknown) {
-            $data = '[unknown %s type]'.$type;
+            $data = '[unknown %s type]';
         }
     }
     $evt->advise_after();

--- a/inc/template.php
+++ b/inc/template.php
@@ -647,6 +647,8 @@ function tpl_get_action($type) {
     $params      = array('do' => $type);
     $nofollow    = true;
     $replacement = '';
+
+    $unknown = false;
     switch($type) {
         case 'edit':
             // most complicated type - we need to decide on current action
@@ -771,9 +773,23 @@ function tpl_get_action($type) {
             //$type = 'media';
             break;
         default:
-            return '[unknown %s type]';
+            //unknown type
+            $unknown = true;
     }
-    return compact('accesskey', 'type', 'id', 'method', 'params', 'nofollow', 'replacement');
+
+    $data = compact('accesskey', 'type', 'id', 'method', 'params', 'nofollow', 'replacement');
+
+    $evt = new Doku_Event('TPL_ACTION_UNKNOWN', $data);
+    if($evt->advise_before()) {
+        //handle unknown types
+        if($unknown) {
+            $data = '[unknown %s type]'.$type;
+        }
+    }
+    $evt->advise_after();
+    unset($evt);
+
+    return $data;
 }
 
 /**


### PR DESCRIPTION
Alternative for #471, see question at that PR as well.

Put the event after the switch-case.

Current implementation let modify properties of core action/button-properties or adding new action.
```php
$evt = new Doku_Event('TPL_ACTION_UNKNOWN', $data);
    if($evt->advise_before()) {
        //handle unknown types
        if($unknown) {
            $data = '[unknown %s type]'.$type;
        }
    }
    $evt->advise_after();
    unset($evt);
```

If desired, handling of only unknown cases is possible by:
```php
if($unknown) {
    $evt = new Doku_Event('TPL_ACTION_UNKNOWN', $data);
    if($evt->advise_before()) {
        //handle unknown types
        $data = '[unknown %s type]'.$type;
    }
    $evt->advise_after();
    unset($evt);
}
```

Could replace and close #1277