### PR TITLE
Made internallink pattern inner section not greedy to prevent link ex…

### DIFF
--- a/_test/tests/inc/parser/parser_links.test.php
+++ b/_test/tests/inc/parser/parser_links.test.php
@@ -289,6 +289,21 @@ class TestOfDoku_Parser_Links extends TestOfDoku_Parser {
         $this->assertEquals(array_map('stripByteIndex',$this->H->calls),$calls);
     }
 
+    function testExternalInInternalLinkNoExtensionToThreeSquareBrackets() {
+        $this->P->addMode('internallink',new Doku_Parser_Mode_InternalLink());
+        $this->P->parse("Foo [[https://www.dokuwiki.org/faq:support|[DokuWiki] Support]] [Bar[Foo[Bar]]]");
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('externallink',array('https://www.dokuwiki.org/faq:support','[DokuWiki] Support')),
+            array('cdata',array(' [Bar[Foo[Bar]]]')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripByteIndex',$this->H->calls),$calls);
+    }
+
     function testInterwikiLink() {
         $this->P->addMode('internallink',new Doku_Parser_Mode_InternalLink());
         $this->P->parse("Foo [[iw>somepage|Some Page]] Bar");
@@ -686,6 +701,5 @@ class TestOfDoku_Parser_Links extends TestOfDoku_Parser {
         );
         $this->assertEquals(array_map('stripByteIndex',$this->H->calls),$calls);
     }
-
 }
 

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -895,7 +895,7 @@ class Doku_Parser_Mode_internallink extends Doku_Parser_Mode {
 
     function connectTo($mode) {
         // Word boundaries?
-        $this->Lexer->addSpecialPattern("\[\[(?:(?:[^[\]]*?\[.*?\])|.*?)\]\]",$mode,'internallink');
+        $this->Lexer->addSpecialPattern("\[\[(?:(?:[^[\]]*?\[.*?\])|.*?)+?\]\]",$mode,'internallink');
     }
 
     function getSort() {


### PR DESCRIPTION
…tension. Fixes #829.

Hi,
please check and merge if OK.

Honestly I don't understand to 100% why it fixes the problem. I find it strange that if you replace the `+?` with a single `+` or `*` then that also fixes the problem.
Regards,
Lars
