### PR TITLE
Add a class for submit buttons for customizations.

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -227,6 +227,7 @@ function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label
         $ret .= 'accesskey="'.$akey.'" ';
     }
     $ret .= 'title="'.$tip.'" ';
+    $ret .= 'class="sub_'.$name.'" ';
     $ret .= '/>';
     $ret .= hsc($label);
     $ret .= '</button>';


### PR DESCRIPTION
Hello!

I have made a small modification to dokuwiki that adds a class for the submit buttons that are rendered in `inc/html.php`. The advantage in doing so is that it allows the customisation of individual buttons - for example, you could replace the buttons in CSS with images, or set the background colour, etc...

![buttons-css](https://cloud.githubusercontent.com/assets/6966515/12011199/40a584f2-accd-11e5-8287-d636a43f2745.png)

In the attached image is still a work in progress but the buttons have been replaced by icons entirely in CSS by adding the snippet:

	button.sub_media,
	button.sub_media:hover,
	button.sub_media:active,
	button.sub_media:focus {
		background-image: url(/lib/tpl/was/images/login-icon.png);
	    background-repeat: no-repeat;
	    background-position: center;
	    font-size: 0;
	    line-height: 0;
	    width: 32px;
	    height: 32px;
	    border-style: none !important;
	    border: 0px;
	    background-color: transparent;
	    vertical-align: middle;
	    -moz-box-sizing: border-box;
	    -webkit-box-sizing: border-box;
	    box-sizing: border-box;
	}

to the `css/basic.css` of the theme. For example, for the ``Edit`` button, this would generate the HTML:

    	<button type="submit" accesskey="e" title="Edit [E]" class="sub_edit">Edit</button>

In case this is useful, please apply - you can also change the name of the generated class. Right now it is generated as the concatenation between the string `sub_` (from submit) and the name of the button. For example: `sub_edit`, `sub_media`, `sub_revs`, etc...

This does not break the default theme since the `sub_` classes will not be defined in CSS and thus they will inherit from `button`. In fact, if the `sub_` classes are not defined at all, then the usual buttons will appear.

Thank you!