### PR TITLE
have the HTTPClient switch to TLS if "https" and a custom port is used

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -278,7 +278,7 @@ class HTTPClient {
         }
 
         // add SSL stream prefix if needed - needs SSL support in PHP
-        if($port == 443 || $this->proxy_ssl) {
+        if($port == 443 || $this->proxy_ssl || $uri['scheme'] == 'https') {
             if(!in_array('ssl', stream_get_transports())) {
                 $this->status = -200;
                 $this->error = 'This PHP version does not support SSL - cannot connect to server';


### PR DESCRIPTION
This is to ensure that we use SSL/TLS if a custom port is defined an no
proxy is used.

Fixes #1526