### PR TITLE
Fix broken JS in xhtml

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -147,7 +147,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                     }
 
                     // add footnote markup and close this footnote
-                    $this->doc .= $footnote;
+                    $this->doc .= '<span class="content">'.$footnote.'</span>';
                     $this->doc .= '</div>'.DOKU_LF;
                 }
             }

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -147,7 +147,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                     }
 
                     // add footnote markup and close this footnote
-                    $this->doc .= '<span class="content">'.$footnote.'</span>';
+                    $this->doc .= '<div class="content">'.$footnote.'</div>';
                     $this->doc .= '</div>'.DOKU_LF;
                 }
             }

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -168,26 +168,28 @@ var dw_behaviour = {
      * disable multiple revisions checkboxes if two are checked
      *
      * @author Andreas Gohr <andi@splitbrain.org>
+     * @author Anika Henke <anika@selfthinker.org>
      */
-    revisionBoxHandler: function(){
-        var $checked = jQuery('#page__revisions input[type=checkbox]:checked');
-        var $all     = jQuery('#page__revisions input[type=checkbox]');
+    revisionBoxHandler: function() {
+        var $revisions = jQuery('#page__revisions');
+        var $all       = jQuery('input[type=checkbox]', $revisions);
+        var $checked   = $all.filter(':checked');
+        var $button    = jQuery('button', $revisions);
 
-        if($checked.length < 2){
-            $all.attr('disabled',false);
-            jQuery('#page__revisions button').attr('disabled',true);
-        }else{
-            $all.attr('disabled',true);
-            jQuery('#page__revisions button').attr('disabled',false);
-            for(var i=0; i<$checked.length; i++){
-                $checked[i].disabled = false;
-                if(i>1){
-                    $checked[i].checked = false;
+        if($checked.length < 2) {
+            $all.removeAttr('disabled');
+            $button.attr('disabled', true);
+        } else {
+            $all.attr('disabled', true);
+            $button.removeAttr('disabled');
+            $checked.each(function(i) {
+                jQuery(this).removeAttr('disabled');
+                if(i>1) {
+                    jQuery(this).attr('checked', false);
                 }
-            }
+            });
         }
     }
-
 };
 
 jQuery(dw_behaviour.init);

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -63,7 +63,7 @@ var dw_editor = {
             ['smaller', function(){dw_editor.sizeCtl(editor,-100);}],
             ['wrap', function(){dw_editor.toggleWrap(editor);}]
         ], function (_, img) {
-            jQuery(document.createElement('IMG'))
+            jQuery(document.createElement('img'))
                 .attr('src', DOKU_BASE+'lib/images/' + img[0] + '.gif')
                 .attr('alt', '')
                 .click(img[1])

--- a/lib/scripts/page.js
+++ b/lib/scripts/page.js
@@ -83,23 +83,26 @@ dw_page = {
      *
      * @author Andreas Gohr <andi@splitbrain.org>
      * @author Chris Smith <chris@jalakai.co.uk>
+     * @author Anika Henke <anika@selfthinker.org>
      */
     footnoteDisplay: function () {
-        var content = jQuery(jQuery(this).attr('href')) // Footnote text anchor
-                      .closest('div.fn').html();
+        var $content = jQuery(jQuery(this).attr('href')) // Footnote text anchor
+                      .parent().siblings('.content').clone();
 
-        if (content === null){
+        if (!$content) {
             return;
         }
 
-        // strip the leading content anchors and their comma separators
-        content = content.replace(/((^|\s*,\s*)<sup>.*?<\/sup>)+\s*/gi, '');
-
         // prefix ids on any elements with "insitu__" to ensure they remain unique
-        content = content.replace(/\bid=(['"])([^"']+)\1/gi,'id="insitu__$2');
+        jQuery('[id]', $content).each(function(){
+            var id = jQuery(this).attr('id');
+            jQuery(this).attr('id', 'insitu__' + id);
+        });
 
+        var content = $content.html().trim();
         // now put the content into the wrapper
-        dw_page.insituPopup(this, 'insitu__fn').html(content).show().attr('aria-hidden', 'false');
+        dw_page.insituPopup(this, 'insitu__fn').html(content)
+        .show().attr('aria-hidden', 'false');
     },
 
     /**

--- a/lib/tpl/dokuwiki/css/_footnotes.css
+++ b/lib/tpl/dokuwiki/css/_footnotes.css
@@ -23,6 +23,9 @@ div.insitu-footnote {
 }
 .dokuwiki div.footnotes div.fn {
 }
+.dokuwiki div.footnotes div.fn div.content {
+    display: inline;
+}
 .dokuwiki div.footnotes div.fn sup a.fn_bot {
     font-weight: bold;
 }


### PR DESCRIPTION
When [serving DokuWiki as XHTML](https://www.dokuwiki.org/tips:xhtml5) there are some JavaScript errors. This fixes most of those errors mentioned in [FS#2550](https://bugs.dokuwiki.org/index.php?do=details&task_id=2550).

I'll explain the issues further in the comments below.
