### PR TITLE
autoload plugin namespace

### DIFF
--- a/inc/load.php
+++ b/inc/load.php
@@ -117,7 +117,7 @@ function load_autoload($name){
     // plugin namespace
     if(substr($name, 0, 16) == 'dokuwiki/plugin/') {
         $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
-        $file = DOKU_PLUGIN . substr($name, 7) . '.php';
+        $file = DOKU_PLUGIN . substr($name, 16) . '.php';
         if(file_exists($file)) {
             require $file;
             return true;

--- a/inc/load.php
+++ b/inc/load.php
@@ -111,21 +111,23 @@ function load_autoload($name){
         return true;
     }
 
-    // our own namespace
+    // namespace to directory conversion
     $name = str_replace('\\', '/', $name);
-    if(substr($name, 0, 9) == 'dokuwiki/') {
-        require substr($name, 9) . '.php';
-        return true;
-    }
 
     // plugin namespace
-    if(substr($name, 0, 7) == 'plugin/') {
+    if(substr($name, 0, 16) == 'dokuwiki/plugin/') {
         $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
         $file = DOKU_PLUGIN . substr($name, 7) . '.php';
         if(file_exists($file)) {
             require $file;
             return true;
         }
+    }
+
+    // our own namespace
+    if(substr($name, 0, 9) == 'dokuwiki/') {
+        require substr($name, 9) . '.php';
+        return true;
     }
 
     // Plugin loading

--- a/inc/load.php
+++ b/inc/load.php
@@ -118,6 +118,16 @@ function load_autoload($name){
         return true;
     }
 
+    // plugin namespace
+    if(substr($name, 0, 7) == 'plugin/') {
+        $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
+        $file = DOKU_PLUGIN . substr($name, 7) . '.php';
+        if(file_exists($file)) {
+            require $file;
+            return true;
+        }
+    }
+
     // Plugin loading
     if(preg_match('/^(auth|helper|syntax|action|admin|renderer|remote)_plugin_('.DOKU_PLUGIN_NAME_REGEX.')(?:_([^_]+))?$/',
                   $name, $m)) {


### PR DESCRIPTION
This introduces an autoloader for namespaces starting with plugin\*

This way, plugins can easily have additional classes auto loaded without
needing to register their own loader. A plugin\*\test\* namespace will
automatically be mapped to the _test directory of the plugin.

See https://github.com/cosmocode/dokuwiki-plugin-struct/blob/master/action/autoloader.php for an example plugin registering its own namespace.