### PR TITLE
Keep searches within wiki/data/pages

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -24,6 +24,9 @@ if(!defined('DOKU_INC')) die('meh.');
  * @author  Andreas Gohr <andi@splitbrain.org>
  */
 function search(&$data,$base,$func,$opts,$dir='',$lvl=1,$sort='natural'){
+    $rootpath=DOKU_INC.'data/pages/';    
+    if (substr($base,0,strlen($rootpath))<>$rootpath) $base=$rootpath;
+
     $dirs   = array();
     $files  = array();
     $filepaths = array();


### PR DESCRIPTION
Found an issue where a plugin was calling the search function against the OS's file system root directory (As in / ) in Linux.  This enforces searching the confines of dokuwiki pages.

I've tested against several other plugins (Namely ORPHANSWANTED and the CHANGES) and have the results I expect.