### PR TITLE
Small fixes for file size changes

### DIFF
--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -118,12 +118,12 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
         // find $a_webm in $url
-        $a_webm = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1 KB)">kind_zu_katze.webm</a>';
+        $a_webm = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1&#xa0;KB)">kind_zu_katze.webm</a>';
         $substr_start = strpos($url, $a_webm, $substr_start + strlen($source_ogv));
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
         // find $a_webm in $url
-        $a_ogv = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8 KB)">kind_zu_katze.ogv</a>';
+        $a_ogv = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8&#xa0;KB)">kind_zu_katze.ogv</a>';
         $substr_start = strpos($url, $a_ogv, $substr_start + strlen($a_webm));
         $this->assertNotSame(false, $substr_start, 'Substring not found.');
 

--- a/inc/common.php
+++ b/inc/common.php
@@ -1477,7 +1477,7 @@ function filesize_h($size, $dec = 1) {
         $i++;
     }
 
-    return round($size, $dec).' '.$sizes[$i];
+    return round($size, $dec).'&#xa0;'.$sizes[$i];
 }
 
 /**

--- a/inc/html.php
+++ b/inc/html.php
@@ -587,20 +587,7 @@ function html_revisions($first=0, $media_id = false){
         $form->addElement((empty($editor))?('('.$lang['external_edit'].')'):'<bdi>'.editorinfo($editor).'</bdi>');
         $form->addElement(form_makeCloseTag('span'));
 
-        if(isset($sizechange)) {
-            $class = 'sizechange';
-            $value = filesize_h(abs($sizechange));
-            if($sizechange > 0) {
-                $class .= ' positive';
-                $value = '+' . $value;
-            } elseif($sizechange < 0) {
-                $class .= ' negative';
-                $value = '-' . $value;
-            }
-            $form->addElement(form_makeOpenTag('span', array('class' => $class)));
-            $form->addElement($value);
-            $form->addElement(form_makeCloseTag('span'));
-        }
+        html_sizechange($sizechange, $form);
 
         $form->addElement('('.$lang['current'].')');
 
@@ -690,20 +677,7 @@ function html_revisions($first=0, $media_id = false){
         }
         $form->addElement(form_makeCloseTag('span'));
 
-        if(isset($info['sizechange'])) {
-            $class = 'sizechange';
-            $value = filesize_h(abs($info['sizechange']));
-            if($info['sizechange'] > 0) {
-                $class .= ' positive';
-                $value = '+' . $value;
-            } elseif($info['sizechange'] < 0) {
-                $class .= ' negative';
-                $value = '-' . $value;
-            }
-            $form->addElement(form_makeOpenTag('span', array('class' => $class)));
-            $form->addElement($value);
-            $form->addElement(form_makeCloseTag('span'));
-        }
+        html_sizechange($info['sizechange'], $form);
 
         if ($media_id) $form->addElement(form_makeCloseTag('div'));
 
@@ -913,20 +887,7 @@ function html_recent($first = 0, $show_changes = 'both') {
         }
         $form->addElement(form_makeCloseTag('span'));
 
-        if(isset($recent['sizechange'])) {
-            $class = 'sizechange';
-            $value = filesize_h(abs($recent['sizechange']));
-            if($recent['sizechange'] > 0) {
-                $class .= ' positive';
-                $value = '+' . $value;
-            } elseif($recent['sizechange'] < 0) {
-                $class .= ' negative';
-                $value = '-' . $value;
-            }
-            $form->addElement(form_makeOpenTag('span', array('class' => $class)));
-            $form->addElement($value);
-            $form->addElement(form_makeCloseTag('span'));
-        }
+        html_sizechange($recent['sizechange'], $form);
 
         $form->addElement(form_makeCloseTag('div'));
         $form->addElement(form_makeCloseTag('li'));
@@ -2439,6 +2400,7 @@ function html_tabs($tabs, $current_tab = null) {
 
     echo '</ul>'.NL;
 }
+
 /**
  * Prints a single tab
  *
@@ -2463,3 +2425,26 @@ function html_tab($href, $caption, $selected=false) {
     echo $tab;
 }
 
+/**
+ * Display size change
+ *
+ * @param int $sizechange - size of change in Bytes
+ * @param Doku_Form $form - form to add elements to
+ */
+
+function html_sizechange($sizechange, Doku_Form $form) {
+    if(isset($sizechange)) {
+        $class = 'sizechange';
+        $value = filesize_h(abs($sizechange));
+        if($sizechange > 0) {
+            $class .= ' positive';
+            $value = '+' . $value;
+        } elseif($sizechange < 0) {
+            $class .= ' negative';
+            $value = '-' . $value;
+        }
+        $form->addElement(form_makeOpenTag('span', array('class' => $class)));
+        $form->addElement($value);
+        $form->addElement(form_makeCloseTag('span'));
+    }
+}

--- a/inc/html.php
+++ b/inc/html.php
@@ -2442,6 +2442,8 @@ function html_sizechange($sizechange, Doku_Form $form) {
         } elseif($sizechange < 0) {
             $class .= ' negative';
             $value = '-' . $value;
+        } else {
+            $value = '±' . $value;
         }
         $form->addElement(form_makeOpenTag('span', array('class' => $class)));
         $form->addElement($value);

--- a/lib/tpl/dokuwiki/css/_recent.css
+++ b/lib/tpl/dokuwiki/css/_recent.css
@@ -47,20 +47,20 @@
 
 /*____________ size differences ____________*/
 
-.dokuwiki li .sizechange {
+.dokuwiki form.changes li .sizechange {
     font-size: 80%;
-    border-radius: 0.2em;
-    padding: 0.1em 0.2em
+    border-radius: .2em;
+    padding: .1em .2em;
+    /* cannot use non-guaranteed style.ini colour placeholders, dark templates need to overwrite */
+    background-color: #ddd;
 }
 
-.dokuwiki li .sizechange.positive {
+.dokuwiki form.changes li .sizechange.positive {
     background-color: #cfc;;
 }
-
-.dokuwiki li .sizechange.negative {
+.dokuwiki form.changes li .sizechange.negative {
     background-color: #fdd;
 }
-
 
 /*____________ page navigator ____________*/
 


### PR DESCRIPTION
This fixes a few minor issues with the file size changes (#1316):

* I noticed that sometimes the unit can wrap onto the next line. There should generally always be a non-breaking space (or a thinner nbsp like U+202F) between a number and a unit. ![image](https://cloud.githubusercontent.com/assets/108893/15457753/57e3e36a-2087-11e6-9854-633b233840fe.png)
* When the change in the file size was zero, the output was missing a background colour. I also added a +/- sign as it would otherwise be less clear that this number refers to a change. ![image](https://cloud.githubusercontent.com/assets/108893/15457766/a3bea662-2087-11e6-8c79-7df50fd52f07.png)
* I changed the CSS selectors to be more consistent (as mentioned in #1316).