### PR TITLE
Remove '?do=' from the end of the URL of Show Page

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -675,7 +675,7 @@ function tpl_get_action($type) {
                     $accesskey     = 'v';
                 }
             } else {
-                $params    = array('do' => '');
+                $params    = '';
                 $type      = 'show';
                 $accesskey = 'v';
             }


### PR DESCRIPTION
Pressing "Show Page" button we go to a page with '?do=' at the end of an address.
That breaks the functionality of "Page Rename" button.
So I propose change in case of type=show
<code>
$params    = array('do' => '');
</code>
to
<code>
$params    = '';
</code>
(Not sure however, would that cause side effects?)