### PR TITLE
Keep query params during redirect to headpage

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -81,7 +81,11 @@ function getID($param='id',$clean=true){
             // fall back to default
             $id = $id.$conf['start'];
         }
-        if (isset($ACT) && $ACT === 'show') send_redirect(wl($id,'',true));
+        if (isset($ACT) && $ACT === 'show') {
+            $urlParameters = $_GET;
+            if (isset($urlParameters['id'])) {unset($urlParameters['id']);}
+            send_redirect(wl($id,$urlParameters,true));
+        }
     }
 
     if($clean) $id = cleanID($id);

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -83,7 +83,9 @@ function getID($param='id',$clean=true){
         }
         if (isset($ACT) && $ACT === 'show') {
             $urlParameters = $_GET;
-            if (isset($urlParameters['id'])) {unset($urlParameters['id']);}
+            if (isset($urlParameters['id'])) {
+                unset($urlParameters['id']);
+            }
             send_redirect(wl($id,$urlParameters,true));
         }
     }


### PR DESCRIPTION
As discussed in Issue #1454 dokuwiki currently "forgets" additional queryparams when redirecting from devel: to devel:start

Example:
https://www.dokuwiki.org/devel:?foo=bar
should result in
https://www.dokuwiki.org/devel:start?foo=bar
but actually results in
https://www.dokuwiki.org/devel:start

This commit fixes that behavior.

Fixes #1454