### PR TITLE
Move the output of a sidebar after a page content

### DIFF
--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -34,19 +34,6 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 
         <div class="wrapper group">
 
-            <?php if($showSidebar): ?>
-                <!-- ********** ASIDE ********** -->
-                <div id="dokuwiki__aside"><div class="pad aside include group">
-                    <h3 class="toggle"><?php echo $lang['sidebar'] ?></h3>
-                    <div class="content"><div class="group">
-                        <?php tpl_flush() ?>
-                        <?php tpl_includeFile('sidebarheader.html') ?>
-                        <?php tpl_include_page($conf['sidebar'], true, true) ?>
-                        <?php tpl_includeFile('sidebarfooter.html') ?>
-                    </div></div>
-                </div></div><!-- /aside -->
-            <?php endif; ?>
-
             <!-- ********** CONTENT ********** -->
             <div id="dokuwiki__content"><div class="pad group">
                 <?php html_msgarea() ?>
@@ -66,6 +53,19 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 
                 <?php tpl_flush() ?>
             </div></div><!-- /content -->
+
+            <?php if($showSidebar): ?>
+                <!-- ********** ASIDE ********** -->
+                <div id="dokuwiki__aside"><div class="pad aside include group">
+                    <h3 class="toggle"><?php echo $lang['sidebar'] ?></h3>
+                    <div class="content"><div class="group">
+                        <?php tpl_flush() ?>
+                        <?php tpl_includeFile('sidebarheader.html') ?>
+                        <?php tpl_include_page($conf['sidebar'], true, true) ?>
+                        <?php tpl_includeFile('sidebarfooter.html') ?>
+                    </div></div>
+                </div></div><!-- /aside -->
+            <?php endif; ?>
 
             <hr class="a11y" />
 


### PR DESCRIPTION
Currently a default "dokuwiki" template outputs a sidebar first, and only then a page content. Often a sidebar may contain something that loads for a relatively long time (like several seconds). It may be a large index tree (e.g. of indexmenu plugin), or even some elements from another web service (like Google translate module, or an outside Search engine, etc).
So in such cases a user has to wait for maybe several seconds before a page content is shown. I propose to move the sidebar output ("ASIDE" block after the "CONTENT" block). Thus the page content will be shown without delay. I tested it on my PC, and it really feels more comfortable.