### PR TITLE
Fixed bug in obtainLock(), where it always fails to verify the lock. …

### DIFF
--- a/bin/dwpage.php
+++ b/bin/dwpage.php
@@ -248,7 +248,7 @@ class PageCLI extends DokuCLI {
 
         lock($wiki_id);
 
-        if(checklock($wiki_id) != $this->username) {
+        if(checklock($wiki_id)) {
             $this->error("Unable to obtain lock for $wiki_id ");
             var_dump(checklock($wiki_id));
             exit(1);


### PR DESCRIPTION
obtainLock() calls checklock() and wrongly compares the return value to $this->username.
However, checklock() actually returns "false" if it verifies there is a lock belonging to $this->username.

…This fixes #1019, fixes #1311