### PR TITLE
Fix xmlrpc constructor for php7

### DIFF
--- a/lib/exe/xmlrpc.php
+++ b/lib/exe/xmlrpc.php
@@ -16,7 +16,7 @@ class dokuwiki_xmlrpc_server extends IXR_Server {
     /**
      * Constructor. Register methods and run Server
      */
-    function dokuwiki_xmlrpc_server(){
+    function __construct(){
         $this->remote = new RemoteAPI();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));


### PR DESCRIPTION
In php7 constructors with the same name as the class are deprecated. ``__construct()`` should be used.

Depending on the server-configuration this could result in a warning which would break the API.