### PR TITLE
add paytribute option in tribute to Terry Pratchett

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -137,6 +137,7 @@ $conf['rss_update'] = 5*60;              //Update the RSS feed every n seconds (
 $conf['rss_show_summary'] = 1;           //Add revision summary to title? 0|1
 
 /* Advanced Settings */
+$conf['paytribute']  = 0;                //Send X-Clacks-overhead HTTP header in tribute to Terry Pratchett
 $conf['updatecheck'] = 1;                //automatically check for new releases?
 $conf['userewrite']  = 0;                //this makes nice URLs: 0: off 1: .htaccess 2: internal
 $conf['useslash']    = 0;                //use slash instead of colon? only when rewrite is on

--- a/inc/init.php
+++ b/inc/init.php
@@ -139,24 +139,29 @@ if ($conf['gzip_output'] &&
     ob_start('ob_gzhandler');
 }
 
-// init session
-if(!headers_sent() && !defined('NOSESSION')) {
-    if(!defined('DOKU_SESSION_NAME'))     define ('DOKU_SESSION_NAME', "DokuWiki");
-    if(!defined('DOKU_SESSION_LIFETIME')) define ('DOKU_SESSION_LIFETIME', 0);
-    if(!defined('DOKU_SESSION_PATH')) {
-        $cookieDir = empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'];
-        define ('DOKU_SESSION_PATH', $cookieDir);
+if(!headers_sent()) {
+    if($conf['paytribute']) {
+        header('X-Clacks-overhead: GNU Terry Pratchett');
     }
-    if(!defined('DOKU_SESSION_DOMAIN'))   define ('DOKU_SESSION_DOMAIN', '');
+    // init session
+    if(!defined('NOSESSION')) {
+        if(!defined('DOKU_SESSION_NAME'))     define ('DOKU_SESSION_NAME', "DokuWiki");
+        if(!defined('DOKU_SESSION_LIFETIME')) define ('DOKU_SESSION_LIFETIME', 0);
+        if(!defined('DOKU_SESSION_PATH')) {
+            $cookieDir = empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'];
+            define ('DOKU_SESSION_PATH', $cookieDir);
+        }
+        if(!defined('DOKU_SESSION_DOMAIN'))   define ('DOKU_SESSION_DOMAIN', '');
 
-    session_name(DOKU_SESSION_NAME);
-    session_set_cookie_params(DOKU_SESSION_LIFETIME, DOKU_SESSION_PATH, DOKU_SESSION_DOMAIN, ($conf['securecookie'] && is_ssl()), true);
-    session_start();
+        session_name(DOKU_SESSION_NAME);
+        session_set_cookie_params(DOKU_SESSION_LIFETIME, DOKU_SESSION_PATH, DOKU_SESSION_DOMAIN, ($conf['securecookie'] && is_ssl()), true);
+        session_start();
 
-    // load left over messages
-    if(isset($_SESSION[DOKU_COOKIE]['msg'])) {
-        $MSG = $_SESSION[DOKU_COOKIE]['msg'];
-        unset($_SESSION[DOKU_COOKIE]['msg']);
+        // load left over messages
+        if(isset($_SESSION[DOKU_COOKIE]['msg'])) {
+            $MSG = $_SESSION[DOKU_COOKIE]['msg'];
+            unset($_SESSION[DOKU_COOKIE]['msg']);
+        }
     }
 }
 

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -155,6 +155,7 @@ $lang['rss_show_summary'] = 'XML feed show summary in title';
 $lang['rss_media']   = 'What kind of changes should be listed in the XML feed?';
 
 /* Advanced Options */
+$lang['paytribute']  = 'Send in each response an HTTP header in tribute to Terry Pratchett.';
 $lang['updatecheck'] = 'Check for updates and security warnings? DokuWiki needs to contact update.dokuwiki.org for this feature.';
 $lang['userewrite']  = 'Use nice URLs';
 $lang['useslash']    = 'Use slash as namespace separator in URLs';

--- a/lib/plugins/config/lang/fr/lang.php
+++ b/lib/plugins/config/lang/fr/lang.php
@@ -141,6 +141,7 @@ $lang['rss_content']           = 'Quel contenu afficher dans le flux XML?';
 $lang['rss_update']            = 'Fréquence de mise à jour du flux XML (secondes)';
 $lang['rss_show_summary']      = 'Le flux XML affiche le résumé dans le titre';
 $lang['rss_media']             = 'Quels types de changements doivent être listés dans le flux XML?';
+$lang['paytribute']            = 'Envoyer avec chaque réponse un entête HTTP d\'hommage à Terry Pratchett.';
 $lang['updatecheck']           = 'Vérifier les mises à jour et alertes de sécurité? DokuWiki doit pouvoir contacter update.dokuwiki.org';
 $lang['userewrite']            = 'Utiliser des URL esthétiques';
 $lang['useslash']              = 'Utiliser « / » comme séparateur de catégories dans les URL';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -202,6 +202,7 @@ $meta['rss_update']  = array('numeric');
 $meta['rss_show_summary'] = array('onoff');
 
 $meta['_advanced']   = array('fieldset');
+$meta['paytribute']  = array('onoff');
 $meta['updatecheck'] = array('onoff');
 $meta['userewrite']  = array('multichoice','_choices' => array(0,1,2),'_caution' => 'danger');
 $meta['useslash']    = array('onoff');


### PR DESCRIPTION
This is a proposal for a new on/off option. When enabled, in response
to any request, DW sends an
"X-Clacks-overhead: GNU Terry Pratchett" HTTP header in tribute
to Terry Pratchett. More info on http://www.gnuterrypratchett.com/ .
 
Since DokuWiki release names are Discworld characters' name, it just seems to
me the right thing to do. I hope you'll find the idea fun too.

The new option 'paytribute', it is off by default.
if switched on, inc/init.php calls header() to send the header. I did
it in inc/init.php so that it works with the various request handlers : 
doku.php, ajax.php, xmlrpc.php jquery.php etc...

Schplurtz
Debian sends this header from their servers, by the way.