### PR TITLE
Disable/enable user editing of AD display name or email address

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -119,8 +119,8 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin {
         }
 
         // other can do's are changed in $this->_loadServerConfig() base on domain setup
-        $this->cando['modName'] = true;
-        $this->cando['modMail'] = true;
+        $this->cando['modName'] = (bool)$this->conf['update_name'];
+        $this->cando['modMail'] = (bool)$this->conf['update_mail'];
         $this->cando['getUserCount'] = true;
     }
 

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -13,3 +13,5 @@ $conf['use_tls']            = 0;
 $conf['debug']              = 0;
 $conf['expirywarn']         = 0;
 $conf['additional']         = '';
+$conf['update_name']        = 0;
+$conf['update_mail']        = 0;

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -13,3 +13,5 @@ $meta['use_tls']            = array('onoff','_caution' => 'danger');
 $meta['debug']              = array('onoff','_caution' => 'security');
 $meta['expirywarn']         = array('numeric', '_min'=>0,'_caution' => 'danger');
 $meta['additional']         = array('string','_caution' => 'danger');
+$meta['update_name']        = array('onoff','_caution' => 'danger');
+$meta['update_mail']        = array('onoff','_caution' => 'danger');

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -13,3 +13,5 @@ $lang['use_tls']            = 'Use TLS connection? If used, do not enable SSL ab
 $lang['debug']              = 'Display additional debugging output on errors?';
 $lang['expirywarn']         = 'Days in advance to warn user about expiring password. 0 to disable.';
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
+$lang['update_name']        = 'Allow users to update their AD display name?';
+$lang['update_mail']        = 'Allow users to update their email address?';


### PR DESCRIPTION
* Created two new options to enable or disable the editing of the display name or the email address in Active Directory. This will allow for the admin to turn the edit feature off if it is not desired that the user could edit their attributes or to prevent errors in case AD does not permit the user to update these attributes.

I split this out from my last update as this is a new feature and there possibly will be more discussion around this.