### PR TITLE
multicheckbox without extra string input

### DIFF
--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -1186,7 +1186,7 @@ if (!class_exists('setting_multicheckbox')) {
 
         var $_choices = array();
         var $_combine = array();
-        var $_nostring = '';
+        var $_other = 'always';
 
         /**
          * update changed setting with user provided value $input
@@ -1270,16 +1270,20 @@ if (!class_exists('setting_multicheckbox')) {
             }
 
             // handle any remaining values
-            if ($this->_nostring != 'on') {
+            if ($this->_other != 'never'){
                 $other = join(',',$value);
-    
-                $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
-                                " selectiondefault" : "";
-    
-                $input .= '<div class="other'.$class.'">'."\n";
-                $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
-                $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
-                $input .= "</div>\n";
+                // test equivalent to ($this->_other == 'always' || ($other && $this->_other == 'exists')
+                // use != 'exists' rather than == 'always' to ensure invalid values default to 'always'
+                if ($this->_other != 'exists' || $other) {
+
+                    $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
+                                    " selectiondefault" : "";
+
+                    $input .= '<div class="other'.$class.'">'."\n";
+                    $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
+                    $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
+                    $input .= "</div>\n";
+                }
             }
             $label = '<label>'.$this->prompt($plugin).'</label>';
             return array($label,$input);

--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -1186,6 +1186,7 @@ if (!class_exists('setting_multicheckbox')) {
 
         var $_choices = array();
         var $_combine = array();
+        var $_nostring = 'off';
 
         /**
          * update changed setting with user provided value $input
@@ -1269,16 +1270,17 @@ if (!class_exists('setting_multicheckbox')) {
             }
 
             // handle any remaining values
-            $other = join(',',$value);
-
-            $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
-                            " selectiondefault" : "";
-
-            $input .= '<div class="other'.$class.'">'."\n";
-            $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
-            $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
-            $input .= "</div>\n";
-
+            if ($this->_nostring == 'off') {
+                $other = join(',',$value);
+    
+                $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
+                                " selectiondefault" : "";
+    
+                $input .= '<div class="other'.$class.'">'."\n";
+                $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
+                $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
+                $input .= "</div>\n";
+            }
             $label = '<label>'.$this->prompt($plugin).'</label>';
             return array($label,$input);
         }

--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -1186,7 +1186,7 @@ if (!class_exists('setting_multicheckbox')) {
 
         var $_choices = array();
         var $_combine = array();
-        var $_nostring = 'off';
+        var $_nostring = '';
 
         /**
          * update changed setting with user provided value $input
@@ -1270,7 +1270,7 @@ if (!class_exists('setting_multicheckbox')) {
             }
 
             // handle any remaining values
-            if ($this->_nostring == 'off') {
+            if ($this->_nostring != 'on') {
                 $other = join(',',$value);
     
                 $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -70,6 +70,12 @@
  *   '_pregflags'  - string, default 'ui', valid preg pattern modifiers used when testing regex input values, for more
  *                   information see http://uk1.php.net/manual/en/reference.pcre.pattern.modifiers.php
  *   '_multiple'   - bool, allow multiple comma separated email values; optional for 'email', ignored by others
+ *   '_other'      - how to handle other values (not listed in _choices). accepted values: 'always','exists','never'
+ *                   default value 'always'. 'exists' only shows 'other' input field when the setting contains value(s)
+ *                   not listed in choices (e.g. due to manual editing or update changing _choices).  This is safer than
+ *                   'never' as it will not discard unknown/other values.
+ *                   optional for 'multicheckbox', ignored by others
+ *
  *
  * @author    Chris Smith <chris@jalakai.co.uk>
  */


### PR DESCRIPTION
I think it would be "nice" to have a `multicheckbox` without the additional string input.

The widget `multicheckbox` could accept a parameter, say `_nostring` with value `on`, which disable the extra string, otherwise (default) it is created with it.

So the syntax would be:
```
// multicheckbox without the additional string input
$meta['multi'] = array('multicheckbox', '_nostring' => 'on', '_choices' => array('a','b','c','d'));

// multicheckbox with the additional string input (default)
$meta['multi'] = array('multicheckbox', '_choices' => array('a','b','c','d'));
```