### PR TITLE
Keep filter options in the extension manager

### DIFF
--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -116,20 +116,27 @@ jQuery(function(){
     if ( $extmgr.find('.plugins, .templates').hasClass('active') ) {
         var $extlist = jQuery('#extension__list');
         $extlist.addClass('hasDisplayOptions');
-        var $displayOpts = jQuery('<p>', { id: 'extension__viewoptions'} ).appendTo($extmgr.find( '.panelHeader' ));
 
+        var $displayOpts = jQuery('<p>', { id: 'extension__viewoptions'} ).appendTo($extmgr.find( '.panelHeader' ));
         $displayOpts.append(LANG.plugins.extension.display_viewoptions);
 
         var displayOptionsHandler = function(){
             $extlist.toggleClass( this.name );
+            DokuCookie.setValue('extension__show_'+this.name, $extlist.hasClass(this.name) ? '1' : '0');
         };
 
         jQuery(['enabled', 'disabled', 'updatable']).each(function(index, chkName){
-            var $label = jQuery( '<label></label>' ).appendTo($displayOpts);
-            jQuery( '<input />', { type: 'checkbox', name: chkName })
+            var $label = jQuery( '<label></label>' )
+                .appendTo($displayOpts);
+            var $input = jQuery( '<input />', { type: 'checkbox', name: chkName })
                 .change(displayOptionsHandler)
-                .appendTo($label)
-                .click();
+                .appendTo($label);
+
+            var previous = DokuCookie.getValue('extension__show_'+chkName);
+            if(typeof previous === "undefined" || previous == '1') {
+                $input.click();
+            }
+
             jQuery( '<span/>' )
                 .append(' '+LANG.plugins.extension['display_'+chkName])
                 .appendTo($label);

--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -122,7 +122,7 @@ jQuery(function(){
 
         var displayOptionsHandler = function(){
             $extlist.toggleClass( this.name );
-            DokuCookie.setValue('extension__show_'+this.name, $extlist.hasClass(this.name) ? '1' : '0');
+            DokuCookie.setValue('ext_'+this.name, $extlist.hasClass(this.name) ? '1' : '0');
         };
 
         jQuery(['enabled', 'disabled', 'updatable']).each(function(index, chkName){
@@ -132,7 +132,7 @@ jQuery(function(){
                 .change(displayOptionsHandler)
                 .appendTo($label);
 
-            var previous = DokuCookie.getValue('extension__show_'+chkName);
+            var previous = DokuCookie.getValue('ext_'+chkName);
             if(typeof previous === "undefined" || previous == '1') {
                 $input.click();
             }

--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -126,8 +126,13 @@ jQuery(function(){
 
         jQuery(['enabled', 'disabled', 'updatable']).each(function(index, chkName){
             var $label = jQuery( '<label></label>' ).appendTo($displayOpts);
-            jQuery( '<input />', { type: 'checkbox', name: chkName }).change(displayOptionsHandler).appendTo($label).click();
-            jQuery( '<span/>' ).append(' '+LANG.plugins.extension['display_'+chkName]).appendTo($label);
+            jQuery( '<input />', { type: 'checkbox', name: chkName })
+                .change(displayOptionsHandler)
+                .appendTo($label)
+                .click();
+            jQuery( '<span/>' )
+                .append(' '+LANG.plugins.extension['display_'+chkName])
+                .appendTo($label);
         });
     }
 });


### PR DESCRIPTION
The extension list can be filtered by 'enabled', 'disabled', and 'updatable'.
After page reload, for example by updating an plugin, the selected filtering was forgotten.

Now the applied filtering is stored in de Doku settings cookie. 
So that after updating one plugin, you get listed directly the other not yet updated plugins.

(hopefully the key names of this setting in cookie are not too long)