### PR TITLE
authldap user whitelist

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -57,6 +57,9 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
         if(empty($pass)) return false;
         if(!$this->_openLDAP()) return false;
 
+        // reject if whitelist enabled and user not listed
+        if(!$this->_isWhitelisted($user)) { return false; }
+        
         // indirect user bind
         if($this->getConf('binddn') && $this->getConf('bindpw')) {
             // use superuser credentials
@@ -642,6 +645,20 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
     protected function _debug($message, $err, $line, $file) {
         if(!$this->getConf('debug')) return;
         msg($message, $err, $line, $file);
+    }
+    
+    /**
+    * Check if user is whitelisted if option enabled
+    *
+    * @param string $user
+    * @return bool
+    */
+    protected function _isWhitelisted($user) { 
+		if($this->getConf('enableWhitelist')==0) { return true; }
+		$names = explode(',', str_replace(' ', '', $this->getConf('whitelist')));
+		$dbg=in_array($user, $names);
+		$this->_debug('LDAP whitelist match for '.$user.': '.(($dbg)?'success':'failed'), 0, __LINE__, __FILE__ );
+		return $dbg;
     }
 
 }

--- a/lib/plugins/authldap/conf/default.php
+++ b/lib/plugins/authldap/conf/default.php
@@ -20,3 +20,5 @@ $conf['userkey']    = 'uid';
 $conf['groupkey']   = 'cn';
 $conf['debug']      = 0;
 $conf['modPass']    = 1;
+$conf['enableWhitelist']= 0;
+$conf['whitelist'] = '';

--- a/lib/plugins/authldap/conf/metadata.php
+++ b/lib/plugins/authldap/conf/metadata.php
@@ -19,3 +19,5 @@ $meta['userkey']     = array('string','_caution' => 'danger');
 $meta['groupkey']    = array('string','_caution' => 'danger');
 $meta['debug']       = array('onoff','_caution' => 'security');
 $meta['modPass']     = array('onoff');
+$meta['enableWhitelist'] = array('onoff', '_caution' => 'danger');
+$meta['whitelist']  = array('string', '_caution' => 'danger');  

--- a/lib/plugins/authldap/lang/en/settings.php
+++ b/lib/plugins/authldap/lang/en/settings.php
@@ -17,6 +17,8 @@ $lang['userkey']     = 'Attribute denoting the username; must be consistent to u
 $lang['groupkey']    = 'Group membership from any user attribute (instead of standard AD groups) e.g. group from department or telephone number';
 $lang['modPass']     = 'Can the LDAP password be changed via dokuwiki?';
 $lang['debug']       = 'Display additional debug information on errors';
+$lang['enableWhitelist'] = 'Limit acces to below specified users only!';
+$lang['whitelist']  = 'Comma separated list of user names. This option is useful if you´re not admin of the LDAP directory.';
 
 
 $lang['deref_o_0']   = 'LDAP_DEREF_NEVER';


### PR DESCRIPTION
For all of those who doesn´t have administrative access to the LDAP directory but want to be in charge of who can access dokuwiki.

I hat to do this modification for one of our wiki´s because I have to use a top level LDAP directory to get all users. For sure authplain would be an alternative since manual configuration of user names is needed anyway. But there ist still the advantage of changed passwords and expired user accounts.

