### PR TITLE
implement @retry annotation for our test suite

### DIFF
--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -127,4 +127,44 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
         global $INPUT;
         $INPUT = new Input();
     }
+
+    /**
+     * This implements a retry annotation to automatically rerun flaky tests on failure
+     *
+     * @link http://stackoverflow.com/a/7705811/172068
+     * @throws Exception
+     */
+    public function runBare() {
+        // how often should this test be retried?
+        $retryCount = 1;
+        $annotations = $this->getAnnotations();
+        if(isset($annotations['method']['retry'][0])) {
+            $retryCount = (int) $annotations['method']['retry'][0];
+            if($retryCount < 1) $retryCount = 1;
+        }
+
+        $e = null;
+        for ($i = 0; $i < $retryCount; $i++) {
+            try {
+                parent::runBare();
+                return;
+            } catch (PHPUnit_Framework_IncompleteTestError $e) {
+                // return right away
+                throw $e;
+            } catch (PHPUnit_Framework_SkippedTestError $e) {
+                // return right away
+                throw $e;
+            } catch (Exception $e) {
+                // last one thrown below
+            }
+
+            // wait til retry (each time a little longer)
+            usleep($i * 250000);
+        }
+
+        if($e) {
+            throw $e;
+        }
+    }
+
 }

--- a/_test/tests/test/retry.test.php
+++ b/_test/tests/test/retry.test.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @group integration
+ */
+class InttestsRetryTest extends DokuWikiTest {
+
+    /**
+     * This test only succeeds after 3 retries
+     *
+     * @retry 4
+     */
+    function testRetry() {
+        static $run = 0;
+        $run++;
+
+        if($run > 3) {
+            $this->assertTrue(true);
+        } else {
+            $this->assertTrue(false);
+        }
+    }
+
+}


### PR DESCRIPTION
Some of our tests rely on external resources (like HTTP servers) that
are somewhat flaky sometimes. Instead of having them fail whenever
something goes wrong at the other end, it would be nice to be able to
just retry them a few times before really failing.

This implements a @retry annotation that allows a test to be repeated
the given number of times before it is marked as failed.