### PR TITLE
Return valid xml when XML-RPC interface not enabled

### DIFF
--- a/inc/load.php
+++ b/inc/load.php
@@ -68,6 +68,7 @@ function load_autoload($name){
         'FeedParser'            => DOKU_INC.'inc/FeedParser.php',
         'IXR_Server'            => DOKU_INC.'inc/IXR_Library.php',
         'IXR_Client'            => DOKU_INC.'inc/IXR_Library.php',
+        'IXR_Error'             => DOKU_INC.'inc/IXR_Library.php',
         'IXR_IntrospectionServer' => DOKU_INC.'inc/IXR_Library.php',
         'Doku_Plugin_Controller'=> DOKU_INC.'inc/plugincontroller.class.php',
         'Tar'                   => DOKU_INC.'inc/Tar.class.php',

--- a/lib/exe/xmlrpc.php
+++ b/lib/exe/xmlrpc.php
@@ -4,7 +4,7 @@ if(!defined('DOKU_INC')) define('DOKU_INC',dirname(__FILE__).'/../../');
 require_once(DOKU_INC.'inc/init.php');
 session_write_close();  //close session
 
-if(!$conf['remote']) die('XML-RPC server not enabled.');
+if(!$conf['remote']) die((new IXR_Error(-32605, "XML-RPC server not enabled."))->getXml());
 
 /**
  * Contains needed wrapper functions and registers all available


### PR DESCRIPTION
DokuWiki responds with "XML-RPC server not enabled." to any XML-RPC request if the interface is not enabled. This leads to confusing errors when using Python's [xmlrpclib](https://docs.python.org/2/library/xmlrpclib.html), which always tries to parse the response using [expat](https://docs.python.org/2/library/pyexpat.html). You never get to see the actual response though, as reported e.g. in kynan/dokuwikixmlrpc#2

It would be great to get back a well formed XML response along the lines of

```
<?xml version="1.0"?>
<methodResponse>
    <fault>
        <value>
            <struct>
                <member>
                    <name>faultCode</name>
                    <value>
                        <int>-1</int>
                    </value>
                </member>
                <member>
                    <name>faultString</name>
                    <value>
                        <string>XML-RPC server not enabled</string>
                    </value>
                </member>
            </struct>
        </value>
    </fault>
</methodResponse>
```
