### PR TITLE
Test against the current hhvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,27 @@ php:
   - "5.5"
   - "5.4"
   - "5.3"
-  - "hhvm"
+
 env:
   - DISABLE_FUNCTIONS=
   - DISABLE_FUNCTIONS="gzopen"
 matrix:
+  fast_finish: true
+  include:
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+        - postgresql
+      env: DISABLE_FUNCTIONS=
   allow_failures:
     - php: "hhvm"
   exclude:
@@ -23,9 +39,6 @@ notifications:
         - "chat.freenode.net#dokuwiki"
     on_success: change
     on_failure: change
-services:
-  - "mysql"
-  - "postgresql"
 install:
   - wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit.phar
   - chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
   - wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit.phar
   - chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit
 before_script:
+  # Disable the HHVM JIT for faster Unit Testing
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
   - test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp _test/mysql.conf.php.dist _test/mysql.conf.php
   - cp _test/pgsql.conf.php.dist _test/pgsql.conf.php


### PR DESCRIPTION
This provides the current HHVM version (3.15.3 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released.

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/