### PR TITLE
Optimizations to autoloader

### DIFF
--- a/inc/load.php
+++ b/inc/load.php
@@ -115,7 +115,7 @@ function load_autoload($name){
     $name = str_replace('\\', '/', $name);
     if(substr($name, 0, 9) == 'dokuwiki/') {
         require substr($name, 9) . '.php';
-        return true
+        return true;
     }
 
     // Plugin loading

--- a/inc/load.php
+++ b/inc/load.php
@@ -107,14 +107,15 @@ function load_autoload($name){
     );
 
     if(isset($classes[$name])){
-        require_once($classes[$name]);
-        return;
+        require ($classes[$name]);
+        return true;
     }
 
     // our own namespace
     $name = str_replace('\\', '/', $name);
     if(substr($name, 0, 9) == 'dokuwiki/') {
-        require_once(substr($name, 9) . '.php');
+        require substr($name, 9) . '.php';
+        return true
     }
 
     // Plugin loading
@@ -124,9 +125,9 @@ function load_autoload($name){
         $c = ((count($m) === 4) ? "/{$m[3]}" : '');
         $plg = DOKU_PLUGIN . "{$m[2]}/{$m[1]}$c.php";
         if(file_exists($plg)){
-            include_once DOKU_PLUGIN . "{$m[2]}/{$m[1]}$c.php";
+            include $plg;
         }
-        return;
+        return true;
     }
 }
 


### PR DESCRIPTION
Autoloader should return true if it can handle the class so other registered autoloader don't execute.
require is faster than require_once and should be safe to use since the autoloader won't run if the class already exists