### PR TITLE
Added getter function getLastlevel() in Doku_Renderer_xhtml.

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1422,6 +1422,16 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $this->doc .= '</td>';
     }
 
+    /**
+     * Returns the current header level.
+     * (required e.g. by the filelist plugin)
+     *
+     * @return int The current header level
+     */
+    function getLastlevel() {
+        return $this->lastlevel;
+    }
+
     #region Utility functions
 
     /**


### PR DESCRIPTION
This is required for the filelist plugin to fix issue #11 since $lastlevel became protected in "hrun".

Please check and merge if ok. Would be great if it could get in the next release.