### PR TITLE
Added (failing) test for the new blank() function

### DIFF
--- a/_test/tests/inc/common_blank.test.php
+++ b/_test/tests/inc/common_blank.test.php
@@ -35,6 +35,12 @@ class common_blank_test extends DokuWikiTest {
         }
     }
 
+    function test_array() {
+        $foo = array();
+        blank($foo['bar']['baz']);
+        $this->assertFalse(isset($foo['bar']));
+    }
+
     function test_trim() {
         $whitespace = " \t\r\n";
         $this->assertFalse(blank($whitespace), "using default \$trim value");


### PR DESCRIPTION
This test illustrates a problem with the new blank function. When used on a multidimensional array, it will create upperlevel keys. I'm a bit at a loss how to fix that currently and am hoping for input.

See https://github.com/splitbrain/dokuwiki/blob/master/inc/common.php#L33 for the ``blank()`` function definition.

Any ideas how to solve this?

@dom-mel @Chris--S @michitux @micgro42 