### PR TITLE
Add a protected file to the authplain config cascade

### DIFF
--- a/inc/config_cascade.php
+++ b/inc/config_cascade.php
@@ -62,6 +62,7 @@ $config_cascade = array_merge(
         ),
         'plainauth.users' => array(
             'default'   => DOKU_CONF . 'users.auth.php',
+            'protected' => '' // not used by default
         ),
         'plugins' => array(
             'default'   => array(DOKU_CONF . 'plugins.php'),

--- a/lib/plugins/authplain/auth.php
+++ b/lib/plugins/authplain/auth.php
@@ -173,6 +173,13 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
             msg($this->getLang('usernotexists'), -1);
             return false;
         }
+
+        // don't modify protected users
+        if(!empty($userinfo['protected'])) {
+            msg(sprintf($this->getLang('protected'), hsc($user)), -1);
+            return false;
+        }
+
         if(!is_array($changes) || !count($changes)) return true;
 
         // update userinfo with new data, remembering to encrypt any password
@@ -215,6 +222,11 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
 
         $deleted = array();
         foreach($users as $user) {
+            // don't delete protected users
+            if(!empty($this->users[$user]['protected'])) {
+                msg(sprintf($this->getLang('protected'), hsc($user)), -1);
+                continue;
+            }
             if(isset($this->users[$user])) $deleted[] = preg_quote($user, '/');
         }
 
@@ -324,11 +336,31 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
     protected function _loadUserData() {
         global $config_cascade;
 
-        $this->users = array();
+        $this->users = $this->_readUserFile($config_cascade['plainauth.users']['default']);
 
-        if(!file_exists($config_cascade['plainauth.users']['default'])) return;
+        // support protected users
+        if(!empty($config_cascade['plainauth.users']['protected'])) {
+            $protected = $this->_readUserFile($config_cascade['plainauth.users']['protected']);
+            foreach(array_keys($protected) as $key) {
+                $protected[$key]['protected'] = true;
+            }
+            $this->users = array_merge($this->users, $protected);
+        }
+    }
 
-        $lines = file($config_cascade['plainauth.users']['default']);
+    /**
+     * Read user data from given file
+     *
+     * ignores non existing files
+     *
+     * @param string $file the file to load data from
+     * @return array
+     */
+    protected function _readUserFile($file) {
+        $users = array();
+        if(!file_exists($file)) return $users;
+
+        $lines = file($file);
         foreach($lines as $line) {
             $line = preg_replace('/#.*$/', '', $line); //ignore comments
             $line = trim($line);
@@ -341,11 +373,12 @@ class auth_plugin_authplain extends DokuWiki_Auth_Plugin {
 
             $groups = array_values(array_filter(explode(",", $row[4])));
 
-            $this->users[$row[0]]['pass'] = $row[1];
-            $this->users[$row[0]]['name'] = urldecode($row[2]);
-            $this->users[$row[0]]['mail'] = $row[3];
-            $this->users[$row[0]]['grps'] = $groups;
+            $users[$row[0]]['pass'] = $row[1];
+            $users[$row[0]]['name'] = urldecode($row[2]);
+            $users[$row[0]]['mail'] = $row[3];
+            $users[$row[0]]['grps'] = $groups;
         }
+        return $users;
     }
 
     protected function _splitUserData($line){

--- a/lib/plugins/authplain/lang/en/lang.php
+++ b/lib/plugins/authplain/lang/en/lang.php
@@ -6,3 +6,4 @@
 $lang['userexists']     = 'Sorry, a user with this login already exists.';
 $lang['usernotexists']  = 'Sorry, that user doesn\'t exist.';
 $lang['writefail']      = 'Unable to modify user data. Please inform the Wiki-Admin';
+$lang['protected']      = 'Data for user %s is protected and can not be modified or deleted.';


### PR DESCRIPTION
This adds the possibility to define file with protected users in the
config cascade to be used with the plain auth mechanism.

This makes it possible for farms to have way to inherit Farmer users in
animals.