### PR TITLE
Change URLs to windows network shares

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1033,7 +1033,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         $link['title'] = $this->_xmlEntities($url);
         $url           = str_replace('\\', '/', $url);
-        $url           = 'file:///'.$url;
+        $url           = 'file:////'.$url;
         $link['url']   = $url;
 
         //output formatted


### PR DESCRIPTION
It is not possible for me to open links on a windows network share because it returns links like `file:///xyz`. With proposed change the slashes are properly excaped and it returns links like :`file://xyz`