### PR TITLE
inline small images into the CSS by default

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -149,7 +149,7 @@ $conf['compression'] = 'gz';             //compress old revisions: (0: off) ('gz
                                          //  bz2 generates smaller files, but needs more cpu-power
 $conf['gzip_output'] = 0;                //use gzip content encodeing for the output xhtml (if allowed by browser)
 $conf['compress']    = 1;                //Strip whitespaces and comments from Styles and JavaScript? 1|0
-$conf['cssdatauri']  = 0;                //Maximum byte size of small images to embed into CSS, won't work on IE<8
+$conf['cssdatauri']  = 512;              //Maximum byte size of small images to embed into CSS, won't work on IE<8
 $conf['send404']     = 0;                //Send a HTTP 404 status for non existing pages?
 $conf['broken_iua']  = 0;                //Platform with broken ignore_user_abort (IIS+CGI) 0|1
 $conf['xsendfile']   = 0;                //Use X-Sendfile (1 = lighttpd, 2 = standard)


### PR DESCRIPTION
Since we no longer support old IE 8 and below we can enable data uris
by default now. The picked size here is open for discussion.

A typical HTTP header for a static image ressource is about 200 to 250
bytes at dokuwiki.org. I picked twice of that as the cutoff for inlining
images.