### PR TITLE
* Added missing 'userchangefail' in English to authad.

### DIFF
--- a/lib/plugins/authad/lang/en/lang.php
+++ b/lib/plugins/authad/lang/en/lang.php
@@ -9,6 +9,7 @@
 $lang['domain']          = 'Logon Domain';
 $lang['authpwdexpire']   = 'Your password will expire in %d days, you should change it soon.';
 $lang['passchangefail']  = 'Failed to change the password. Maybe the password policy was not met?';
+$lang['userchangefail']  = 'Failed to change user attributes. Maybe your account does not have permissions to make changes?';
 $lang['connectfail']     = 'Failed to connect to Active Directory server.';
 
 //Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
I was generating this error with the authad plugin but since there is no message defined, I was getting an empty error prompt.