### PR TITLE
If external link inserted with link wizard, empty input

### DIFF
--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -259,7 +259,14 @@ var dw_linkwiz = {
         dw_linkwiz.hide();
 
         // reset the entry to the parent namespace
-        dw_linkwiz.$entry.val(dw_linkwiz.$entry.val().replace(/[^:]*$/, ''));
+        var externallinkpattern = new RegExp('^((f|ht)tps?:)?//', 'i'),
+            entry_value;
+        if(externallinkpattern.test(dw_linkwiz.$entry.val())) {
+            entry_value = ''; //reset whole external links
+        }else {
+            entry_value = dw_linkwiz.$entry.val().replace(/[^:]*$/, '')
+        }
+        dw_linkwiz.$entry.val(entry_value);
     },
 
     /**

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -261,9 +261,13 @@ var dw_linkwiz = {
         // reset the entry to the parent namespace
         var externallinkpattern = new RegExp('^((f|ht)tps?:)?//', 'i'),
             entry_value;
-        if(externallinkpattern.test(dw_linkwiz.$entry.val())) {
-            entry_value = ''; //reset whole external links
-        }else {
+        if (externallinkpattern.test(dw_linkwiz.$entry.val())) {
+            if (JSINFO.namespace) {
+                entry_value = JSINFO.namespace + ':';
+            } else {
+                entry_value = ''; //reset whole external links
+            }
+        } else {
             entry_value = dw_linkwiz.$entry.val().replace(/[^:]*$/, '')
         }
         dw_linkwiz.$entry.val(entry_value);


### PR DESCRIPTION
Default the link wizard reset the input value of the wizard to the parent namespace.
(so it resets e.g. `abc:cde:page` to `abc:cde:`).

External links were handled the same: these were reset to `http:`
Now http://, https:// and ftp:// are recognized and reset ~~at all~~ *edit:* to the parent namespace.

Fixes #1483 
