### PR TITLE
Fix strict standard warnings in dropdowns for PHP <=5.6

### DIFF
--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -142,12 +142,14 @@ class DropdownElement extends InputElement {
     protected function getFirstOption() {
         $options = $this->options();
         if (!empty($options)) {
-            return (string) array_shift(array_keys($options));
+            $keys = array_keys($options);
+            return (string) array_shift($keys);
         }
         foreach ($this->optGroups as $optGroup) {
             $options = $optGroup->options();
             if (!empty($options)) {
-                return (string) array_shift(array_keys($options));
+                $keys = array_keys($options);
+                return (string) array_shift($keys);
             }
         }
     }


### PR DESCRIPTION
PHP 5.6 and below throw a strict standards warning at the changed lines.
An intermediate variable is introduced to avoid this warning.

PHP 7+ changes the severity of this warning to E_NOTICE which is
suppressed by DokuWiki.

This error was introduced in #1778