### PR TITLE
error fix with php 5.5+ for is_writable with NOBODY

### DIFF
--- a/inc/SimplePie.php
+++ b/inc/SimplePie.php
@@ -3395,7 +3395,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	 */
 	public function save($data)
 	{
-		if (file_exists($this->name) && is_writeable($this->name) || file_exists($this->location) && is_writeable($this->location))
+		if (file_exists($this->name) && iswritable($this->name) || file_exists($this->location) && iswritable($this->location))
 		{
 			if ($data instanceof SimplePie)
 			{
@@ -12394,7 +12394,7 @@ class SimplePie_Misc
 			}
 
 			$log_file = @ini_get('error_log');
-			if (!empty($log_file) && ('syslog' !== $log_file) && !@is_writable($log_file))
+			if (!empty($log_file) && ('syslog' !== $log_file) && !@iswritable($log_file))
 			{
 				$log_error = false;
 			}

--- a/inc/Sitemapper.php
+++ b/inc/Sitemapper.php
@@ -34,9 +34,9 @@ class Sitemapper {
         $sitemap = Sitemapper::getFilePath();
 
         if(file_exists($sitemap)){
-            if(!is_writable($sitemap)) return false;
+            if(!iswritable($sitemap)) return false;
         }else{
-            if(!is_writable(dirname($sitemap))) return false;
+            if(!iswritable(dirname($sitemap))) return false;
         }
 
         if(@filesize($sitemap) &&

--- a/inc/common.php
+++ b/inc/common.php
@@ -226,7 +226,7 @@ function pageinfo() {
     }
     $info['rev'] = $REV;
     if($info['exists']) {
-        $info['writable'] = (is_writable($info['filepath']) &&
+        $info['writable'] = (iswritable($info['filepath']) &&
             ($info['perm'] >= AUTH_EDIT));
     } else {
         $info['writable'] = ($info['perm'] >= AUTH_CREATE);

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -138,7 +138,7 @@ function check(){
         }
     }
 
-    if(is_writable($conf['changelog'])){
+    if(iswritable($conf['changelog'])){
         msg('Changelog is writable',1);
     }else{
         if (file_exists($conf['changelog'])) {
@@ -161,7 +161,7 @@ function check(){
         }
     }
 
-    if(is_writable(DOKU_CONF)){
+    if(iswritable(DOKU_CONF)){
         msg('conf directory is writable',1);
     }else{
         msg('conf directory is not writable',-1);
@@ -169,7 +169,7 @@ function check(){
 
     if($conf['authtype'] == 'plain'){
         global $config_cascade;
-        if(is_writable($config_cascade['plainauth.users']['default'])){
+        if(iswritable($config_cascade['plainauth.users']['default'])){
             msg('conf/users.auth.php is writable',1);
         }else{
             msg('conf/users.auth.php is not writable',0);
@@ -220,7 +220,7 @@ function check(){
 
     msg('Your current permission for this page is '.$INFO['perm'],0);
 
-    if(is_writable($INFO['filepath'])){
+    if(iswritable($INFO['filepath'])){
         msg('The current page is writable by the webserver',0);
     }else{
         msg('The current page is not writable by the webserver',0);

--- a/inc/init.php
+++ b/inc/init.php
@@ -3,6 +3,22 @@
  * Initialize some defaults needed for DokuWiki
  */
 
+function iswritable($filename) {
+	//echo PHP_VERSION_ID; die;
+	//return is_writable($filename);
+	
+	// check writability
+	$perms = fileperms($filename);
+	if (($perms & 0x0080) || // owner can write
+		($perms & 0x0010) || // group
+		($perms & 0x0002) // other
+	) {
+		return true;
+	}
+	
+	return false;
+}
+
 /**
  * timing Dokuwiki execution
  */
@@ -348,7 +364,7 @@ function init_path($path){
     }
 
     // check writability
-    if(!@is_writable($p)){
+    if(!@iswritable($p)){
         return '';
     }
 

--- a/inc/search.php
+++ b/inc/search.php
@@ -174,7 +174,7 @@ function search_media(&$data,$base,$file,$type,$lvl,$opts){
     $info['file']     = utf8_basename($file);
     $info['size']     = filesize($base.'/'.$file);
     $info['mtime']    = filemtime($base.'/'.$file);
-    $info['writable'] = is_writable($base.'/'.$file);
+    $info['writable'] = iswritable($base.'/'.$file);
     if(preg_match("/\.(jpe?g|gif|png)$/",$file)){
         $info['isimg'] = true;
         $info['meta']  = new JpegMeta($base.'/'.$file);
@@ -423,7 +423,7 @@ function search_universal(&$data,$base,$file,$type,$lvl,$opts){
         $item['size']       = filesize($base.'/'.$file);
         $item['mtime']      = filemtime($base.'/'.$file);
         $item['rev']        = $item['mtime'];
-        $item['writable']   = is_writable($base.'/'.$file);
+        $item['writable']   = iswritable($base.'/'.$file);
         $item['executable'] = is_executable($base.'/'.$file);
     }
 

--- a/install.php
+++ b/install.php
@@ -5,6 +5,22 @@
  * @author      Chris Smith <chris@jalakai.co.uk>
  */
 
+function iswritable($filename) {
+	//echo PHP_VERSION_ID; die;
+	//return is_writable($filename);
+
+	// check writability
+	$perms = fileperms($filename);
+	if (($perms & 0x0080) || // owner can write
+		($perms & 0x0010) || // group
+		($perms & 0x0002) // other
+	) {
+		return true;
+	}
+
+	return false;
+}
+
 if(!defined('DOKU_INC')) define('DOKU_INC',dirname(__FILE__).'/');
 if(!defined('DOKU_CONF')) define('DOKU_CONF',DOKU_INC.'conf/');
 if(!defined('DOKU_LOCAL')) define('DOKU_LOCAL',DOKU_INC.'conf/');
@@ -536,7 +552,9 @@ function check_permissions(){
 
     $ok = true;
     foreach($dirs as $dir){
-        if(!file_exists("$dir/.") || !is_writable($dir)){
+        if(!file_exists("$dir/.") || !iswritable($dir)){
+        	
+        	var_dump(is_writable($dir)); die;
             $dir     = str_replace($_SERVER['DOCUMENT_ROOT'],'{DOCUMENT_ROOT}', $dir);
             $error[] = sprintf($lang['i_permfail'],$dir);
             $ok      = false;


### PR DESCRIPTION
http://php.net/manual/en/function.is-writable.php

fix access for NOBODY by replacing bugged php function is_writable() with lower lvl one as is_writable() does not check group membership of PHP 5.5+ (since 5.5.16 or something)

w/o it doku will keep saying "The datadir ('pages') at ./data/pages is not found, isn't accessible or writable ....."

as it sees zero permissions though they were granted. 


p.s.
this how i fixed it for myself, it doesnt looks good, but it works. also wiki has to many write checks as for me, fopen can be replaced with file_puts_contents etc.


regards