### PR TITLE
Added file-in-use reference to media-manager

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1162,6 +1162,18 @@ function media_details($image, $auth, $rev='', $meta=false) {
         }
     }
     echo '</dl>'.NL;
+    echo '<dl>'.NL;
+    echo '<dt>'.$lang['reference'].':</dt>';
+    $media_usage = ft_mediause($image,true);
+    if(count($media_usage) > 0){
+        foreach($media_usage as $path){
+            echo '<dd>'.html_wikilink($path).'</dd>';
+        }
+    }else{
+        echo '<dd>'.$lang['nothingfound'].'</dd>';
+    }
+    echo '</dl>'.NL;
+
 }
 
 /**


### PR DESCRIPTION
Added a reference to the media-manager where you can see on which pages the file is used.

This change contains the same code as in #321 but for the media-manager. 

It was proposed in https://forum.dokuwiki.org/thread/13784
