### PR TITLE
remove fullpath() call in pageinfo

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -213,7 +213,7 @@ function pageinfo() {
     }
 
     $info['locked']     = checklock($ID);
-    $info['filepath']   = fullpath(wikiFN($ID));
+    $info['filepath']   = wikiFN($ID);
     $info['exists']     = file_exists($info['filepath']);
     $info['currentrev'] = @filemtime($info['filepath']);
     if($REV) {
@@ -227,7 +227,7 @@ function pageinfo() {
             msg($lang['nosecedit'], 0);
         } else {
             //really use old revision
-            $info['filepath'] = fullpath(wikiFN($ID, $REV));
+            $info['filepath'] = wikiFN($ID, $REV);
             $info['exists']   = file_exists($info['filepath']);
         }
     }

--- a/inc/template.php
+++ b/inc/template.php
@@ -995,9 +995,9 @@ function tpl_pageinfo($ret = false) {
     $fn = $INFO['filepath'];
     if(!$conf['fullpath']) {
         if($INFO['rev']) {
-            $fn = str_replace(fullpath($conf['olddir']).'/', '', $fn);
+            $fn = str_replace($conf['olddir'].'/', '', $fn);
         } else {
-            $fn = str_replace(fullpath($conf['datadir']).'/', '', $fn);
+            $fn = str_replace($conf['datadir'].'/', '', $fn);
         }
     }
     $fn   = utf8_decodeFN($fn);


### PR DESCRIPTION
fullpath processing here seems unnecessary, wikiFN($ID) returns a valid filepath for the page text file.
