### PR TITLE
do not accept empty or root $base in search. fixes #1452

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -28,6 +28,11 @@ function search(&$data,$base,$func,$opts,$dir='',$lvl=1,$sort='natural'){
     $files  = array();
     $filepaths = array();
 
+    // safeguard against runaways #1452
+    if($base == '' || $base == '/') {
+        throw new RuntimeException('No valid $base passed to search() - possible misconfiguration or bug');
+    }
+
     //read in directories and files
     $dh = @opendir($base.'/'.$dir);
     if(!$dh) return;


### PR DESCRIPTION
You really never want to search the whole filesystem, so something must
have gone wrong. Better abort than go on.

This replaces #1453 

@michitux @Pontiac76