### PR TITLE
Form TagCloseElements should conform to expectations of functions inherited from Element

### DIFF
--- a/inc/Form/TagCloseElement.php
+++ b/inc/Form/TagCloseElement.php
@@ -34,11 +34,15 @@ class TagCloseElement extends ValueElement {
      * do not call this
      *
      * @param $id
-     * @return void
+     * @return string
      * @throws \BadMethodCallException
      */
     public function id($id = null) {
-        throw new \BadMethodCallException('You can\t add ID to closing tag');
+        if ($id === null) {
+            return '';
+        } else {
+            throw new \BadMethodCallException('You can\t add ID to closing tag');
+        }
     }
 
     /**
@@ -46,22 +50,30 @@ class TagCloseElement extends ValueElement {
      *
      * @param $name
      * @param $value
-     * @return void
+     * @return string
      * @throws \BadMethodCallException
      */
     public function attr($name, $value = null) {
-        throw new \BadMethodCallException('You can\t add attributes to closing tag');
+        if ($value === null) {
+            return '';
+        } else {
+            throw new \BadMethodCallException('You can\t add attributes to closing tag');
+        }
     }
 
     /**
      * do not call this
      *
      * @param $attributes
-     * @return void
+     * @return array
      * @throws \BadMethodCallException
      */
     public function attrs($attributes = null) {
-        throw new \BadMethodCallException('You can\t add attributes to closing tag');
+        if ($attributes === null) {
+            return array();
+        } else {
+            throw new \BadMethodCallException('You can\t add attributes to closing tag');
+        }
     }
 
     /**


### PR DESCRIPTION
`TagCloseElements` currently always throws an exception on `->id($id)`, `->attr($name, $value)` and `->attrs($attributs)` even when the parameters `$id` `$value` and `$attributs` are `null`/unset.
This behaviour breaks the `Form::findPositionByAttribute` function. This pull request makes the functions conform with the expectations derived from the original `Element` class' functions.

See also issue #1312