### PR TITLE
Handle delayed writes gracefully

### DIFF
--- a/_test/tests/inc/changelog_getlastrevisionat.test.php
+++ b/_test/tests/inc/changelog_getlastrevisionat.test.php
@@ -150,11 +150,16 @@ class changelog_getlastrevisionat_test extends DokuWikiTest {
         $revexpected = @filemtime(mediaFn($image));
         $rev = $revexpected + 10;
 
+        $this->waitForTick(true);
+
         $ret = media_delete($image, 0);
 
         $medialog = new MediaChangelog($image);
         $current = $medialog->getLastRevisionAt($rev);
-        $this->assertEquals($revexpected, $current);
+        // as we wait for a tick, we should get something greater than the timestamp
+        $this->assertGreaterThan($revexpected, $current);
+        // however, it should be less than the current time or equal to it
+        $this->assertLessThanOrEqual(time(), $current);
         
         //restore settings
         $_SERVER['REMOTE_USER'] = $oldRemoteUser;

--- a/_test/tests/inc/remoteapicore.test.php
+++ b/_test/tests/inc/remoteapicore.test.php
@@ -40,6 +40,13 @@ class remoteapicore_test extends DokuWikiTest {
         $AUTH_ACL = $this->oldAuthAcl;
     }
 
+    /** Delay writes of old revisions by a second. */
+    public function handle_write(Doku_Event $event, $param) {
+        if ($event->data[3] !== false) {
+            $this->waitForTick();
+        }
+    }
+
     public function test_getVersion() {
         $this->assertEquals(getVersion(), $this->remote->call('dokuwiki.getVersion'));
     }
@@ -382,6 +389,9 @@ You can use up to five different levels of',
     }
 
     public function test_getPageVersions() {
+        /** @var $EVENT_HANDLER Doku_Event_Handler */
+        global $EVENT_HANDLER;
+        $EVENT_HANDLER->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE', $this, 'handle_write');
         global $conf;
 
         $id = 'revpage';

--- a/inc/RemoteAPICore.php
+++ b/inc/RemoteAPICore.php
@@ -449,14 +449,20 @@ class RemoteAPICore {
             throw new RemoteException('The requested page does not exist', 121);
         }
 
+        // set revision to current version if empty, use revision otherwise
+        // as the timestamps of old files are not necessarily correct
+        if($rev === '') {
+            $rev = $time;
+        }
+
         $pagelog = new PageChangeLog($id, 1024);
-        $info = $pagelog->getRevisionInfo($time);
+        $info = $pagelog->getRevisionInfo($rev);
 
         $data = array(
             'name'         => $id,
-            'lastModified' => $this->api->toDate($time),
+            'lastModified' => $this->api->toDate($rev),
             'author'       => (($info['user']) ? $info['user'] : $info['ip']),
-            'version'      => $time
+            'version'      => $rev
         );
 
         return ($data);
@@ -806,7 +812,7 @@ class RemoteAPICore {
                 // specified via $conf['recent']
                 if($time){
                     $pagelog->setChunkSize(1024);
-                    $info = $pagelog->getRevisionInfo($time);
+                    $info = $pagelog->getRevisionInfo($rev ? $rev : $time);
                     if(!empty($info)) {
                         $data = array();
                         $data['user'] = $info['user'];

--- a/inc/common.php
+++ b/inc/common.php
@@ -1324,7 +1324,7 @@ function saveWikiText($id, $text, $summary, $minor = false) {
         // pre-save deleted revision
         @touch($svdta['file']);
         clearstatcache();
-        $data['newRevision'] = saveOldRevision($id);
+        $svdta['newRevision'] = saveOldRevision($id);
         // remove empty file
         @unlink($svdta['file']);
         $filesize_new = 0;

--- a/inc/io.php
+++ b/inc/io.php
@@ -202,7 +202,12 @@ function io_writeWikiPage($file, $content, $id, $rev=false) {
  */
 function _io_writeWikiPage_action($data) {
     if (is_array($data) && is_array($data[0]) && count($data[0])===3) {
-        return call_user_func_array('io_saveFile', $data[0]);
+        $ok = call_user_func_array('io_saveFile', $data[0]);
+        // for attic files make sure the file has the mtime of the revision
+        if($ok && is_int($data[3]) && $data[3] > 0) {
+            @touch($data[0][0], $data[3]);
+        }
+        return $ok;
     } else {
         return false; //callback error
     }


### PR DESCRIPTION
In the remote API, DokuWiki currently assumes that timestamps of files in the attic are identical with the revision. Unfortunately, they are not (at least not necessarily). A typo in `saveWikiText` lead to similar problems with the timestamp of saved deleted revisions. These changes fix both and add test cases to test this behaviour. Unfortunately, the test cases add additional delays. I tried to keep them as minimal as possible, they should lead to additional 9 seconds of test execution time.

This should (hopefully) fix random test failures as seen in [travis build #2532](https://travis-ci.org/splitbrain/dokuwiki/builds/188039085).