### PR TITLE
[WiP] Deactivate XSS-Protection during preview

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -29,6 +29,8 @@ function act_dispatch(){
 
     // give plugins an opportunity to process the action
     $evt = new Doku_Event('ACTION_ACT_PREPROCESS',$ACT);
+
+    $headers = array();
     if ($evt->advise_before()) {
 
         //sanitize $ACT
@@ -144,8 +146,10 @@ function act_dispatch(){
             $ACT = act_draftdel($ACT);
 
         //draft saving on preview
-        if($ACT == 'preview')
+        if($ACT == 'preview') {
+            $headers[] = "X-XSS-Protection: 0";
             $ACT = act_draftsave($ACT);
+        }
 
         //edit
         if(in_array($ACT, array('edit', 'preview', 'recover'))) {
@@ -189,7 +193,6 @@ function act_dispatch(){
     global $license;
 
     //call template FIXME: all needed vars available?
-    $headers = array();
     $headers[] = 'Content-Type: text/html; charset=utf-8';
     trigger_event('ACTION_HEADERS_SEND',$headers,'act_sendheaders');
 


### PR DESCRIPTION
The motivation is to work around/fix issue #1182.

My preferred way to handle this situation would be to use a `Content-Security-Policy`-header. However using `header('Content-Security-Policy: script-src * \'unsafe-inline\' \'unsafe-eval\'')`, i.e. allowing everything, did not have any visible effect and did not fix the problem. This is despite the fact that the actual errormessage says `The XSS Auditor refused to execute a script in 'http://127.0.0.1/~michael/dokuwiki/doku.php' because its source code was found within the request. The auditor was enabled as the server sent neither an 'X-XSS-Protection' nor 'Content-Security-Policy' header.`

ToDo:
- [ ] Implement a check for Chrome only.