### PR TITLE
Support for PHPUnit 6.0

### DIFF
--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -1,8 +1,30 @@
 <?php
+
+
+if(!class_exists('PHPUnit_Framework_TestCase')) {
+    /**
+     * phpunit 5/6 compatibility
+     */
+    class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
+        /**
+         * @param string $class
+         * @param null|string $message
+         */
+        public function setExpectedException($class, $message=null) {
+            $this->expectException($class);
+            if(!is_null($message)) {
+                $this->expectExceptionMessage($message);
+            }
+        }
+    }
+}
+
+
+
 /**
  * Helper class to provide basic functionality for tests
  */
-abstract class DokuWikiTest extends PHPUnit\Framework\TestCase {
+abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
 
     /**
      * tests can override this

--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -2,7 +2,7 @@
 /**
  * Helper class to provide basic functionality for tests
  */
-abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
+abstract class DokuWikiTest extends PHPUnit\Framework\TestCase {
 
     /**
      * tests can override this

--- a/_test/phpunit.xml
+++ b/_test/phpunit.xml
@@ -4,6 +4,7 @@
     convertNoticesToExceptions="false"
     colors="true"
     stderr="true"
+    backupGlobals="true"
     >
 
     <testsuites>

--- a/_test/tests/inc/io_replaceinfile.test.php
+++ b/_test/tests/inc/io_replaceinfile.test.php
@@ -101,9 +101,9 @@ class io_replaceinfile_test extends DokuWikiTest {
     function test_badparam()
     {
         if (class_exists('PHPUnit\Framework\Error\Warning')) {
-            $expect = PHPUnit\Framework\Error\Warning::class; // PHPUnit 6
+            $expect = 'PHPUnit\Framework\Error\Warning'; // PHPUnit 6
         } else {
-            $expect = PHPUnit_Framework_Error_Warning::class; // PHPUnit 5
+            $expect = 'PHPUnit_Framework_Error_Warning'; // PHPUnit 5
         }
         $this->setExpectedException($expect);
 

--- a/_test/tests/inc/io_replaceinfile.test.php
+++ b/_test/tests/inc/io_replaceinfile.test.php
@@ -98,7 +98,7 @@ class io_replaceinfile_test extends DokuWikiTest {
     /**
      * Test passing an invalid parameter.
      *
-     * @expectedException PHPUnit_Framework_Error_Warning
+     * @expectedException PHPUnit\Framework\Error\Warning
      */
     function test_badparam()
     {

--- a/_test/tests/inc/io_replaceinfile.test.php
+++ b/_test/tests/inc/io_replaceinfile.test.php
@@ -101,12 +101,11 @@ class io_replaceinfile_test extends DokuWikiTest {
     function test_badparam()
     {
         if (class_exists('PHPUnit\Framework\Error\Warning')) {
-            // PHPUnit 6
-            $this->expectException(PHPUnit\Framework\Error\Warning::class);
+            $expect = PHPUnit\Framework\Error\Warning::class; // PHPUnit 6
         } else {
-            // PHPUnit 5
-            $this->expectException(PHPUnit_Framework_Error_Warning::class);
+            $expect = PHPUnit_Framework_Error_Warning::class; // PHPUnit 5
         }
+        $this->setExpectedException($expect);
 
         /* The empty $oldline parameter should be caught before the file doesn't exist test. */
         $this->assertFalse(io_replaceInFile(TMP_DIR.'/not_existing_file.txt', '', '', false, 0));

--- a/_test/tests/inc/io_replaceinfile.test.php
+++ b/_test/tests/inc/io_replaceinfile.test.php
@@ -97,11 +97,17 @@ class io_replaceinfile_test extends DokuWikiTest {
 
     /**
      * Test passing an invalid parameter.
-     *
-     * @expectedException PHPUnit\Framework\Error\Warning
      */
     function test_badparam()
     {
+        if (class_exists('PHPUnit\Framework\Error\Warning')) {
+            // PHPUnit 6
+            $this->expectException(PHPUnit\Framework\Error\Warning::class);
+        } else {
+            // PHPUnit 5
+            $this->expectException(PHPUnit_Framework_Error_Warning::class);
+        }
+
         /* The empty $oldline parameter should be caught before the file doesn't exist test. */
         $this->assertFalse(io_replaceInFile(TMP_DIR.'/not_existing_file.txt', '', '', false, 0));
     }


### PR DESCRIPTION
this (mostly) fixes #1837 

If the tests are actually run with PHPUnit 6.0, then the `--globals-backup` flag has to be used.