### PR TITLE
Provide icons for plugins in admin menu

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -2174,7 +2174,12 @@ function html_admin(){
         ptln('<ul>');
         foreach ($menu as $item) {
             if (!$item['prompt']) continue;
-            ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.$item['prompt'].'</a></div></li>');
+            //add icon to the item, in case of being specified
+            if(strlen($item['icon']) > 0){
+                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.'<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-item"></img>'.'&nbsp;'.$item['prompt'].'</a></div></li>');
+            } else {
+                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.$item['prompt'].'</a></div></li>');
+            }
         }
         ptln('</ul>');
     }

--- a/inc/html.php
+++ b/inc/html.php
@@ -2175,12 +2175,16 @@ function html_admin(){
         ptln('<ul>');
         foreach ($menu as $item) {
             if (!$item['prompt']) continue;
+            ptln('  <li><div class="li admin-plugin-container"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">');
+            ptln('<div class="admin-plugin-icon">');
             //add icon to the item, in case of being specified
-            ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">');
             if(strlen($item['icon']) > 0){
-                ptln('<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-plugin-icon"></img>');
+                ptln('<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'"></img>');
             }
+            ptln('</div>');
+            ptln('<div class="admin-plugin-name">');
             ptln($item['prompt']);
+            ptln('</div>');
             ptln('</a></div></li>');
         }
         ptln('</ul>');

--- a/inc/html.php
+++ b/inc/html.php
@@ -2177,7 +2177,7 @@ function html_admin(){
             if (!$item['prompt']) continue;
             //add icon to the item, in case of being specified
             if(strlen($item['icon']) > 0){
-                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.'<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-item"></img>'.'&nbsp;'.$item['prompt'].'</a></div></li>');
+                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.'<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-plugin-icon"></img>'.'&nbsp;'.$item['prompt'].'</a></div></li>');
             } else {
                 ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.$item['prompt'].'</a></div></li>');
             }

--- a/inc/html.php
+++ b/inc/html.php
@@ -2073,7 +2073,8 @@ function html_admin(){
 
         $menu[$p] = array('plugin' => $p,
                 'prompt' => $obj->getMenuText($conf['lang']),
-                'sort' => $obj->getMenuSort()
+                'icon' => $obj->getMenuIcon(),
+                'sort' => $obj->getMenuSort(),
                 );
     }
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -2073,7 +2073,7 @@ function html_admin(){
 
         $menu[$p] = array('plugin' => $p,
                 'prompt' => $obj->getMenuText($conf['lang']),
-                'icon' => $obj->getMenuIcon(),
+                'icon' => $obj->getMenuIconSvgOnly(),
                 'sort' => $obj->getMenuSort(),
                 );
     }
@@ -2172,20 +2172,20 @@ function html_admin(){
         // output the menu
         ptln('<div class="clearer"></div>');
         print p_locale_xhtml('adminplugins');
-        ptln('<ul>');
+        ptln('<ul class="admin_plugins icon">');       
         foreach ($menu as $item) {
             if (!$item['prompt']) continue;
-            ptln('  <li><div class="li admin-plugin-container"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">');
-            ptln('<div class="admin-plugin-icon">');
+            ptln('<li><div class="li admin_plugin_container">');
+            ptln('<div class="admin_plugin_icon">');
             //add icon to the item, in case of being specified
             if(strlen($item['icon']) > 0){
-                ptln('<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'"></img>');
+                 ptln('<img src="'.$item['icon'].'" alt="admin_icon_'.hsc($item['prompt']).'"></img>');
             }
             ptln('</div>');
-            ptln('<div class="admin-plugin-name">');
+            ptln('<div class="admin_plugin_name"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">');
             ptln($item['prompt']);
-            ptln('</div>');
-            ptln('</a></div></li>');
+            ptln('</a></div>');
+            ptln('</div></li>');
         }
         ptln('</ul>');
     }

--- a/inc/html.php
+++ b/inc/html.php
@@ -2176,11 +2176,12 @@ function html_admin(){
         foreach ($menu as $item) {
             if (!$item['prompt']) continue;
             //add icon to the item, in case of being specified
+            ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">');
             if(strlen($item['icon']) > 0){
-                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.'<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-plugin-icon"></img>'.'&nbsp;'.$item['prompt'].'</a></div></li>');
-            } else {
-                ptln('  <li><div class="li"><a href="'.wl($ID, 'do=admin&amp;page='.$item['plugin']).'">'.$item['prompt'].'</a></div></li>');
+                ptln('<img src="'.$item['icon'].'" alt="admin-icon-'.hsc($item['prompt']).'" class="admin-menu-plugin-icon"></img>');
             }
+            ptln($item['prompt']);
+            ptln('</a></div></li>');
         }
         ptln('</ul>');
     }

