### PR TITLE
Add an ACL check in page_findnearest, fix #1369

### DIFF
--- a/_test/tests/inc/pageutils_findnearest.test.php
+++ b/_test/tests/inc/pageutils_findnearest.test.php
@@ -78,7 +78,7 @@ class pageutils_findnearest_test extends DokuWikiTest {
         $sidebar = page_findnearest('sidebar');
         $this->assertEquals('sidebar', $sidebar);
 
-        $sidebar = page_findnearest('sidebar', true);
+        $sidebar = page_findnearest('sidebar', false);
         $this->assertEquals('internal:sidebar', $sidebar);
 
         $INPUT->server->set('REMOTE_USER', 'max');

--- a/_test/tests/inc/pageutils_findnearest.test.php
+++ b/_test/tests/inc/pageutils_findnearest.test.php
@@ -1,6 +1,33 @@
 <?php
 
 class pageutils_findnearest_test extends DokuWikiTest {
+
+    var $oldAuthAcl;
+
+    function setUp() {
+        parent::setUp();
+        global $AUTH_ACL;
+        global $auth;
+        global $conf;
+        $conf['superuser'] = 'john';
+        $conf['useacl']    = 1;
+
+        $this->oldAuthAcl = $AUTH_ACL;
+        $auth = new DokuWiki_Auth_Plugin();
+
+        $AUTH_ACL = array(
+            '*           @ALL           1',
+            'internal:*    @ALL           0',
+            'internal:*    max            1',
+            '*           @user          8',
+        );
+    }
+
+    function tearDown() {
+        global $AUTH_ACL;
+        $AUTH_ACL = $this->oldAuthAcl;
+    }
+
     function testNoSidebar() {
         global $ID;
 
@@ -37,4 +64,26 @@ class pageutils_findnearest_test extends DokuWikiTest {
         $this->assertEquals('sidebar', $sidebar);
     }
 
+    function testACLWithSidebar() {
+        global $ID;
+        global $INPUT;
+
+        $INPUT->server->set('REMOTE_USER', 'foo');
+
+        saveWikiText('sidebar', 'top sidebar', '');
+        saveWikiText('internal:sidebar', 'internal sidebar', '');
+
+        $ID = 'internal:foo:bar';
+
+        $sidebar = page_findnearest('sidebar');
+        $this->assertEquals('sidebar', $sidebar);
+
+        $sidebar = page_findnearest('sidebar', true);
+        $this->assertEquals('internal:sidebar', $sidebar);
+
+        $INPUT->server->set('REMOTE_USER', 'max');
+
+        $sidebar = page_findnearest('sidebar');
+        $this->assertEquals('internal:sidebar', $sidebar);
+    }
 }

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -746,10 +746,10 @@ function utf8_decodeFN($file){
  * @todo   add event hook
  *
  * @param  string $page the pagename you're looking for
- * @param bool $ignoreacl If pages that can't be accessed by the current user shall be returend
+ * @param bool $useacl only return pages readable by the current user, false to ignore ACLs
  * @return false|string the full page id of the found page, false if any
  */
-function page_findnearest($page, $ignoreacl = false){
+function page_findnearest($page, $useacl = true){
     if (!$page) return false;
     global $ID;
 
@@ -757,7 +757,7 @@ function page_findnearest($page, $ignoreacl = false){
     do {
         $ns = getNS($ns);
         $pageid = cleanID("$ns:$page");
-        if(page_exists($pageid) && ($ignoreacl || auth_quickaclcheck($pageid) >= AUTH_READ)){
+        if(page_exists($pageid) && (!$useacl || auth_quickaclcheck($pageid) >= AUTH_READ)){
             return $pageid;
         }
     } while($ns);

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -757,7 +757,7 @@ function page_findnearest($page, $ignoreacl = false){
     do {
         $ns = getNS($ns);
         $pageid = cleanID("$ns:$page");
-        if(page_exists($pageid) && ($ignoreacl || auth_quickaclcheck($pageid) > 0)){
+        if(page_exists($pageid) && ($ignoreacl || auth_quickaclcheck($pageid) >= AUTH_READ)){
             return $pageid;
         }
     } while($ns);

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -738,24 +738,26 @@ function utf8_decodeFN($file){
 
 /**
  * Find a page in the current namespace (determined from $ID) or any
- * higher namespace
+ * higher namespace that can be accessed by the current user,
+ * this condition can be overriden by an optional parameter.
  *
  * Used for sidebars, but can be used other stuff as well
  *
  * @todo   add event hook
  *
  * @param  string $page the pagename you're looking for
- * @return string|false the full page id of the found page, false if any
+ * @param bool $ignoreacl If pages that can't be accessed by the current user shall be returend
+ * @return false|string the full page id of the found page, false if any
  */
-function page_findnearest($page){
+function page_findnearest($page, $ignoreacl = false){
     if (!$page) return false;
     global $ID;
 
     $ns = $ID;
     do {
         $ns = getNS($ns);
-        $pageid = ltrim("$ns:$page",':');
-        if(page_exists($pageid)){
+        $pageid = cleanID("$ns:$page");
+        if(page_exists($pageid) && ($ignoreacl || auth_quickaclcheck($pageid) > 0)){
             return $pageid;
         }
     } while($ns);

--- a/inc/template.php
+++ b/inc/template.php
@@ -1712,14 +1712,14 @@ function tpl_license($img = 'badge', $imgonly = false, $return = false, $wrap = 
  * @param string $pageid The page name you want to include
  * @param bool $print Should the content be printed or returned only
  * @param bool $propagate Search higher namespaces, too?
- * @param bool $ignoreacl Include the page without chcking ACLs?
+ * @param bool $useacl Include the page only if the ACLs check out?
  * @return bool|null|string
  */
-function tpl_include_page($pageid, $print = true, $propagate = false, $ignoreacl = false) {
+function tpl_include_page($pageid, $print = true, $propagate = false, $useacl = true) {
     if (!$pageid) return false;
     if($propagate) {
-        $pageid = page_findnearest($pageid, $ignoreacl);
-    } elseif(!$ignoreacl && auth_quickaclcheck($pageid) == AUTH_NONE) {
+        $pageid = page_findnearest($pageid, $useacl);
+    } elseif($useacl && auth_quickaclcheck($pageid) == AUTH_NONE) {
         return false;
     }
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -1716,20 +1716,19 @@ function tpl_license($img = 'badge', $imgonly = false, $return = false, $wrap = 
  * @return bool|null|string
  */
 function tpl_include_page($pageid, $print = true, $propagate = false, $useacl = true) {
-    if (!$pageid) return false;
     if($propagate) {
         $pageid = page_findnearest($pageid, $useacl);
     } elseif($useacl && auth_quickaclcheck($pageid) == AUTH_NONE) {
         return false;
     }
+    if(!$pageid) return false;
 
     global $TOC;
     $oldtoc = $TOC;
     $html   = p_wiki_xhtml($pageid, '', false);
     $TOC    = $oldtoc;
 
-    if(!$print) return $html;
-    echo $html;
+    if($print) echo $html;
     return $html;
 }
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -1709,14 +1709,19 @@ function tpl_license($img = 'badge', $imgonly = false, $return = false, $wrap = 
  * This function is useful to populate sidebars or similar features in a
  * template
  *
- * @param string $pageid
- * @param bool $print
- * @param bool $propagate
+ * @param string $pageid The page name you want to include
+ * @param bool $print Should the content be printed or returned only
+ * @param bool $propagate Search higher namespaces, too?
+ * @param bool $ignoreacl Include the page without chcking ACLs?
  * @return bool|null|string
  */
-function tpl_include_page($pageid, $print = true, $propagate = false) {
+function tpl_include_page($pageid, $print = true, $propagate = false, $ignoreacl = false) {
     if (!$pageid) return false;
-    if ($propagate) $pageid = page_findnearest($pageid);
+    if($propagate) {
+        $pageid = page_findnearest($pageid, $ignoreacl);
+    } elseif(!$ignoreacl && auth_quickaclcheck($pageid) == AUTH_NONE) {
+        return false;
+    }
 
     global $TOC;
     $oldtoc = $TOC;


### PR DESCRIPTION
This means that templates that use this function will no longer display
pages like sidebars that can't be accessed by the current user.