### PR TITLE
Fix bulk upload to allow multiple groups

### DIFF
--- a/lib/plugins/usermanager/admin.php
+++ b/lib/plugins/usermanager/admin.php
@@ -1000,7 +1000,7 @@ class admin_plugin_usermanager extends DokuWiki_Admin_Plugin {
         $INPUT->set('userpass', $candidate[1]);
         $INPUT->set('username', $candidate[2]);
         $INPUT->set('usermail', $candidate[3]);
-        $INPUT->set('usergroups', $candidate[4]);
+        $INPUT->set('usergroups', implode(',', array_slice($candidate, 4)));
 
         $cleaned = $this->_retrieveUser();
         list($user,/* $pass */,$name,$mail,/* $grps */) = $cleaned;


### PR DESCRIPTION
When bulk importing users, only the first group listed is assigned. This is due to the direct addressing of the candidate array, and groups being separated by commas. My change slices off the fourth and any following array pieces and joins them by commas.

Tested on Release 2015-08-10a "Detritus".