### PR TITLE
Add generic 3way merge capability

### DIFF
--- a/inc/DifferenceEngine.php
+++ b/inc/DifferenceEngine.php
@@ -1314,19 +1314,20 @@ class Diff3 extends Diff {
      *
      * @param string $label1  label for first version
      * @param string $label2  label for second version
+     * @param string $label3  separator between versions
      * @return array          lines of the merged text
      */
-    function mergedOutput($label1 = false, $label2 = false) {
+    function mergedOutput($label1='<<<<<<<',$label2='>>>>>>>',$label3='=======') {
         $lines = array();
         foreach ($this->_edits as $edit) {
             if ($edit->isConflict()) {
                 /* FIXME: this should probably be moved somewhere else. */
                 $lines = array_merge($lines,
-                                     array('<<<<<<<' . ($label1 ? ' ' . $label1 : '')),
+                                     array($label1),
                                      $edit->final1,
-                                     array("======="),
+                                     array($label3),
                                      $edit->final2,
-                                     array('>>>>>>>' . ($label2 ? ' ' . $label2 : '')));
+                                     array($label2));
                 $this->_conflictingBlocks++;
             } else {
                 $lines = array_merge($lines, $edit->merged());

--- a/inc/DifferenceEngine.php
+++ b/inc/DifferenceEngine.php
@@ -1281,5 +1281,240 @@ class InlineDiffFormatter extends DiffFormatter {
     }
 }
 
+/**
+ * A class for computing three way diffs.
+ *
+ * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
+ */
+class Diff3 extends Diff {
+
+    /**
+     * Conflict counter.
+     *
+     * @var integer
+     */
+    var $_conflictingBlocks = 0;
+
+    /**
+     * Computes diff between 3 sequences of strings.
+     *
+     * @param array $orig    The original lines to use.
+     * @param array $final1  The first version to compare to.
+     * @param array $final2  The second version to compare to.
+     */
+    function __construct($orig, $final1, $final2) {
+        $engine = new _DiffEngine();
+
+        $this->_edits = $this->_diff3($engine->diff($orig, $final1),
+                                      $engine->diff($orig, $final2));
+    }
+
+    /**
+     * Returns the merged lines
+     *
+     * @param string $label1  label for first version
+     * @param string $label2  label for second version
+     * @return array          lines of the merged text
+     */
+    function mergedOutput($label1 = false, $label2 = false) {
+        $lines = array();
+        foreach ($this->_edits as $edit) {
+            if ($edit->isConflict()) {
+                /* FIXME: this should probably be moved somewhere else. */
+                $lines = array_merge($lines,
+                                     array('<<<<<<<' . ($label1 ? ' ' . $label1 : '')),
+                                     $edit->final1,
+                                     array("======="),
+                                     $edit->final2,
+                                     array('>>>>>>>' . ($label2 ? ' ' . $label2 : '')));
+                $this->_conflictingBlocks++;
+            } else {
+                $lines = array_merge($lines, $edit->merged());
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @access private
+     */
+    function _diff3($edits1, $edits2) {
+        $edits = array();
+        $bb = new _Diff3_BlockBuilder();
+
+        $e1 = current($edits1);
+        $e2 = current($edits2);
+        while ($e1 || $e2) {
+            if ($e1 && $e2 && is_a($e1, '_DiffOp_copy') && is_a($e2, '_DiffOp_copy')) {
+                /* We have copy blocks from both diffs. This is the (only)
+                 * time we want to emit a diff3 copy block.  Flush current
+                 * diff3 diff block, if any. */
+                if ($edit = $bb->finish()) {
+                    $edits[] = $edit;
+                }
+
+                $ncopy = min($e1->norig(), $e2->norig());
+                assert($ncopy > 0);
+                $edits[] = new _Diff3_Op_copy(array_slice($e1->orig, 0, $ncopy));
+
+                if ($e1->norig() > $ncopy) {
+                    array_splice($e1->orig, 0, $ncopy);
+                    array_splice($e1->closing, 0, $ncopy);
+                } else {
+                    $e1 = next($edits1);
+                }
+
+                if ($e2->norig() > $ncopy) {
+                    array_splice($e2->orig, 0, $ncopy);
+                    array_splice($e2->closing, 0, $ncopy);
+                } else {
+                    $e2 = next($edits2);
+                }
+            } else {
+                if ($e1 && $e2) {
+                    if ($e1->orig && $e2->orig) {
+                        $norig = min($e1->norig(), $e2->norig());
+                        $orig = array_splice($e1->orig, 0, $norig);
+                        array_splice($e2->orig, 0, $norig);
+                        $bb->input($orig);
+                    }
+
+                    if (is_a($e1, '_DiffOp_copy')) {
+                        $bb->out1(array_splice($e1->closing, 0, $norig));
+                    }
+
+                    if (is_a($e2, '_DiffOp_copy')) {
+                        $bb->out2(array_splice($e2->closing, 0, $norig));
+                    }
+                }
+
+                if ($e1 && ! $e1->orig) {
+                    $bb->out1($e1->closing);
+                    $e1 = next($edits1);
+                }
+                if ($e2 && ! $e2->orig) {
+                    $bb->out2($e2->closing);
+                    $e2 = next($edits2);
+                }
+            }
+        }
+
+        if ($edit = $bb->finish()) {
+            $edits[] = $edit;
+        }
+
+        return $edits;
+    }
+}
+
+/**
+ * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
+ *
+ * @access private
+ */
+class _Diff3_Op {
+
+    function __construct($orig = false, $final1 = false, $final2 = false) {
+        $this->orig = $orig ? $orig : array();
+        $this->final1 = $final1 ? $final1 : array();
+        $this->final2 = $final2 ? $final2 : array();
+    }
+
+    function merged() {
+        if (!isset($this->_merged)) {
+            if ($this->final1 === $this->final2) {
+                $this->_merged = &$this->final1;
+            } elseif ($this->final1 === $this->orig) {
+                $this->_merged = &$this->final2;
+            } elseif ($this->final2 === $this->orig) {
+                $this->_merged = &$this->final1;
+            } else {
+                $this->_merged = false;
+            }
+        }
+
+        return $this->_merged;
+    }
+
+    function isConflict() {
+        return $this->merged() === false;
+    }
+
+}
+
+/**
+ * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
+ *
+ * @access private
+ */
+class _Diff3_Op_copy extends _Diff3_Op {
+
+    function __construct($lines = false) {
+        $this->orig = $lines ? $lines : array();
+        $this->final1 = &$this->orig;
+        $this->final2 = &$this->orig;
+    }
+
+    function merged() {
+        return $this->orig;
+    }
+
+    function isConflict() {
+        return false;
+    }
+}
+
+/**
+ * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
+ *
+ * @access private
+ */
+class _Diff3_BlockBuilder {
+
+    function __construct() {
+        $this->_init();
+    }
+
+    function input($lines) {
+        if ($lines) {
+            $this->_append($this->orig, $lines);
+        }
+    }
+
+    function out1($lines) {
+        if ($lines) {
+            $this->_append($this->final1, $lines);
+        }
+    }
+
+    function out2($lines) {
+        if ($lines) {
+            $this->_append($this->final2, $lines);
+        }
+    }
+
+    function isEmpty() {
+        return !$this->orig && !$this->final1 && !$this->final2;
+    }
+
+    function finish() {
+        if ($this->isEmpty()) {
+            return false;
+        } else {
+            $edit = new _Diff3_Op($this->orig, $this->final1, $this->final2);
+            $this->_init();
+            return $edit;
+        }
+    }
+
+    function _init() {
+        $this->orig = $this->final1 = $this->final2 = array();
+    }
+
+    function _append(&$array, $lines) {
+        array_splice($array, sizeof($array), 0, $lines);
+    }
+}
 
 //Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
This Pull-Request cherry-picks two commits from the [3waymerge-Branch](https://github.com/splitbrain/dokuwiki/tree/3waymerge) or the corresponding pull request #1068, respectively.

The goal is to provide the generic merging-functionality to plugins, without having to worry about the specific implementation of a general editing UI for merges just yet.

