### PR TITLE
Add parent namespace pattern replacement

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1103,6 +1103,7 @@ function parsePageTemplate(&$data) {
         array(
              '@ID@',
              '@NS@',
+             '@CURNS@',
              '@FILE@',
              '@!FILE@',
              '@!FILE!@',
@@ -1118,6 +1119,7 @@ function parsePageTemplate(&$data) {
         array(
              $id,
              getNS($id),
+             curNS($id),
              $file,
              utf8_ucfirst($file),
              utf8_strtoupper($file),


### PR DESCRIPTION
As desired in #1337, I added a feature replacing `@CURNS@` to the current namespace in this pull-request.

As I commented in #1337, existing page including `@CURNS@` string may be influenced. But the number of such pages may be small, so I think this new feature has more merits than the demerit.

