### PR TITLE
set TO header when sending BCC only mail #1422

### DIFF
--- a/_test/tests/inc/mailer.test.php
+++ b/_test/tests/inc/mailer.test.php
@@ -169,6 +169,16 @@ class mailer_test extends DokuWikiTest {
         $this->assertEquals(0, preg_match('/(^|\n)To: (\n|$)/', $header), 'To found in headers.');
     }
 
+    function test_BBConly() {
+        $mail = new TestMailer();
+        $mail->bcc('some one <mail@example.com>');
+        $mail->cleanHeaders();
+        $headers = $mail->prop('headers');
+
+        $this->assertEquals('some one <mail@example.com>', $headers['Bcc']);
+        $this->assertEquals('undisclosed-recipients:;', $headers['To']);
+    }
+
     /**
      * @group internet
      */

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -544,6 +544,10 @@ class Mailer {
                 $this->headers[$addr] = $this->cleanAddress($this->headers[$addr]);
             }
         }
+        // make sure there's a To header when sending to BCC only #1422
+        if(isset($this->headers['Bcc']) && !isset($this->headers['To'])) {
+            $this->headers['To'] = 'undisclosed-recipients:;';
+        }
 
         if(isset($this->headers['Subject'])) {
             // add prefix to subject


### PR DESCRIPTION
When sending a mail to BCC reveivers only, the TO header should be set to undisclosed-recipients:; Usually this is done automatically by the MTA, but some seem to reject the mail instead.

Would be helpful if a few people could test this with real world MTAs.