### PR TITLE
Css modification actions

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -396,10 +396,15 @@ function tpl_metaheaders($alt = true) {
     }
 
     // load stylesheets
-    $head['link'][] = array(
-        'rel' => 'stylesheet', 'type'=> 'text/css',
-        'href'=> DOKU_BASE.'lib/exe/css.php?t='.rawurlencode($conf['template']).'&tseed='.$tseed
-    );
+    foreach( scandir( template('') ) as $ini_file ) {
+        // allow all .ini files in a templates 'ini' dir to be a flavour for stylesheet creation
+        list( $flavour, $ext ) = explode( '.', $ini_file, 2 );
+        if ( $ext != 'ini' ) continue;
+        $head['link'][] = array(
+            'rel' => 'stylesheet', 'type'=> 'text/css',
+            'href'=> DOKU_BASE.'lib/exe/css.php?t='.rawurlencode($conf['template']).'&f='.rawurlencode($flavour).'&tseed='.$tseed
+        );
+    }
 
     // make $INFO and other vars available to JavaScripts
     $json   = new JSON();

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -114,8 +114,8 @@ function css_out(){
 
     // check cache age & handle conditional request
     // This may exit if a cache can be used
-    $cache_ok = $cache->useCache(array('files' => $cache_files));
-    http_cached($cache->cache, $cache_ok);
+    http_cached($cache->cache,
+                $cache->useCache(array('files' => $cache_files)));
 
     // start output buffering
     ob_start();

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -61,72 +61,99 @@ function css_out(){
 
     // Array of needed files and their web locations, the latter ones
     // are needed to fix relative paths in the stylesheets
-    $files = array();
+    // We only need to build the list for the requested flavour.
+    $media_files = array();
     foreach($mediatypes as $mediatype) {
-        $files[$mediatype] = array();
-        // load core styles
-        $files[$mediatype][DOKU_INC.'lib/styles/'.$mediatype.'.css'] = DOKU_BASE.'lib/styles/';
-
-        // load jQuery-UI theme
-        if ($mediatype == 'screen') {
-            $files[$mediatype][DOKU_INC.'lib/scripts/jquery/jquery-ui-theme/smoothness.css'] = DOKU_BASE.'lib/scripts/jquery/jquery-ui-theme/';
-        }
-        // load plugin styles
-        $files[$mediatype] = array_merge($files[$mediatype], css_pluginstyles($mediatype));
-        // load template styles
-        if (isset($styleini['stylesheets'][$mediatype])) {
-            $files[$mediatype] = array_merge($files[$mediatype], $styleini['stylesheets'][$mediatype]);
-        }
-        // load user styles
-        if(!empty($config_cascade['userstyle'][$mediatype])) {
-            foreach($config_cascade['userstyle'][$mediatype] as $userstyle) {
-                $files[$mediatype][$userstyle] = DOKU_BASE;
+        $files = array();
+        if ( $flavour === DEFAULT_FLAVOUR ) {
+            // load core styles
+            $files[DOKU_INC.'lib/styles/'.$mediatype.'.css'] = DOKU_BASE.'lib/styles/';
+    
+            // load jQuery-UI theme
+            if ($mediatype == 'screen') {
+                $files[DOKU_INC.'lib/scripts/jquery/jquery-ui-theme/smoothness.css'] = DOKU_BASE.'lib/scripts/jquery/jquery-ui-theme/';
             }
+            // load plugin styles
+            $files = array_merge($files, css_pluginstyles($mediatype));
+            // load template styles
+            if (isset($styleini['stylesheets'][$mediatype])) {
+                $files = array_merge($files, $styleini['stylesheets'][$mediatype]);
+            }
+            // load user styles
+            if(!empty($config_cascade['userstyle'][$mediatype])) {
+                foreach($config_cascade['userstyle'][$mediatype] as $userstyle) {
+                    $files[$userstyle] = DOKU_BASE;
+                }
+            }
+        } else if (isset($styleini['stylesheets'][$mediatype])) {
+            // only allow the predefined media types
+            $files = $styleini['stylesheets'][$mediatype];
         }
-
-        $cache_files = array_merge($cache_files, array_keys($files[$mediatype]));
+    
+        // Let plugins decide to either put more styles here or to remove some
+        $media_files[$mediatype] = css_filewrapper($mediatype, $flavour, $files);
+    	$CSSEvt = new Doku_Event('CSS_STYLES_INCLUDED', $media_files[$mediatype]);
+    
+        // Make it preventable.
+    	if ( $CSSEvt->advise_before() ) {
+            $cache_files = array_merge($cache_files, array_keys($media_files[$mediatype]['files']));
+    	} else {
+        	// unset if prevented. Nothing will be printed for this mediatype.
+        	unset($media_files[$mediatype]);
+    	}
+    	
+    	// finish event.
+    	$CSSEvt->advise_after();
     }
+
+    // The generated script depends on some dynamic options
+    $cache = new cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl.md5(serialize($cache_files)),'.css');
+    $cache->_event = 'CSS_CACHE_USE';
 
     // check cache age & handle conditional request
     // This may exit if a cache can be used
-    http_cached($cache->cache,
-                $cache->useCache(array('files' => $cache_files)));
+    $cache_ok = $cache->useCache(array('files' => $cache_files));
+    http_cached($cache->cache, $cache_ok);
 
     // start output buffering
     ob_start();
+    
+    if ( $flavour === DEFAULT_FLAVOUR ) {
+        // Fire CSS_STYLES_INCLUDED for one last time to let the
+        // plugins decide whether to include the DW default styles.
+        // This can be done by preventing the Default.
+        $media_files['DW_DEFAULT'] = css_filewrapper('DW_DEFAULT');
+        trigger_event('CSS_STYLES_INCLUDED', $media_files['DW_DEFAULT'], 'css_defaultstyles');
+    }
 
     // build the stylesheet
     foreach ($mediatypes as $mediatype) {
 
-        // print the default classes for interwiki links and file downloads
-        if ($mediatype == 'screen') {
-            print '@media screen {';
-            css_interwiki();
-            css_filetypes();
-            print '}';
+        // Check if there is a wrapper set for this type.
+        if ( !isset($media_files[$mediatype]) ) {
+            continue;
         }
 
+        $cssData = $media_files[$mediatype];
+        
+        // Print the styles.
+    	print NL;
+    	if ( $cssData['encapsulate'] === true ) print $cssData['encapsulationPrefix'] . ' {';
+    	print '/* START '.$cssData['mediatype'].' styles */'.NL;
+    
         // load files
-        $css_content = '';
-        foreach($files[$mediatype] as $file => $location){
+        foreach($cssData['files'] as $file => $location){
             $display = str_replace(fullpath(DOKU_INC), '', fullpath($file));
-            $css_content .= "\n/* XXXXXXXXX $display XXXXXXXXX */\n";
-            $css_content .= css_loadfile($file, $location);
+            print "\n/* XXXXXXXXX $display XXXXXXXXX */\n";
+            print css_loadfile($file, $location);
         }
-        switch ($mediatype) {
-            case 'screen':
-                print NL.'@media screen { /* START screen styles */'.NL.$css_content.NL.'} /* /@media END screen styles */'.NL;
-                break;
-            case 'print':
-                print NL.'@media print { /* START print styles */'.NL.$css_content.NL.'} /* /@media END print styles */'.NL;
-                break;
-            case 'all':
-            case 'feed':
-            default:
-                print NL.'/* START rest styles */ '.NL.$css_content.NL.'/* END rest styles */'.NL;
-                break;
-        }
+        
+    	print NL;
+    	if ( $cssData['encapsulate'] === true ) print '} /* /@media ';
+    	else print '/*';
+    	print ' END '.$cssData['mediatype'].' styles */'.NL;
     }
+
     // end output buffering and get contents
     $css = ob_get_contents();
     ob_end_clean();
@@ -344,6 +371,42 @@ function css_fixreplacementurls($replacements, $location) {
         $replacements[$key] = preg_replace('#(url\([ \'"]*)(?!/|data:|http://|https://| |\'|")#','\\1'.$location,$value);
     }
     return $replacements;
+}
+
+/**
+ * Wrapper for the files, content and mediatype for the event CSS_STYLES_INCLUDED
+ *
+ * @author Gerry Weißbach <gerry.w@gammaproduction.de>
+ *
+ * @param string $mediatype type ofthe current media files/content set
+ * @param array $files set of files that define the current mediatype
+ * @return array
+ */
+function css_filewrapper($mediatype, $flavour=DEFAULT_FLAVOUR, $files=array()){
+    return array(
+            'files'                 => $files,
+	        'mediatype'             => $mediatype,
+	        'flavour'               => $flavour,
+	        'encapsulate'           => in_array($mediatype, array('screen', 'print', 'handheld')),
+	        'encapsulationPrefix'   => '@media '.$mediatype
+        );
+}
+
+/**
+ * Prints the @media encapsulated default styles of DokuWiki
+ *
+ * @author Gerry Weißbach <gerry.w@gammaproduction.de>
+ *
+ * This function is being called by a CSS_STYLES_INCLUDED event
+ * The event can be distinguished by the mediatype which is:
+ *   DW_DEFAULT
+ */
+function css_defaultstyles(){
+	// print the default classes for interwiki links and file downloads
+    print '@media screen {';
+    css_interwiki();
+    css_filetypes();
+    print '}';
 }
 
 /**

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -94,18 +94,18 @@ function css_out(){
     
         // Let plugins decide to either put more styles here or to remove some
         $media_files[$mediatype] = css_filewrapper($mediatype, $flavour, $files);
-    	$CSSEvt = new Doku_Event('CSS_STYLES_INCLUDED', $media_files[$mediatype]);
+        $CSSEvt = new Doku_Event('CSS_STYLES_INCLUDED', $media_files[$mediatype]);
     
         // Make it preventable.
-    	if ( $CSSEvt->advise_before() ) {
+        if ( $CSSEvt->advise_before() ) {
             $cache_files = array_merge($cache_files, array_keys($media_files[$mediatype]['files']));
-    	} else {
-        	// unset if prevented. Nothing will be printed for this mediatype.
-        	unset($media_files[$mediatype]);
-    	}
-    	
-    	// finish event.
-    	$CSSEvt->advise_after();
+        } else {
+            // unset if prevented. Nothing will be printed for this mediatype.
+            unset($media_files[$mediatype]);
+        }
+        
+        // finish event.
+        $CSSEvt->advise_after();
     }
 
     // The generated script depends on some dynamic options
@@ -139,9 +139,9 @@ function css_out(){
         $cssData = $media_files[$mediatype];
         
         // Print the styles.
-    	print NL;
-    	if ( $cssData['encapsulate'] === true ) print $cssData['encapsulationPrefix'] . ' {';
-    	print '/* START '.$cssData['mediatype'].' styles */'.NL;
+        print NL;
+        if ( $cssData['encapsulate'] === true ) print $cssData['encapsulationPrefix'] . ' {';
+        print '/* START '.$cssData['mediatype'].' styles */'.NL;
     
         // load files
         foreach($cssData['files'] as $file => $location){
@@ -150,10 +150,10 @@ function css_out(){
             print css_loadfile($file, $location);
         }
         
-    	print NL;
-    	if ( $cssData['encapsulate'] === true ) print '} /* /@media ';
-    	else print '/*';
-    	print ' END '.$cssData['mediatype'].' styles */'.NL;
+        print NL;
+        if ( $cssData['encapsulate'] === true ) print '} /* /@media ';
+        else print '/*';
+        print ' END '.$cssData['mediatype'].' styles */'.NL;
     }
 
     // end output buffering and get contents
@@ -387,10 +387,10 @@ function css_fixreplacementurls($replacements, $location) {
 function css_filewrapper($mediatype, $flavour=DEFAULT_FLAVOUR, $files=array()){
     return array(
             'files'                 => $files,
-	        'mediatype'             => $mediatype,
-	        'flavour'               => $flavour,
-	        'encapsulate'           => in_array($mediatype, array('screen', 'print', 'handheld')),
-	        'encapsulationPrefix'   => '@media '.$mediatype
+            'mediatype'             => $mediatype,
+            'flavour'               => $flavour,
+            'encapsulate'           => in_array($mediatype, array('screen', 'print', 'handheld')),
+            'encapsulationPrefix'   => '@media '.$mediatype
         );
 }
 
@@ -404,7 +404,7 @@ function css_filewrapper($mediatype, $flavour=DEFAULT_FLAVOUR, $files=array()){
  *   DW_DEFAULT
  */
 function css_defaultstyles(){
-	// print the default classes for interwiki links and file downloads
+    // print the default classes for interwiki links and file downloads
     print '@media screen {';
     css_interwiki();
     css_filetypes();

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -34,18 +34,14 @@ function css_out(){
 
     if ($INPUT->str('s') == 'feed') {
         $mediatypes = array('feed');
-        $type = 'feed';
     } else {
-        $mediatypes = array('screen', 'all', 'print');
-        $type = '';
+        $mediatypes = array('screen', 'all', 'print', 'handheld');
     }
 
     // decide from where to get the template
     $tpl = trim(preg_replace('/[^\w-]+/','',$INPUT->str('t')));
     if(!$tpl) $tpl = $conf['template'];
 
-    // The generated script depends on some dynamic options
-    $cache = new cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].$INPUT->int('preview').DOKU_BASE.$tpl.$type,'.css');
 
     // load styl.ini
     $styleini = css_styleini($tpl, $INPUT->bool('preview'));

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -35,8 +35,10 @@ function css_out(){
 
     if ($INPUT->str('s') == 'feed') {
         $mediatypes = array('feed');
+        $type = 'feed';
     } else {
         $mediatypes = array('screen', 'all', 'print', 'handheld');
+        $type = '';
     }
 
     // decide from where to get the template
@@ -107,7 +109,7 @@ function css_out(){
     }
 
     // The generated script depends on some dynamic options
-    $cache = new cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl.md5(serialize($cache_files)),'.css');
+    $cache = new cache('styles'.$_SERVER['HTTP_HOST'].$_SERVER['SERVER_PORT'].DOKU_BASE.$tpl.$flavour.$type,'.css');
     $cache->_event = 'CSS_CACHE_USE';
 
     // check cache age & handle conditional request

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -45,7 +45,7 @@ function css_out(){
     $tpl = trim(preg_replace('/[^\w-]+/','',$INPUT->str('t')));
     if(!$tpl) $tpl = $conf['template'];
 
-    // decide from where to get the template
+    // decide from where to get the flavour
     $flavour = trim(preg_replace('/[^\w-]+/','',$INPUT->str('f')));
     if(!$flavour) $flavour = DEFAULT_FLAVOUR;
 

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -37,7 +37,7 @@ function css_out(){
         $mediatypes = array('feed');
         $type = 'feed';
     } else {
-        $mediatypes = array('screen', 'all', 'print', 'handheld');
+        $mediatypes = array('screen', 'all', 'print', 'speech');
         $type = '';
     }
 


### PR DESCRIPTION
This is the second part of the #1002 PR - which I think should be closed now.

There is a new event `CSS_CACHE_USE` which unifies the cache usage of js.php and css.php (js.php already has it). The CSS generator can now make use of this special event to determine whether the cache may be used or not.

The `css.php` and `themplate.php` have been updated to support different flavours which will result in different requests for the css resource. This allows template creators to not only structure by different files but also requests. Using the new event `CSS_STYLES_INCLUDED` site owners - and plugin creators - can decide which styles of the core or other plugins should be send to the browser at which time or view mode.

  * new event: `CSS_STYLES_INCLUDED`
    * plugins can modify the list of files that will be used for this media type
    * plugins can modify the encapsulation string (default: `@media $mediatype`) and whether to encapsulate at all
    * plugins can prevent a media type and flavour from being printed at all
    * there is a special media type `DW_DEFAULT` to indicate the default interwiki and file icon styles (which can be prevented)
    * the resulting file list will influence the cache

### Motivation

I think it is good to have more options to customise the css output. We're using DW for our professional website in a readonly mode. It is therefore not necessary to include styles and scripts that are only really used for editing or admin or user management purposes. Also, we mostly want our own custom styles only with the DW backend - so the default styles are not really needed as well.

The changes allow us to implement:

  * a plugin that controls what is send to our visitor - especially from the default styles
  * an extra flavour with e.g. administrative styles and styles for the media manager that is only delivered to admins/editors.

I gave the last point some thought. I wanted the template to be able to split its css into flavours (as I call them now) - or chunks. This way it is easier to define certain modes. The problem is: at which point in the request of the page do we bring everything back together (multiple requests vs. many checks in the css.php).

First I implemented flavours to be checked in the `css.php` by adding them to the `style.ini` and putting an extra [stylesheets:flavor] section in it. But the output from parse_ini_file would have to be post processed. I thought about the array syntax in the ini file, but I think it is harder to read and understand (`my_style.less[flavour1,flavour2] = screen`).

A subdirectory for multiple ini files could have worked, but needed more code on the css.php as the current solution. I think that reading the filenames of all ini files for a template and putting each of them into the list of stylesheet files is a good compromise.

What I'm not sure about for the current solution is whether we should restrict the flavours to: 'always', 'editor', 'manager, 'admin' - corresponding to the permissions of DokuWiki. Also: there could be special RTL definitions by having either a 'rtl.ini' or 'admin-rtl.ini'

I hope that most of this makes any sense to you, but I'm happy to discuss and improve the changes.