### PR TITLE
Invalidate user session cache after profile data was changed (fix #1117)

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -1049,12 +1049,19 @@ function updateprofile() {
         return false;
     }
 
-    // update cookie and session with the changed data
     if($changes['pass']) {
+        // update cookie and session with the changed data
         list( /*user*/, $sticky, /*pass*/) = auth_getCookie();
         $pass = auth_encrypt($changes['pass'], auth_cookiesalt(!$sticky, true));
         auth_setCookie($INPUT->server->str('REMOTE_USER'), $pass, (bool) $sticky);
+    } else {
+        // make sure the session is writable
+        @session_start();
+        // invalidate session cache
+        $_SESSION[DOKU_COOKIE]['auth']['time'] = 0;
+        session_write_close();
     }
+
     return true;
 }
 


### PR DESCRIPTION
Set session auth-time to a value before file mtime of data/cache/sessionpurge) after profile was changed.
This will refresh cache because profile data will be reloaded immediately.
If password is changed session cache will be updated via auth_setCookie, so this is just necessary if password is not changed.

This should fix issue #1117 and respect the comments from #1488.

Another approach could be updating session user info directly. IMHO just mark it invalid is a little bit cleaner, so changes in session user profile cache did not affect this again.