### PR TITLE
Check if content really changed in the Editor, before popup a warning…

### DIFF
--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -7,8 +7,15 @@
 
 /**
  * Creates a toolbar button through the DOM
+ * Called for each entry of toolbar definition array (built by inc/toolbar.php and extended via js)
  *
  * Style the buttons through the toolbutton class
+ *
+ * @param {string} icon      image filename, relative to folder lib/images/toolbar/
+ * @param {string} label     title of button, show on mouseover
+ * @param {string} key       hint in title of button for access key
+ * @param {string} id        id of button, and '<id>_ico' of icon
+ * @param {string} classname for styling buttons
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  * @author Michal Rezler <m.rezler@centrum.cz>
@@ -57,10 +64,10 @@ function createToolButton(icon,label,key,id,classname){
  * class or the picker buttons with the pickerbutton class. Picker
  * windows are appended to the body and created invisible.
  *
- * @param  string id    the ID to assign to the picker
- * @param  array  props the properties for the picker
- * @param  string edid  the ID of the textarea
- * @rteurn DOMobject    the created picker
+ * @param  {string} id    the ID to assign to the picker
+ * @param  {Array}  props the properties for the picker
+ * @param  {string} edid  the ID of the textarea
+ * @return DOMobject    the created picker
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function createPicker(id,props,edid){
@@ -126,10 +133,10 @@ function pickerInsert(text,edid){
 /**
  * Add button action for signature button
  *
- * @param  DOMElement btn   Button element to add the action to
- * @param  array      props Associative array of button properties
- * @param  string     edid  ID of the editor textarea
- * @return boolean    If button should be appended
+ * @param  {jQuery} $btn   Button element to add the action to
+ * @param  {Array}  props  Associative array of button properties
+ * @param  {string} edid   ID of the editor textarea
+ * @return {string} picker id for aria-controls attribute
  * @author Gabriel Birke <birke@d-scribe.de>
  */
 function addBtnActionSignature($btn, props, edid) {
@@ -145,6 +152,8 @@ function addBtnActionSignature($btn, props, edid) {
 
 /**
  * Determine the current section level while editing
+ *
+ * @param {string} textboxId   ID of the text field
  *
  * @author Andreas Gohr <gohr@cosmocode.de>
  */

--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -213,6 +213,7 @@ function deleteDraft() {
 /**
  * Activate "not saved" dialog, add draft deletion to page unload,
  * add handlers to monitor changes
+ * Note: textChanged could be set by e.g. html_edit() as well
  *
  * Sets focus to the editbox as well
  */
@@ -234,19 +235,26 @@ jQuery(function () {
         sel.end   = 0;
         DWsetSelection(sel);
         $edit_text.focus();
+
+        var edit_text_content = $edit_text.val();
     }
 
     var checkfunc = function() {
-        textChanged = true; //global var
+        //global var textChanged
+        if ($edit_text.length > 0) {
+            textChanged = edit_text_content != $edit_text.val();
+        } else {
+            textChanged = true;
+        }
+
         summaryCheck();
     };
 
     $editform.change(checkfunc);
     $editform.keydown(checkfunc);
 
-    var edit_text_content = $edit_text.val();
     window.onbeforeunload = function(){
-        if(window.textChanged && edit_text_content != $edit_text.val()) {
+        if(window.textChanged) {
             return LANG.notsavedyet;
         }
     };

--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -235,8 +235,9 @@ jQuery(function () {
     $editform.change(checkfunc);
     $editform.keydown(checkfunc);
 
+    var edit_text_content = $edit_text.val();
     window.onbeforeunload = function(){
-        if(window.textChanged) {
+        if(window.textChanged && edit_text_content != $edit_text.val()) {
             return LANG.notsavedyet;
         }
     };

--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -188,6 +188,10 @@ function currentHeadlineLevel(textboxId){
 window.textChanged = false;
 
 /**
+ * global var which stores original editor content
+ */
+window.doku_edit_text_content = '';
+/**
  * Delete the draft before leaving the page
  */
 function deleteDraft() {
@@ -236,22 +240,17 @@ jQuery(function () {
         DWsetSelection(sel);
         $edit_text.focus();
 
-        var edit_text_content = $edit_text.val();
+        doku_edit_text_content = $edit_text.val();
     }
 
-    var checkfunc = function() {
-        //global var textChanged
-        if ($edit_text.length > 0) {
-            textChanged = edit_text_content != $edit_text.val();
-        } else {
-            textChanged = true;
-        }
+    var changeHandler = function() {
+        doku_hasTextBeenModified();
 
-        summaryCheck();
+        doku_summaryCheck();
     };
 
-    $editform.change(checkfunc);
-    $editform.keydown(checkfunc);
+    $editform.change(changeHandler);
+    $editform.keydown(changeHandler);
 
     window.onbeforeunload = function(){
         if(window.textChanged) {
@@ -276,18 +275,33 @@ jQuery(function () {
     );
 
     var $summary = jQuery('#edit__summary');
-    $summary.change(summaryCheck);
-    $summary.keyup(summaryCheck);
+    $summary.change(doku_summaryCheck);
+    $summary.keyup(doku_summaryCheck);
 
-    if (textChanged) summaryCheck();
+    if (textChanged) doku_summaryCheck();
 });
+
+/**
+ * Updates textChanged variable if content of the editor has been modified
+ */
+function doku_hasTextBeenModified() {
+    if (!textChanged) {
+        var $edit_text = jQuery('#wiki__text');
+
+        if ($edit_text.length > 0) {
+            textChanged = doku_edit_text_content != $edit_text.val();
+        } else {
+            textChanged = true;
+        }
+    }
+}
 
 /**
  * Checks if a summary was entered - if not the style is changed
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  */
-function summaryCheck(){
+function doku_summaryCheck(){
     var $sum = jQuery('#edit__summary'),
         missing = $sum.val() === '';
     $sum.toggleClass('missing', missing).toggleClass('edit', !missing);


### PR DESCRIPTION
… when leaving

Fixes #1199

Does this check catch all changes by modifications via the mouse actions?
 * [x] middle mouse click paste (default linux feature)
 * [x] moving text
 * [x] paste, cut etc
 * [x] a vs á
 * [x] plugins with custom editor like Data plugin and Edittable
 * [x] other?
