### PR TITLE
Allow form dropdown options as arrays with numeric keys

### DIFF
--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -58,7 +58,10 @@ class form_dropdownelement_test extends DokuWikiTest {
                     'data-foo' => 'bar'
                 )
             ),
-            'second'
+            'second',
+            '3' => array(
+                'label' => 'the label of the complex third option',
+            )
         );
 
         $form->addDropdown('foo', $options, 'label text');
@@ -70,7 +73,7 @@ class form_dropdownelement_test extends DokuWikiTest {
         $this->assertTrue($select->length == 1);
 
         $options = $pq->find('option');
-        $this->assertTrue($options->length == 2);
+        $this->assertEquals(3, $options->length);
 
         $option = $pq->find('option#theID');
         $this->assertEquals(1, $option->length);

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -50,13 +50,13 @@ class OptGroup extends Element {
         if(!is_array($options)) throw new \InvalidArgumentException('Options have to be an array');
         $this->options = array();
         foreach($options as $key => $val) {
-            if(is_int($key)) {
-                $this->options[$val] = array('label' => (string) $val);
-            } elseif (!is_array($val)) {
-                $this->options[$key] = array('label' => (string) $val);
-            } else {
+            if (is_array($val)) {
                 if (!key_exists('label', $val)) throw new \InvalidArgumentException('If option is given as array, it has to have a "label"-key!');
                 $this->options[$key] = $val;
+            } elseif(is_int($key)) {
+                $this->options[$val] = array('label' => (string) $val);
+            } else {
+                $this->options[$key] = array('label' => (string) $val);
             }
         }
         return $this;


### PR DESCRIPTION
The problem this is solving is that PHP does not allow for array-keys to
be strings of ints. It always converts them to actual ints. This caused
a problem when trying to use complex array-options with integers as
keys.

Hence I resort the conditions. Checking for arrays first, then handling other cases afterwards.