### PR TITLE
JS modification action

### DIFF
--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -36,10 +36,6 @@ function js_out(){
     $tpl = trim(preg_replace('/[^\w-]+/','',$INPUT->str('t')));
     if(!$tpl) $tpl = $conf['template'];
 
-    // The generated script depends on some dynamic options
-    $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl,'.js');
-    $cache->_event = 'JS_CACHE_USE';
-
     // array of core files
     $files = array(
                 DOKU_INC.'lib/scripts/jquery/jquery.cookie.js',
@@ -74,6 +70,13 @@ function js_out(){
             $files[] = $userscript;
         }
     }
+
+    // Let plugins decide to either put more scripts here or to remove some
+	trigger_event('JS_SCRIPT_LIST', $files);
+
+    // The generated script depends on some dynamic options
+    $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].md5(serialize($files)),'.js');
+    $cache->_event = 'JS_CACHE_USE';
 
     $cache_files = array_merge($files, getConfigFiles('main'));
     $cache_files[] = __FILE__;

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -72,7 +72,7 @@ function js_out(){
     }
 
     // Let plugins decide to either put more scripts here or to remove some
-	trigger_event('JS_SCRIPT_LIST', $files);
+    trigger_event('JS_SCRIPT_LIST', $files);
 
     // The generated script depends on some dynamic options
     $cache = new cache('scripts'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].md5(serialize($files)),'.js');


### PR DESCRIPTION
This was part of the PR #1002 - I extracted the JS part to make it available already. I'm working on a new solution to incorporate the suggestions made by @selfthinker for the CSS part.

Add Event to modify the list of javascript files before they are processed. This allows plugins to not have their - or other plugins - script delivered to the client. Creating the list of files upfront might add a little overhead which I think is OK when you can be certain that only JavaScript that really is needed will be delivered to the client.

Multiple Javascript requests, e.g. to only send the jQuery part or just editor/administrator scripts, could be implemented with this modification (I know, jQuery has already been split).