### PR TITLE
Make cropped images responsive

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1572,12 +1572,6 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                 $ret .= ' alt=""';
             }
 
-            if(!is_null($width))
-                $ret .= ' width="'.$this->_xmlEntities($width).'"';
-
-            if(!is_null($height))
-                $ret .= ' height="'.$this->_xmlEntities($height).'"';
-
             $ret .= ' />';
 
         } elseif(media_supportedav($mime, 'video') || media_supportedav($mime, 'audio')) {


### PR DESCRIPTION
Adding the width and height attributes to the img-tags makes the cropped images stretch instead of scaling down proportionally when the screen is smaller than the image. I can't really see any other good reason to keep the attributes so I suggest removing them completely. Please correct me if I'm wrong.