### PR TITLE
Show specific error messages if user creation fails

### DIFF
--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -518,16 +518,20 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
                     $pass = auth_pwgen($user);
                 } else {
                     msg($this->lang['add_fail'], -1);
+                    msg($this->lang['addUser_error_missing_pass'], -1);
                     return false;
                 }
             } else {
                 if (!$this->_verifyPassword($pass,$passconfirm)) {
+                    msg($this->lang['add_fail'], -1);
+                    msg($this->lang['addUser_error_pass_not_identical'], -1);
                     return false;
                 }
             }
         } else {
             if (!empty($pass)){
                 msg($this->lang['add_fail'], -1);
+                msg($this->lang['addUser_error_modPass_disabled'], -1);
                 return false;
             }
         }
@@ -535,10 +539,13 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         if ($this->_auth->canDo('modName')){
             if (empty($name)){
                 msg($this->lang['add_fail'], -1);
+                msg($this->lang['addUser_error_name_missing'], -1);
                 return false;
             }
         } else {
             if (!empty($name)){
+                msg($this->lang['add_fail'], -1);
+                msg($this->lang['addUser_error_modName_disabled'], -1);
                 return false;
             }
         }
@@ -546,10 +553,13 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         if ($this->_auth->canDo('modMail')){
             if (empty($mail)){
                 msg($this->lang['add_fail'], -1);
+                msg($this->lang['addUser_error_mail_missing'], -1);
                 return false;
             }
         } else {
             if (!empty($mail)){
+                msg($this->lang['add_fail'], -1);
+                msg($this->lang['addUser_error_modMail_disabled'], -1);
                 return false;
             }
         }
@@ -563,6 +573,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
             }
         } else {
             msg($this->lang['add_fail'], -1);
+            msg($this->lang['addUser_error_create_event_failed'], -1);
         }
 
         return $ok;

--- a/lib/plugins/usermanager/lang/en/lang.php
+++ b/lib/plugins/usermanager/lang/en/lang.php
@@ -76,3 +76,11 @@ $lang['import_error_create']  = 'Unable to create the user';
 $lang['import_notify_fail']   = 'Notification message could not be sent for imported user, %s with email %s.';
 $lang['import_downloadfailures'] = 'Download Failures as CSV for correction';
 
+$lang['addUser_error_missing_pass'] = 'Please either set a password or activate user notification to enable password generation.';
+$lang['addUser_error_pass_not_identical'] = 'The entered passwords were not identical.';
+$lang['addUser_error_modPass_disabled'] = 'Modifing passwords is currently disabled';
+$lang['addUser_error_name_missing'] = 'Please enter a name for the new user.';
+$lang['addUser_error_modName_disabled'] = 'Modifing names is currently disabled.';
+$lang['addUser_error_mail_missing'] = 'Please enter an Email-Adress for the new user.';
+$lang['addUser_error_modMail_disabled'] = 'Modifing Email-Adresses is currently disabled.';
+$lang['addUser_error_create_event_failed'] = 'The create UserMod event failed.';

--- a/lib/plugins/usermanager/lang/en/lang.php
+++ b/lib/plugins/usermanager/lang/en/lang.php
@@ -83,4 +83,4 @@ $lang['addUser_error_name_missing'] = 'Please enter a name for the new user.';
 $lang['addUser_error_modName_disabled'] = 'Modifing names is currently disabled.';
 $lang['addUser_error_mail_missing'] = 'Please enter an Email-Adress for the new user.';
 $lang['addUser_error_modMail_disabled'] = 'Modifing Email-Adresses is currently disabled.';
-$lang['addUser_error_create_event_failed'] = 'The create UserMod event failed.';
+$lang['addUser_error_create_event_failed'] = 'A plugin prevented the new user being added. Review possible other messages for more information.';


### PR DESCRIPTION
Currently only a too general message `'User addition failed'` is shown, without indicating the specific cause of the failure.
This pull request adds more specific messages to each failure.

This should fix #1172 and also its duplicate #1371. Hence we it closes #1173.