### PR TITLE
apply fixed-width font to uses of the <tt> element

### DIFF
--- a/lib/tpl/dokuwiki/css/basic.less
+++ b/lib/tpl/dokuwiki/css/basic.less
@@ -257,12 +257,20 @@ mark {
     color: inherit;
 }
 
+.monospaced {
+    font-family: Consolas, "Andale Mono WT", "Andale Mono", "Bitstream Vera Sans Mono", "Nimbus Mono L", Monaco, "Courier New", monospace;
+    /* same font stack should be used for ".dokuwiki table.diff td" in _diff.css */
+}
+
+tt {
+    .monospaced;
+}
+
 pre,
 code,
 samp,
 kbd {
-    font-family: Consolas, "Andale Mono WT", "Andale Mono", "Bitstream Vera Sans Mono", "Nimbus Mono L", Monaco, "Courier New", monospace;
-    /* same font stack should be used for ".dokuwiki table.diff td" in _diff.css */
+    .monospaced;
     font-size: 1em;
     direction: ltr;
     text-align: left;


### PR DESCRIPTION
This change modifies the default dokuwiki template.

I'd like to be able to format short blocks of inline text to use a fixed-width font without it being set into an off-color background. One way I've found to do this is by using the 'creole' plugin, but without CSS styling for the `<tt>` tag, the results aren't very appealing.