### PR TITLE
Add a configuration option to hide the title in the page header.

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -32,6 +32,7 @@ $conf['allowdebug']  = 0;                 //allow debug output, enable if needed
 $conf['recent']      = 20;                //how many entries to show in recent
 $conf['recent_days'] = 7;                 //How many days of recent changes to keep. (days)
 $conf['breadcrumbs'] = 10;                //how many recent visited pages to show
+$conf['showtitle']   = 1;                 //show the wiki title beside the logo 0|1
 $conf['youarehere']  = 0;                 //show "You are here" navigation? 0|1
 $conf['fullpath']    = 0;                 //show full path of the document or relative to datadir only? 0|1
 $conf['typography']  = 1;                 //smartquote conversion 0=off, 1=doublequotes, 2=all quotes

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -69,6 +69,7 @@ $lang['allowdebug']  = 'Allow debug. <b>Disable if not needed!</b>';
 $lang['recent']      = 'Number of entries per page in the recent changes';
 $lang['recent_days'] = 'How many recent changes to keep (days)';
 $lang['breadcrumbs'] = 'Number of "trace" breadcrumbs. Set to 0 to disable.';
+$lang['showtitle']   = 'Show wiki title in the header beside the logo';
 $lang['youarehere']  = 'Use hierarchical breadcrumbs (you probably want to disable the above option then)';
 $lang['fullpath']    = 'Reveal full path of pages in the footer';
 $lang['typography']  = 'Do typographical replacements';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -111,6 +111,7 @@ $meta['_display']    = array('fieldset');
 $meta['recent']      = array('numeric');
 $meta['recent_days'] = array('numeric');
 $meta['breadcrumbs'] = array('numeric','_min' => 0);
+$meta['showtitle']   = array('onoff');
 $meta['youarehere']  = array('onoff');
 $meta['fullpath']    = array('onoff','_caution' => 'security');
 $meta['typography']  = array('multichoice','_choices' => array(0,1,2));

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -25,7 +25,7 @@ if (!defined('DOKU_INC')) die();
             // display logo and wiki title in a link to the home page
             tpl_link(
                 wl(),
-                '<img src="'.$logo.'" '.$logoSize[3].' alt="" /> <span>'.$conf['title'].'</span>',
+                '<img src="'.$logo.'" '.$logoSize[3].' alt="" /> <span>'.($conf['showtitle'] ? $conf['title'] : '').'</span>',
                 'accesskey="h" title="[H]"'
             );
         ?></h1>


### PR DESCRIPTION
I delete the wiki title every time I upgrade so thought it might be worth making this suggestion.

Is this the preferred way to handle a setting like this? It would probably make more sense to use the new style manager plugin instead of adding another global setting, but I couldn't see a way to implement a boolean setting.