### PR TITLE
Change default image size values

### DIFF
--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -246,10 +246,11 @@ var dw_mediamanager = {
                 }
 
                 s = parseInt(dw_mediamanager.size, 10);
+                var size = s * 200;
 
                 if (s && s >= 1 && s < 4) {
                     opts += (opts.length) ? '&' : '?';
-                    opts += dw_mediamanager.size + '00';
+                    opts += size;
                     if (dw_mediamanager.ext === 'swf') {
                         switch (s) {
                             case 1:


### PR DESCRIPTION
See #1685 

This PR changes the image sizes to small=200, medium=400, and large=600. This makes the image sizes more relevant for today's HD displays.