--- a/lib/plugins/admin.php
+++ b/lib/plugins/admin.php
@@ -52,7 +52,8 @@ class DokuWiki_Admin_Plugin extends DokuWiki_Plugin {
         $returnValue = '';        
         
         if(strlen($this->getMenuIcon()) != '' && is_file(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)))){
-           if(mimetype(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)), false)[0] == 'svg') {
+           $calculated = mimetype(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)), false);
+           if(is_array($calculated) && $calculated[0] == 'svg') {
                $returnValue = $this->getMenuIcon();
            }
         }

--- a/lib/plugins/admin.php
+++ b/lib/plugins/admin.php
@@ -34,9 +34,29 @@ class DokuWiki_Admin_Plugin extends DokuWiki_Plugin {
      * Return the path to the icon being displayed in the main admin menu.
      * Default means, there won't be any icon.
      * (Override this function for setting another image)
+     * 
+     * CAUTION:
+     * Only svg-files are allowed
+     * 
      */
     public function getMenuIcon(){
         return '';
+    }
+    
+    /**
+     * Return the path to the icon being displayed in the main admin menu.
+     * In case of file mime-type not being SVG, an empty string will be returned.
+     * @return string menu icon url or empty
+     */
+    public function getMenuIconSvgOnly(){
+        $returnValue = '';        
+        
+        if(strlen($this->getMenuIcon()) != '' && is_file(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)))){
+           if(array_values(mimetype(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)), false)) == array('svg','application/octet-stream', true)) {
+               $returnValue = $this->getMenuIcon();
+           }
+        }
+        return $returnValue;
     }
     
     /**

--- a/lib/plugins/admin.php
+++ b/lib/plugins/admin.php
@@ -31,6 +31,15 @@ class DokuWiki_Admin_Plugin extends DokuWiki_Plugin {
     }
 
     /**
+     * Return the path to the icon being displayed in the main admin menu.
+     * Default means, there won't be any icon.
+     * (Override this function for setting another image)
+     */
+    public function getMenuIcon(){
+        return '';
+    }
+    
+    /**
      * Determine position in list in admin window
      * Lower values are sorted up
      *

--- a/lib/plugins/admin.php
+++ b/lib/plugins/admin.php
@@ -52,7 +52,7 @@ class DokuWiki_Admin_Plugin extends DokuWiki_Plugin {
         $returnValue = '';        
         
         if(strlen($this->getMenuIcon()) != '' && is_file(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)))){
-           if(array_values(mimetype(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)), false)) == array('svg','application/octet-stream', true)) {
+           if(mimetype(DOKU_INC.substr($this->getMenuIcon(), strlen(DOKU_BASE)), false)[0] == 'svg') {
                $returnValue = $this->getMenuIcon();
            }
         }

--- a/lib/tpl/dokuwiki/css/_admin.css
+++ b/lib/tpl/dokuwiki/css/_admin.css
@@ -49,6 +49,55 @@
     background-image: url(../../images/admin/popularity.png);
 }
 
+/* DokuWiki additional plugins below */
+.dokuwiki ul.admin_plugins {
+	float: left;
+	width: 40%;
+}
+
+.dokuwiki ul.admin_plugins.no_icon{
+	float: left;
+	width: 40%;
+}
+
+.dokuwiki ul.admin_plugins.icon{
+	list-style-type: none;
+}
+
+.dokuwiki ul.admin_plugins li {
+	pading-left: 35px;
+	margin: 0 0 0.4em 0;
+	color: inherit;
+	background: transparent none no-repeat scroll 0 0;
+}
+
+.dokuwiki ul.admin_plugins li .admin_plugin_container {
+	display: block;
+	height: 20px;
+	vertical-align: middle;
+}
+
+.dokuwiki ul.admin_plugins li .admin_plugin_container div.admin_plugin_icon {
+	width: 20px;
+	height: 20px;
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.dokuwiki ul.admin_plugins li .admin_plugin_container div.admin_plugin_icon img {
+	height: 20px;
+	width: 20px;
+}
+
+.dokuwiki ul.admin_plugins li .admin_plugin_container div.admin_plugin_name {
+	padding-left: 0.5em;
+	vertical-align: middle;
+	display: inline-block;
+	text-align: center;
+	margin: 0 auto;
+}
+
+
 /* DokuWiki version below */
 .dokuwiki #admin__version {
     clear: left;


### PR DESCRIPTION
These changes provide the option to specify an icon for the admin menu.

By default, no icon will be displayed.

Icons can be specified by overriding the `getMenuIcon` method in each plugin, returning the src to the icon.