### PR TITLE
 added rev number to most recent link in old revisions page

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -550,7 +550,9 @@ function html_revisions($first=0, $media_id = false){
                     $sizechange = null;
                 }
             }
-            $href = wl($id);
+            $pagelog = new PageChangeLog($ID);
+            $latestrev = $pagelog->getRevisions(-1, 1)[0];
+            $href = wl($id,"rev=$latestrev",false,'&');
             $summary = $INFO['sum'];
             $editor = $INFO['editor'];
         }

--- a/inc/html.php
+++ b/inc/html.php
@@ -551,7 +551,7 @@ function html_revisions($first=0, $media_id = false){
                 }
             }
             $pagelog = new PageChangeLog($ID);
-            $latestrev = $pagelog->getRevisions(-1, 1)[0];
+            $latestrev = array_pop($pagelog->getRevisions(-1, 1));
             $href = wl($id,"rev=$latestrev",false,'&');
             $summary = $INFO['sum'];
             $editor = $INFO['editor'];


### PR DESCRIPTION
We use dokuwiki as internal company knowladgebase. Most of the time we need to link spesific revision of a page across pages. But current page revision number is not appear on **Old revisions** or another page.
So i update the link in **Old revisions** page. 

Now we can get current page link with revision number to use as referance.
