### PR TITLE
preg_replace eval modifier

### DIFF
--- a/lib/plugins/authad/adLDAP/classes/adLDAPUtils.php
+++ b/lib/plugins/authad/adLDAP/classes/adLDAPUtils.php
@@ -99,19 +99,23 @@ class adLDAPUtils {
     * @author Port by Andreas Gohr <andi@splitbrain.org>
     * @return string
     */
-    public function ldapSlashes($str){
-        return preg_replace('/([\x00-\x1F\*\(\)\\\\])/e',
-                            '"\\\\\".join("",unpack("H2","$1"))',
-                            $str);
+    protected function ldapSlashes($str) {
+        // see https://github.com/adldap/adLDAP/issues/22
+        return preg_replace_callback(
+            '/([\x00-\x1F\*\(\)\\\\])/',
+            function ($matches) {
+                return "\\".join("", unpack("H2", $matches[1]));
+            },
+            $str
+        );
     }
-    
     /**
     * Converts a string GUID to a hexdecimal value so it can be queried
-    * 
+    *
     * @param string $strGUID A string representation of a GUID
     * @return string
     */
-    public function strGuidToHex($strGUID) 
+    public function strGuidToHex($strGUID)
     {
         $strGUID = str_replace('-', '', $strGUID);
 

--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -275,6 +275,10 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
 
     /**
      * Definition of the function modifyUser in order to modify the password
+     *
+     * @param   string $user    nick of the user to be changed
+     * @param   array  $changes array of field/value pairs to be changed (password will be clear text)
+     * @return  bool   true on success, false on error
      */
 
     function modifyUser($user,$changes){


### PR DESCRIPTION
Found another piece of code with deprecated /e modifier, as also reported by #1551 

Reused code from #1373