### PR TITLE
Allow true/false for onoff config setting

### DIFF
--- a/lib/plugins/config/_test/configuration.test.php
+++ b/lib/plugins/config/_test/configuration.test.php
@@ -11,6 +11,9 @@ class plugin_config_configuration_test extends DokuWikiTest {
     private $config = '';
     private $meta = '';
 
+    /**
+     * Load config files
+     */
     function __construct() {
         $this->config = dirname(__FILE__).'/data/config.php';
         $this->meta   = dirname(__FILE__).'/data/metadata.php';
@@ -22,7 +25,7 @@ class plugin_config_configuration_test extends DokuWikiTest {
 
         $conf = $confmgr->_read_config($this->config);
 
-        //print_r($conf);
+        // var_dump($conf);
 
         $this->assertEquals('42', $conf['int1']);
         $this->assertEquals('6*7', $conf['int2']);
@@ -34,6 +37,40 @@ class plugin_config_configuration_test extends DokuWikiTest {
         $this->assertEquals('Hello "World"', $conf['str5']);
 
         $this->assertEquals(array('foo', 'bar', 'baz'), $conf['arr1']);
+    }
+
+    function test_readconfig_onoff() {
+        $confmgr = new configuration($this->meta);
+
+        $conf = $confmgr->_read_config($this->config);
+
+        // var_dump($conf);
+
+        $this->assertEquals(0, $conf['onoff1']);
+        $this->assertEquals(1, $conf['onoff2']);
+        $this->assertEquals(2, $conf['onoff3']);
+        $this->assertEquals(0, $conf['onoff4']);
+        $this->assertEquals(1, $conf['onoff5']);
+        $this->assertEquals(false, $conf['onoff6']);
+        $this->assertEquals(true, $conf['onoff7']);
+        $this->assertEquals('false', $conf['onoff8']);
+        $this->assertEquals('true', $conf['onoff9']);
+
+        $this->assertEquals('false senctence', $conf['str11']);
+        $this->assertEquals('true sentence', $conf['str12']);
+        $this->assertEquals('truesfdf', $conf['str13']);
+        $this->assertEquals("true", $conf['str14']);
+        $this->assertEquals("truesfdsf", $conf['str15']);
+
+        $this->assertTrue($conf['onoff1'] == false);
+        $this->assertTrue($conf['onoff2'] == true);
+        $this->assertTrue($conf['onoff3'] == true);
+        $this->assertTrue($conf['onoff4'] == false);
+        $this->assertTrue($conf['onoff5'] == true);
+        $this->assertTrue($conf['onoff6'] == false);
+        $this->assertTrue($conf['onoff7'] == true);
+        $this->assertTrue($conf['onoff8'] == true); //string
+        $this->assertTrue($conf['onoff9'] == true); //string
     }
 
 }

--- a/lib/plugins/config/_test/data/config.php
+++ b/lib/plugins/config/_test/data/config.php
@@ -14,3 +14,19 @@ $conf['arr1']  = array('foo','bar', 'baz');
 
 $conf['foo']['bar'] = 'x1';
 $conf['foo']['baz'] = 'x2';
+
+$conf['onoff1'] = 0;
+$conf['onoff2'] = 1;
+$conf['onoff3'] = 2;
+$conf['onoff4'] = '0';
+$conf['onoff5'] = '1';
+$conf['onoff6'] = false;
+$conf['onoff7'] = true;
+$conf['onoff8'] = 'false';
+$conf['onoff9'] = 'true';
+
+$conf['str11']  = 'false senctence';
+$conf['str12']  = 'true sentence';
+$conf['str13']  = 'truesfdf';
+$conf['str14']  = "true";
+$conf['str15']  = "truesfdsf";

--- a/lib/plugins/config/_test/data/metadata.php
+++ b/lib/plugins/config/_test/data/metadata.php
@@ -11,3 +11,18 @@ $meta['str5'] = array('string');
 
 $meta['arr1'] = array('array');
 
+$meta['onoff1'] = array('onoff');
+$meta['onoff2'] = array('onoff');
+$meta['onoff3'] = array('onoff');
+$meta['onoff4'] = array('onoff');
+$meta['onoff5'] = array('onoff');
+$meta['onoff6'] = array('onoff');
+$meta['onoff7'] = array('onoff');
+$meta['onoff8'] = array('onoff');
+$meta['onoff9'] = array('onoff');
+
+$meta['str11'] = array('string');
+$meta['str12'] = array('string');
+$meta['str13'] = array('string');
+$meta['str14'] = array('string');
+$meta['str15'] = array('string');

--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -220,15 +220,12 @@ if (!class_exists('configuration')) {
                         $len = count($arr);
                         for($j=0; $j<$len; $j++){
                             $arr[$j] = trim($arr[$j]);
-                            $arr[$j] = preg_replace('/^(\'|")(.*)(?<!\\\\)\1$/s','$2',$arr[$j]);
-                            $arr[$j] = strtr($arr[$j], array('\\\\'=>'\\','\\\''=>'\'','\\"'=>'"'));
+                            $arr[$j] = $this->_readValue($arr[$j]);
                         }
 
                         $value = $arr;
                     }else{
-                        // remove quotes from quoted strings & unescape escaped data
-                        $value = preg_replace('/^(\'|")(.*)(?<!\\\\)\1$/s','$2',$value);
-                        $value = strtr($value, array('\\\\'=>'\\','\\\''=>'\'','\\"'=>'"'));
+                        $value = $this->_readValue($value);
                     }
 
                     $config[$key] = $value;
@@ -236,6 +233,32 @@ if (!class_exists('configuration')) {
             }
 
             return $config;
+        }
+
+        /**
+         * Convert php string into value
+         *
+         * @param string $value
+         * @return bool|string
+         */
+        protected function _readValue($value) {
+            $removequotes_pattern = '/^(\'|")(.*)(?<!\\\\)\1$/s';
+            $unescape_pairs = array(
+                '\\\\' => '\\',
+                '\\\'' => '\'',
+                '\\"' => '"'
+            );
+
+            if($value == 'true') {
+                $value = true;
+            } elseif($value == 'false') {
+                $value = false;
+            } else {
+                // remove quotes from quoted strings & unescape escaped data
+                $value = preg_replace($removequotes_pattern,'$2',$value);
+                $value = strtr($value, $unescape_pairs);
+            }
+            return $value;
         }
 
         /**


### PR DESCRIPTION
Changed the values recognized by the general config parser.
If value in config is a php boolean it is recognized as boolean, not if it
is a php string 'true' or 'false'.

Fixes #718