### PR TITLE
show login form when non-logged in user requests forbidden media file

### DIFF
--- a/lib/exe/fetch.php
+++ b/lib/exe/fetch.php
@@ -67,6 +67,14 @@ if (defined('SIMPLE_TEST')) {
         if($data['status'] != 200) {
             http_status($data['status'], $data['statusmessage']);
         }
+        // redirect to login-form if forbidden
+        // workaround for ACLs broken on non-logged-in users
+        if ($data['status'] == 403) {
+            global $ACT;
+            $ACT = "show";
+            act_dispatch();
+            exit;
+        }
         // die on errors
         if($data['status'] > 203) {
             print $data['statusmessage'];


### PR DESCRIPTION
Based on the patch by @ysalomon in
https://github.com/splitbrain/dokuwiki/issues/1169#issuecomment-166149698

Instead of outputting the status code, show the login page if we would return forbidden. Better then the original patch this does not touch other return codes (like 404).

fixes #1169