### PR TITLE
Fix #1606 link to the first section of the configuration manager

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -354,7 +354,9 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
         // build toc
         $t = array();
 
-        $t[] = html_mktocitem('configuration_manager', $this->getLang('_configuration_manager'), 1);
+        $check = false;
+        $title = $this->getLang('_configuration_manager');
+        $t[] = html_mktocitem(sectionID($title, $check), $title, 1);
         $t[] = html_mktocitem('dokuwiki_settings', $this->getLang('_header_dokuwiki'), 1);
         /** @var setting $setting */
         foreach($toc['conf'] as $setting) {


### PR DESCRIPTION
This lets the section id depend on the localized header. Even though it is not guaranteed that this is actually the title in the introduction it should be the case for most languages as the comment in the English language file says that it is the same.