### PR TITLE
add convenience function for empty check without 0

### DIFF
--- a/_test/tests/inc/common_blank.test.php
+++ b/_test/tests/inc/common_blank.test.php
@@ -36,15 +36,17 @@ class common_blank_test extends DokuWikiTest {
     }
 
     function test_trim() {
-        $blank = "   ";
-        $this->assertFalse(blank($blank));
-        $this->assertTrue(blank($blank, true));
+        $whitespace = " \t\r\n";
+        $this->assertFalse(blank($whitespace), "using default \$trim value");
+        $this->assertFalse(blank($whitespace, false), "using \$trim = false");
+        $this->assertTrue(blank($whitespace, true), "using \$trim = true");
     }
 
-    function test_undefindex() {
+    function test_undefined() {
         $undef = array();
-        $this->assertTrue(blank($undef['nope']));
-        $this->assertTrue(blank($this->nope));
+        $this->assertTrue(blank($var), "using undefined/unitialised variable");
+        $this->assertTrue(blank($undef['nope']), "using undefined array index");
+        $this->assertTrue(blank($this->nope), "using unset object property");
     }
 
 }

--- a/_test/tests/inc/common_blank.test.php
+++ b/_test/tests/inc/common_blank.test.php
@@ -1,0 +1,50 @@
+<?php
+
+class common_blank_test extends DokuWikiTest {
+
+    private $nope;
+
+    function test_blank() {
+        $tests = array(
+            // these are not blank
+            array('string', false),
+            array(1, false),
+            array(1.0, false),
+            array(0xff, false),
+            array(array('something'), false),
+
+            // these aren't either!
+            array('0', false),
+            array(' ', false),
+            array('0.0', false),
+            array(0, false),
+            array(0.0, false),
+            array(0x00, false),
+            array(true, false),
+
+            // but these are
+            array('', true),
+            array(array(), true),
+            array(null, true),
+            array(false, true),
+            array("\0", true)
+        );
+
+        foreach($tests as $test) {
+            $this->assertEquals($test[1], blank($test[0]), "using " . var_export($test[0], true));
+        }
+    }
+
+    function test_trim() {
+        $blank = "   ";
+        $this->assertFalse(blank($blank));
+        $this->assertTrue(blank($blank, true));
+    }
+
+    function test_undefindex() {
+        $undef = array();
+        $this->assertTrue(blank($undef['nope']));
+        $this->assertTrue(blank($this->nope));
+    }
+
+}

--- a/inc/common.php
+++ b/inc/common.php
@@ -31,6 +31,25 @@ function hsc($string) {
 }
 
 /**
+ * Checks if the given input is blank
+ *
+ * This is similar to empty() but will return false for "0".
+ *
+ * @param $in
+ * @param bool $trim Consider a string of whitespace to be blank
+ * @return bool
+ */
+function blank(&$in, $trim = false) {
+    if(!isset($in)) return true;
+    if(is_null($in)) return true;
+    if(is_array($in)) return empty($in);
+    if($in === "\0") return true;
+    if($trim && trim($in) === '') return true;
+    if(strlen($in) > 0) return false;
+    return empty($in);
+}
+
+/**
  * print a newline terminated string
  *
  * You can give an indention as optional parameter


### PR DESCRIPTION
This allows to quickly check if a variable is empty but keeps strings
and numbers evaluating to zero.

See #1359 