### PR TITLE
Revert "Trim unnecessary / at start of windowssharelink"

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1033,7 +1033,6 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         $link['title'] = $this->_xmlEntities($url);
         $url           = str_replace('\\', '/', $url);
-        $url           = ltrim($url,'/');
         $url           = 'file:///'.$url;
         $link['url']   = $url;
 


### PR DESCRIPTION
Reverts splitbrain/dokuwiki#926

Windows share links didn't work anymore since that change. This is an alternative to the other solution (#1304). See also the bug report in #1302 ("Can not use the windows shares after the update to Detritus").