### PR TITLE
Fix save content modified in COMMON_WIKIPAGE_SAVE

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1325,7 +1325,7 @@ function saveWikiText($id, $text, $summary, $minor = false) {
         io_sweepNS($id, 'mediadir');
     } else {
         // save file (namespace dir is created in io_writeWikiPage)
-        io_writeWikiPage($svdta['file'], $text, $id);
+        io_writeWikiPage($svdta['file'], $svdta['newContent'], $id);
         // pre-save the revision, to keep the attic in sync
         $svdta['newRevision'] = saveOldRevision($id);
         $filesize_new = filesize($svdta['file']);


### PR DESCRIPTION
The event `COMMON_WIKIPAGE_SAVE` offers the opportunity to save the content by modifying `$data['newContent']`. However `saveWikiText()` still saves the original `$text` variable instead of the possibly modified `$svdta['newContent']`. This pull request fixes that incorrect behavior.