### PR TITLE
Fix problems in authpdo

### DIFF
--- a/lib/plugins/authpdo/_test/sqlite.test.php
+++ b/lib/plugins/authpdo/_test/sqlite.test.php
@@ -195,12 +195,12 @@ class sqlite_plugin_authpdo_test extends DokuWikiTest {
 
         $users = $auth->retrieveUsers(0, -1, array('group' => 'admin')); // full group
         $this->assertEquals(array($expect['admin'], $expect['tester']), $users);
-        $count = $auth->getUserCount(array('group' => 'admin'));
+        $count = $auth->getUserCount(array('grps' => 'admin'));
         $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('group' => 'dmi')); // substring
         $this->assertEquals(array($expect['admin'], $expect['tester']), $users);
-        $count = $auth->getUserCount(array('group' => 'dmi'));
+        $count = $auth->getUserCount(array('grps' => 'dmi'));
         $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('user' => 'dmi')); // substring

--- a/lib/plugins/authpdo/_test/sqlite.test.php
+++ b/lib/plugins/authpdo/_test/sqlite.test.php
@@ -171,21 +171,21 @@ class sqlite_plugin_authpdo_test extends DokuWikiTest {
         $users = $auth->retrieveUsers(0, -1, array('group' => 'admin')); // full group
         $this->assertEquals(array('admin', 'tester'), $users);
         $count = $auth->getUserCount(array('group' => 'admin'));
-        $this->assertEquals(2, $count);
+        $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('group' => 'dmi')); // substring
         $this->assertEquals(array('admin', 'tester'), $users);
         $count = $auth->getUserCount(array('group' => 'dmi'));
-        $this->assertEquals(2, $count);
+        $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('user' => 'dmi')); // substring
         $this->assertEquals(array('admin'), $users);
         $count = $auth->getUserCount(array('user' => 'dmi'));
-        $this->assertEquals(1, $count);
+        $this->assertSame(1, $count);
 
         // delete user
         $num = $auth->deleteUsers(array('tester', 'foobar'));
-        $this->assertEquals(1, $num);
+        $this->assertSame(1, $num);
 
     }
 

--- a/lib/plugins/authpdo/_test/sqlite.test.php
+++ b/lib/plugins/authpdo/_test/sqlite.test.php
@@ -158,28 +158,53 @@ class sqlite_plugin_authpdo_test extends DokuWikiTest {
         $info = $auth->getUserData('tester');
         $this->assertEquals(array('admin', 'another', 'user'), $info['grps']);
 
+
+        $expect = array(
+            'admin' => array(
+                'user' => 'admin',
+                'name' => 'The Admin',
+                'mail' => 'admin@example.com',
+                'uid' => '1',
+                'grps' => array('admin', 'user')
+            ),
+            'user' => array(
+                'user' => 'user',
+                'name' => 'A normal user',
+                'mail' => 'user@example.com',
+                'uid' => '2',
+                'grps' => array('user')
+            ),
+            'tester' => array(
+                'user' => 'tester',
+                'name' => 'The Test User',
+                'mail' => 'test@example.com',
+                'uid' => '3',
+                'grps' => array('admin', 'another', 'user')
+            )
+        );
+
         // list users
         $users = $auth->retrieveUsers();
-        $this->assertEquals(array('admin', 'tester', 'user'), $users);
+        $this->assertEquals(array($expect['admin'], $expect['tester'], $expect['user']), $users);
 
         $users = $auth->retrieveUsers(1); // offset
-        $this->assertEquals(array('tester', 'user'), $users);
+        $this->assertEquals(array($expect['tester'], $expect['user']), $users);
 
         $users = $auth->retrieveUsers(1, 1); // offset + limit
-        $this->assertEquals(array('tester'), $users);
+        $this->assertEquals(array($expect['tester']), $users);
 
         $users = $auth->retrieveUsers(0, -1, array('group' => 'admin')); // full group
-        $this->assertEquals(array('admin', 'tester'), $users);
+        $this->assertEquals(array($expect['admin'], $expect['tester']), $users);
         $count = $auth->getUserCount(array('group' => 'admin'));
         $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('group' => 'dmi')); // substring
-        $this->assertEquals(array('admin', 'tester'), $users);
+        $this->assertEquals(array($expect['admin'], $expect['tester']), $users);
         $count = $auth->getUserCount(array('group' => 'dmi'));
         $this->assertSame(2, $count);
 
         $users = $auth->retrieveUsers(0, -1, array('user' => 'dmi')); // substring
-        $this->assertEquals(array('admin'), $users);
+        $this->assertEquals(array($expect['admin']), $users);
         $count = $auth->getUserCount(array('user' => 'dmi'));
         $this->assertSame(1, $count);
 

--- a/lib/plugins/authpdo/auth.php
+++ b/lib/plugins/authpdo/auth.php
@@ -420,7 +420,7 @@ class auth_plugin_authpdo extends DokuWiki_Auth_Plugin {
                 $this->_debug("Statement did not return 'user' attribute", -1, __LINE__);
                 return array();
             }
-            $users[] = $row['user'];
+            $users[] = $this->getUserData($row['user']);
         }
         return $users;
     }

--- a/lib/plugins/authpdo/auth.php
+++ b/lib/plugins/authpdo/auth.php
@@ -446,7 +446,7 @@ class auth_plugin_authpdo extends DokuWiki_Auth_Plugin {
         if(!$result || !isset($result[0]['count'])) {
             $this->_debug("Statement did not return 'count' attribute", -1, __LINE__);
         }
-        return isset($result[0]['count']);
+        return (int) $result[0]['count'];
     }
 
     /**

--- a/lib/plugins/authpdo/auth.php
+++ b/lib/plugins/authpdo/auth.php
@@ -401,6 +401,7 @@ class auth_plugin_authpdo extends DokuWiki_Auth_Plugin {
         if($limit < 0) $limit = 10000; // we don't support no limit
         if(is_null($filter)) $filter = array();
 
+        if(isset($filter['grps'])) $filter['group'] = $filter['grps'];
         foreach(array('user', 'name', 'mail', 'group') as $key) {
             if(!isset($filter[$key])) {
                 $filter[$key] = '%';
@@ -434,6 +435,7 @@ class auth_plugin_authpdo extends DokuWiki_Auth_Plugin {
     public function getUserCount($filter = array()) {
         if(is_null($filter)) $filter = array();
 
+        if(isset($filter['grps'])) $filter['group'] = $filter['grps'];
         foreach(array('user', 'name', 'mail', 'group') as $key) {
             if(!isset($filter[$key])) {
                 $filter[$key] = '%';


### PR DESCRIPTION
this fixes three problems:

* retrieveUsers() did only return user names instead of full user info #1781
* getUserCount() returned a boolean instead of the count #1781 
* filters for groups were not handled correctly

Tests have been adjusted accordingly.