### PR TITLE
make reuse of mediamanager popup easier

### DIFF
--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -257,7 +257,7 @@ var dw_mediamanager = {
         edid = String.prototype.match.call(document.location, /&edid=([^&]+)/);
         edid = edid ? edid[1] : 'wiki__text';
         cb   = String.prototype.match.call(document.location, /&onselect=([^&]+)/);
-        cb   = cb ? cb[1] : 'dw_mediamanager_item_select';
+        cb   = cb ? cb[1].replace(/[^\w]+/, '') : 'dw_mediamanager_item_select';
 
         opener[cb](edid, id, opts, dw_mediamanager.align);
         if(!dw_mediamanager.keepopen) {

--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -214,14 +214,12 @@ var dw_mediamanager = {
      * @author Pierre Spring <pierre.spring@caillou.ch>
      */
     insert: function (id) {
-        var opts, alignleft, alignright, edid, s;
+        var opts, cb, edid, s;
 
         // set syntax options
         dw_mediamanager.$popup.dialog('close');
 
         opts = '';
-        alignleft = '';
-        alignright = '';
 
         if ({img: 1, swf: 1}[dw_mediamanager.ext] === 1) {
 
@@ -254,22 +252,22 @@ var dw_mediamanager = {
                         }
                     }
                 }
-                if (dw_mediamanager.align !== '1') {
-                    alignleft = dw_mediamanager.align === '2' ? '' : ' ';
-                    alignright = dw_mediamanager.align === '4' ? '' : ' ';
-                }
             }
         }
         edid = String.prototype.match.call(document.location, /&edid=([^&]+)/);
-        opener.insertTags(edid ? edid[1] : 'wiki__text',
-                          '{{'+alignleft+id+opts+alignright+'|','}}','');
+        edid = edid ? edid[1] : 'wiki__text';
+        cb   = String.prototype.match.call(document.location, /&onselect=([^&]+)/);
+        cb   = cb ? cb[1] : 'dw_mediamanager_item_select';
 
+        opener[cb](edid, id, opts, dw_mediamanager.align);
         if(!dw_mediamanager.keepopen) {
             window.close();
         }
         opener.focus();
         return false;
     },
+
+
 
     /**
      * Prefills the wikiname.
@@ -920,5 +918,26 @@ var dw_mediamanager = {
         return jQuery.grep(['1', '2', '3', '4'], allowed)[0] || false;
     }
 };
+
+/**
+ * Default implementation for the media manager's select action
+ *
+ * Can be overriden with the onselect URL parameter. Is called on the opener context
+ *
+ * @param {string} edid
+ * @param {string} mediaid
+ * @param {string} opts
+ * @param {string} align [none, left, center, right]
+ */
+function dw_mediamanager_item_select(edid, mediaid, opts, align) {
+    var alignleft = '';
+    var alignright = '';
+    if (align !== '1') {
+        alignleft = align === '2' ? '' : ' ';
+        alignright = align === '4' ? '' : ' ';
+    }
+
+    insertTags(edid, '{{' + alignleft + mediaid + opts + alignright + '|', '}}', '');
+}
 
 jQuery(dw_mediamanager.init);


### PR DESCRIPTION
This introduces a mechanism to override what happens when a media item is selected in the media manager popup by providing a callback name in the URL. The default implementation just does what dw_mediamanager.insert did before and calls insertTags()

- [x] is passing the callback name security relevant? How to prevent misuse?
- [ ] should the parameters passed be somewhat nicer?