### PR TITLE
Add an in-progress class to the quicksearch form.

### DIFF
--- a/lib/scripts/qsearch.js
+++ b/lib/scripts/qsearch.js
@@ -45,6 +45,7 @@ jQuery.fn.dw_qsearch = function (overrides) {
                     dw_qsearch.clear_results();
                     return;
                 }
+                dw_qsearch.$inObj.parents('form').addClass('searching');
                 dw_qsearch.curRequest = jQuery.post(
                     DOKU_BASE + 'lib/exe/ajax.php',
                     {
@@ -81,6 +82,7 @@ jQuery.fn.dw_qsearch = function (overrides) {
          * Empty and hide the output div
          */
         clear_results: function () {
+            dw_qsearch.$inObj.parents('form').removeClass('searching');
             dw_qsearch.$outObj.hide();
             dw_qsearch.$outObj.text('');
         },
@@ -95,6 +97,7 @@ jQuery.fn.dw_qsearch = function (overrides) {
          */
         onCompletion: function (data) {
             var max, $links, too_big;
+            dw_qsearch.$inObj.parents('form').removeClass('searching');
 
             dw_qsearch.curRequest = null;
 


### PR DESCRIPTION
This change adds a new class to the quicksearch's form
element while the quicksearch is running. This is to
make it easier to style the form, e.g. with a throbber gif
in the search box, to indicate that something is happening.
For slow connections, it is sometimes not apparent that
waiting for a few seconds will present the user with a list
of matching pagenames.

The new 'searching' class is added just before the POST
request is sent, and cleared both on successful completion
and when the search box is cleared.