### PR TITLE
#1477:Search heading still displayed although search disabled

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -303,10 +303,13 @@ function tpl_metaheaders($alt = true) {
 
     // the usual stuff
     $head['meta'][] = array('name'=> 'generator', 'content'=> 'DokuWiki');
-    $head['link'][] = array(
-        'rel' => 'search', 'type'=> 'application/opensearchdescription+xml',
-        'href'=> DOKU_BASE.'lib/exe/opensearch.php', 'title'=> $conf['title']
-    );
+    if(actionOK('search')) {
+        $head['link'][] = array(
+            'rel' => 'search', 'type'=> 'application/opensearchdescription+xml',
+            'href'=> DOKU_BASE.'lib/exe/opensearch.php', 'title'=> $conf['title']
+        );
+    }
+
     $head['link'][] = array('rel'=> 'start', 'href'=> DOKU_BASE);
     if(actionOK('index')) {
         $head['link'][] = array(


### PR DESCRIPTION
Hello, this is my first commit to Dokuwiki, please tell me if I am missing something or so. I tried running the unit tests, and a number of them were skipped. I read through the tests, and most likely, the skips were due to my setup. 

Ran codesniffer, which got upset at some comments in the file, namely those at 535-539 and 574-580. I did not touch those as I would not know what to do with them.