### PR TITLE
fix calculation of LastRevisionAt

### DIFF
--- a/_test/tests/inc/changelog_getlastrevisionat.test.php
+++ b/_test/tests/inc/changelog_getlastrevisionat.test.php
@@ -129,17 +129,36 @@ class changelog_getlastrevisionat_test extends DokuWikiTest {
      * test get correct revision on deleted media
      *
      */
-    function test_deletedmedia() {
-        $image = 'wiki:kind_zu_katze.png';
+    function test_deletedimage() {
+        global $conf;
+        global $AUTH_ACL;
+
+        //we need to have a user with AUTH_DELETE rights
+        //save settings
+        $oldSuperUser = $conf['superuser'];
+        $oldUseacl = $conf['useacl'];
+        $oldRemoteUser = $_SERVER['REMOTE_USER'];
+
+        $conf['superuser'] = 'admin';
+        $conf['useacl']    = 1;
+        $_SERVER['REMOTE_USER'] = 'admin';
+
+        $image = 'wiki:imageat.png';
+
+        $ret = copy(mediaFn('wiki:kind_zu_katze.png'),mediaFn($image));
+
         $revexpected = @filemtime(mediaFn($image));
         $rev = $revexpected + 10;
 
-        media_delete('wiki:kind_zu_katze.png', 0);
+        $ret = media_delete($image, 0);
 
         $medialog = new MediaChangelog($image);
         $current = $medialog->getLastRevisionAt($rev);
         $this->assertEquals($revexpected, $current);
-    	
-        media_restore($image, $revexpected, AUTH_UPLOAD);
+        
+        //restore settings
+        $_SERVER['REMOTE_USER'] = $oldRemoteUser;
+        $conf['superuser'] = $oldSuperUser;
+        $conf['useacl'] = $oldUseacl;
     }
 }

--- a/_test/tests/inc/changelog_getlastrevisionat.test.php
+++ b/_test/tests/inc/changelog_getlastrevisionat.test.php
@@ -124,4 +124,22 @@ class changelog_getlastrevisionat_test extends DokuWikiTest {
         $current = $pagelog->getLastRevisionAt($rev);
         $this->assertEquals($currentexpected, $current);
     }
+    
+    /**
+     * test get correct revision on deleted media
+     *
+     */
+    function test_deletedmedia() {
+        $image = 'wiki:kind_zu_katze.png';
+        $revexpected = @filemtime(mediaFn($image));
+        $rev = $revexpected + 10;
+
+        media_delete('wiki:kind_zu_katze.png', 0);
+
+        $medialog = new MediaChangelog($image);
+        $current = $medialog->getLastRevisionAt($rev);
+        $this->assertEquals($revexpected, $current);
+    	
+        media_restore($image, $revexpected, AUTH_UPLOAD);
+    }
 }

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -881,7 +881,7 @@ abstract class ChangeLog {
     */
     function getLastRevisionAt($date_at){
         //requested date_at(timestamp) younger or equal then modified_time($this->id) => load current
-        if($date_at >= @filemtime($this->getFilename())) {
+        if(file_exists($this->getFilename()) && $date_at >= @filemtime($this->getFilename())) {
             return '';
         } else if ($rev = $this->getRelativeRevision($date_at+1, -1)) { //+1 to get also the requested date revision
             return $rev;


### PR DESCRIPTION
if for example the current media file is deleted, the function would return '' instead of the correct LastRevision.
