### PR TITLE
Add support for optgroup-tags for select-fields

### DIFF
--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -104,6 +104,7 @@ class form_dropdownelement_test extends DokuWikiTest {
         $dropdown->val('third');
         $this->assertEquals('third', $dropdown->val());
 
+        /** @var Form\OptGroup[] $optGroups */
         $optGroups = $dropdown->optGroups();
         $this->assertEquals(array(
             'first' => array('label' => 'the label'),
@@ -114,8 +115,8 @@ class form_dropdownelement_test extends DokuWikiTest {
         $html = $form->toHTML();
         $pq = phpQuery::newDocumentXHTML($html);
 
-        $optGroups = $pq->find('optgroup');
-        $this->assertEquals(2, $optGroups->length);
+        $optGroupsHTML = $pq->find('optgroup');
+        $this->assertEquals(2, $optGroupsHTML->length);
 
         $options = $pq->find('option');
         $this->assertEquals(4, $options->length);
@@ -123,8 +124,37 @@ class form_dropdownelement_test extends DokuWikiTest {
         $selected = $pq->find('option[selected=selected]');
         $this->assertEquals('third', $selected->val());
         $this->assertEquals('label of third option', $selected->text());
-
     }
+
+    /**
+     * Ensure that there is always only a single one selected option
+     */
+    public function test_optgroups_doubleselect() {
+        $form = new Form\Form();
+        $options1 = array(
+            'double' => 'the label'
+        );
+
+        $options2 = array(
+            'double' => array (
+                'label' => 'label of third option',
+                'attribute' => 'attribute-value'
+            )
+        );
+
+        $dropdown = $form->addDropdown('foo', null, 'label text');
+        $dropdown->addOptGroup('opt1', $options1);
+        $dropdown->addOptGroup('opt2', $options2);
+        $dropdown->val('double');
+
+        // HTML
+        $html = $form->toHTML();
+        $pq = phpQuery::newDocumentXHTML($html);
+        $selected = $pq->find('option[selected=selected]');
+        $this->assertEquals(1, $selected->length);
+        $this->assertEquals('the label', $selected->text());
+    }
+
 
     /**
      * check that posted values overwrite preset default

--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -81,6 +81,51 @@ class form_dropdownelement_test extends DokuWikiTest {
         $this->assertTrue($option->hasClass('classes'));
     }
 
+    public function test_optgroups() {
+        $form = new Form\Form();
+
+        $options1 = array(
+            'first' => 'the label',
+            'second'
+        );
+
+        $options2 = array(
+            'third' => array (
+                'label' => 'label of third option',
+                'attribute' => 'attribute-value'
+            ),
+            'fourth'
+        );
+
+        $dropdown = $form->addDropdown('foo', null, 'label text');
+        $dropdown->addOptGroup('opt1', $options1);
+        $dropdown->addOptGroup('opt2', $options2);
+
+        $dropdown->val('third');
+        $this->assertEquals('third', $dropdown->val());
+
+        $optGroups = $dropdown->optGroups();
+        $this->assertEquals(array(
+            'first' => array('label' => 'the label'),
+            'second' => array('label' => 'second')
+        ), $optGroups[0]->options());
+
+        // HTML
+        $html = $form->toHTML();
+        $pq = phpQuery::newDocumentXHTML($html);
+
+        $optGroups = $pq->find('optgroup');
+        $this->assertEquals(2, $optGroups->length);
+
+        $options = $pq->find('option');
+        $this->assertEquals(4, $options->length);
+
+        $selected = $pq->find('option[selected=selected]');
+        $this->assertEquals('third', $selected->val());
+        $this->assertEquals('label of third option', $selected->text());
+
+    }
+
     /**
      * check that posted values overwrite preset default
      */

--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -109,7 +109,7 @@ class form_dropdownelement_test extends DokuWikiTest {
         $this->assertEquals(array(
             'first' => array('label' => 'the label'),
             'second' => array('label' => 'second')
-        ), $optGroups[0]->options());
+        ), $optGroups['opt1']->options());
 
         // HTML
         $html = $form->toHTML();

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -52,7 +52,7 @@ class DropdownElement extends InputElement {
      *   * the value being an array of options as defined in @see OptGroup::options()
      *
      * @param null|array $optGroups
-     * @return array
+     * @return OptGroup[]|DropdownElement
      */
     public function optGroups($optGroups = null) {
         if($optGroups === null) {
@@ -65,6 +65,7 @@ class DropdownElement extends InputElement {
         foreach ($optGroups as $label => $options) {
             $this->addOptGroup($label, $options);
         }
+        return $this;
     }
 
     /**

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -33,7 +33,7 @@ class DropdownElement extends InputElement {
     /**
      * @param $label
      * @param $options
-     * @return mixed
+     * @return OptGroup
      * @throws \Exception
      */
     public function addOptGroup($label, $options) {
@@ -161,9 +161,14 @@ class DropdownElement extends InputElement {
      * @return bool
      */
     protected function setValueInOptGroups($value) {
-        $value_exists = $this->options->setValue($value);
-        foreach ($this->optGroups as $optGroup) {
+        $value_exists = false;
+        $isMultiSelect = $this->attributes['multiple'];
+        /** @var OptGroup $optGroup */
+        foreach (array_merge(array($this->options), $this->optGroups) as $optGroup) {
             $value_exists = $optGroup->setValue($value) || $value_exists;
+            if ($value_exists && !$isMultiSelect) {
+                $value = null;
+            }
         }
         return $value_exists;
     }

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -163,11 +163,10 @@ class DropdownElement extends InputElement {
      */
     protected function setValueInOptGroups($value) {
         $value_exists = false;
-        $isMultiSelect = $this->attributes['multiple'];
         /** @var OptGroup $optGroup */
         foreach (array_merge(array($this->options), $this->optGroups) as $optGroup) {
             $value_exists = $optGroup->setValue($value) || $value_exists;
-            if ($value_exists && !$isMultiSelect) {
+            if ($value_exists) {
                 $value = null;
             }
         }

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -165,7 +165,7 @@ class DropdownElement extends InputElement {
         $value_exists = false;
         /** @var OptGroup $optGroup */
         foreach (array_merge(array($this->options), $this->optGroups) as $optGroup) {
-            $value_exists = $optGroup->setValue($value) || $value_exists;
+            $value_exists = $optGroup->storeValue($value) || $value_exists;
             if ($value_exists) {
                 $value = null;
             }

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -10,37 +10,34 @@ namespace dokuwiki\Form;
  */
 class DropdownElement extends InputElement {
 
-    /** @var OptGroup */
-    protected $options = null;
-
     /** @var array OptGroup[] */
     protected $optGroups = array();
 
-    protected $value = '';
-
     /**
      * @param string $name The name of this form element
-     * @param string $options The available options
+     * @param array  $options The available options
      * @param string $label The label text for this element (will be autoescaped)
      */
     public function __construct($name, $options, $label = '') {
         parent::__construct('dropdown', $name, $label);
         $this->rmattr('type');
-        $this->options = new OptGroup(null, $options);
+        $this->optGroups[''] = new OptGroup(null, $options);
         $this->val('');
     }
 
     /**
-     * @param $label
-     * @param $options
-     * @return OptGroup
+     * Add an `<optgroup>` and respective options
+     *
+     * @param string $label
+     * @param array  $options
+     * @return OptGroup a reference to the added optgroup
      * @throws \Exception
      */
     public function addOptGroup($label, $options) {
         if (empty($label)) {
             throw new \InvalidArgumentException(hsc('<optgroup> must have a label!'));
         }
-        $this->optGroups[] = new OptGroup($label, $options);
+        $this->optGroups[$label] = new OptGroup($label, $options);
         return end($this->optGroups);
     }
 
@@ -86,9 +83,9 @@ class DropdownElement extends InputElement {
      */
     public function options($options = null) {
         if ($options === null) {
-            return $this->options->options();
+            return $this->optGroups['']->options();
         }
-        $this->options = new OptGroup(null, $options);
+        $this->optGroups[''] = new OptGroup(null, $options);
         return $this;
     }
 
@@ -164,7 +161,7 @@ class DropdownElement extends InputElement {
     protected function setValueInOptGroups($value) {
         $value_exists = false;
         /** @var OptGroup $optGroup */
-        foreach (array_merge(array($this->options), $this->optGroups) as $optGroup) {
+        foreach ($this->optGroups as $optGroup) {
             $value_exists = $optGroup->storeValue($value) || $value_exists;
             if ($value_exists) {
                 $value = null;
@@ -182,7 +179,6 @@ class DropdownElement extends InputElement {
         if($this->useInput) $this->prefillInput();
 
         $html = '<select ' . buildAttributes($this->attrs()) . '>';
-        $html .= $this->options->toHTML();
         $html = array_reduce($this->optGroups, function($html, OptGroup $optGroup) {return $html . $optGroup->toHTML();}, $html);
         $html .= '</select>';
 

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -10,7 +10,11 @@ namespace dokuwiki\Form;
  */
 class DropdownElement extends InputElement {
 
-    protected $options = array();
+    /** @var OptGroup */
+    protected $options = null;
+
+    /** @var array OptGroup[] */
+    protected $optGroups = array();
 
     protected $value = '';
 
@@ -22,7 +26,45 @@ class DropdownElement extends InputElement {
     public function __construct($name, $options, $label = '') {
         parent::__construct('dropdown', $name, $label);
         $this->rmattr('type');
-        $this->options($options);
+        $this->options = new OptGroup(null, $options);
+        $this->val('');
+    }
+
+    /**
+     * @param $label
+     * @param $options
+     * @return mixed
+     * @throws \Exception
+     */
+    public function addOptGroup($label, $options) {
+        if (empty($label)) {
+            throw new \InvalidArgumentException(hsc('<optgroup> must have a label!'));
+        }
+        $this->optGroups[] = new OptGroup($label, $options);
+        return end($this->optGroups);
+    }
+
+    /**
+     * Set or get the optgroups of an Dropdown-Element.
+     *
+     * optgroups have to be given as associative array
+     *   * the key being the label of the group
+     *   * the value being an array of options as defined in @see OptGroup::options()
+     *
+     * @param null|array $optGroups
+     * @return array
+     */
+    public function optGroups($optGroups = null) {
+        if($optGroups === null) {
+            return $this->optGroups;
+        }
+        if (!is_array($optGroups)) {
+            throw new \InvalidArgumentException(hsc('Argument must be an associative array of label => [options]!'));
+        }
+        $this->optGroups = array();
+        foreach ($optGroups as $label => $options) {
+            $this->addOptGroup($label, $options);
+        }
     }
 
     /**
@@ -42,21 +84,10 @@ class DropdownElement extends InputElement {
      * @return $this|array
      */
     public function options($options = null) {
-        if($options === null) return $this->options;
-        if(!is_array($options)) throw new \InvalidArgumentException('Options have to be an array');
-        $this->options = array();
-
-        foreach($options as $key => $val) {
-            if(is_int($key)) {
-                $this->options[$val] = array('label' => (string) $val);
-            } elseif (!is_array($val)) {
-                $this->options[$key] = array('label' => (string) $val);
-            } else {
-                if (!key_exists('label', $val)) throw new \InvalidArgumentException('If option is given as array, it has to have a "label"-key!');
-                $this->options[$key] = $val;
-            }
+        if ($options === null) {
+            return $this->options->options();
         }
-        $this->val(''); // set default value (empty or first)
+        $this->options = new OptGroup(null, $options);
         return $this;
     }
 
@@ -92,15 +123,49 @@ class DropdownElement extends InputElement {
     public function val($value = null) {
         if($value === null) return $this->value;
 
-        if(isset($this->options[$value])) {
+        $value_exists = $this->setValueInOptGroups($value);
+
+        if($value_exists) {
             $this->value = $value;
         } else {
             // unknown value set, select first option instead
-            $keys = array_keys($this->options);
-            $this->value = (string) array_shift($keys);
+            $this->value = $this->getFirstOption();
+            $this->setValueInOptGroups($this->value);
         }
 
         return $this;
+    }
+
+    /**
+     * Returns the first options as it will be rendered in HTML
+     *
+     * @return string
+     */
+    protected function getFirstOption() {
+        $options = $this->options();
+        if (!empty($options)) {
+            return (string) array_shift(array_keys($options));
+        }
+        foreach ($this->optGroups as $optGroup) {
+            $options = $optGroup->options();
+            if (!empty($options)) {
+                return (string) array_shift(array_keys($options));
+            }
+        }
+    }
+
+    /**
+     * Set the value in the OptGroups, including the optgroup for the options without optgroup.
+     *
+     * @param string $value
+     * @return bool
+     */
+    protected function setValueInOptGroups($value) {
+        $value_exists = $this->options->setValue($value);
+        foreach ($this->optGroups as $optGroup) {
+            $value_exists = $optGroup->setValue($value) || $value_exists;
+        }
+        return $value_exists;
     }
 
     /**
@@ -112,15 +177,8 @@ class DropdownElement extends InputElement {
         if($this->useInput) $this->prefillInput();
 
         $html = '<select ' . buildAttributes($this->attrs()) . '>';
-        foreach($this->options as $key => $val) {
-            $selected = ($key == $this->value) ? ' selected="selected"' : '';
-            $attrs = '';
-            if (is_array($val['attrs'])) {
-                array_walk($val['attrs'],function (&$aval, $akey){$aval = hsc($akey).'="'.hsc($aval).'"';});
-                $attrs = join(' ', $val['attrs']);
-            }
-            $html .= '<option' . $selected . ' value="' . hsc($key) . '" '.$attrs.'>' . hsc($val['label']) . '</option>';
-        }
+        $html .= $this->options->toHTML();
+        $html = array_reduce($this->optGroups, function($html, OptGroup $optGroup) {return $html . $optGroup->toHTML();}, $html);
         $html .= '</select>';
 
         return $html;

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -21,6 +21,7 @@ class DropdownElement extends InputElement {
      */
     public function __construct($name, $options, $label = '') {
         parent::__construct('dropdown', $name, $label);
+        $this->rmattr('type');
         $this->options($options);
     }
 

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -18,14 +18,14 @@ class OptGroup extends Element {
     }
 
     /**
-     * Set the element's value
+     * Store the given value so it can be used during rendering
      *
      * This is intended to be only called from within @see DropdownElement::val()
      *
      * @param string $value
-     * @return bool
+     * @return bool true if an option with the given value exists, false otherwise
      */
-    public function setValue($value) {
+    public function storeValue($value) {
         $this->value = $value;
         return isset($this->options[$value]);
     }

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -8,12 +8,11 @@ class OptGroup extends Element {
     protected $value;
 
     /**
-     * @param string $name The name of this form element
-     * @param string $options The available options
      * @param string $label The label text for this element (will be autoescaped)
+     * @param array  $options The available options
      */
-    public function __construct($name, $options) {
-        parent::__construct('optGroup', array('label' => $name));
+    public function __construct($label, $options) {
+        parent::__construct('optGroup', array('label' => $label));
         $this->options($options);
     }
 

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -88,9 +88,8 @@ class OptGroup extends Element {
         foreach($this->options as $key => $val) {
             $selected = ($key == $this->value) ? ' selected="selected"' : '';
             $attrs = '';
-            if (is_array($val['attrs'])) {
-                array_walk($val['attrs'],function (&$aval, $akey){$aval = hsc($akey).'="'.hsc($aval).'"';});
-                $attrs = join(' ', $val['attrs']);
+            if (!empty($val['attrs']) && is_array($val['attrs'])) {
+                $attrs = buildAttributes($val['attrs']);
             }
             $html .= '<option' . $selected . ' value="' . hsc($key) . '" '.$attrs.'>' . hsc($val['label']) . '</option>';
         }


### PR DESCRIPTION
In more complex selects we may want to group options by some criteria. HTML has the `<optgroup>`-tag for that purpose.

However in order to not duplicate code, I have chosen to move the handling of options to the `OptGroup`-class.

ToDo
-------
- [x] Tests

Known Issues:
------------------
* We no longer ensure that there are no duplicate options. Whereas before there could be no two options with the same value, because every option's value was a key in an associative array, now there can be two options with the same value within different optgroups
* This has also the consequence that there might be more than two options with the `selected`-attribute.

This also fixes #1776 