### PR TITLE
Fix calling undefined function random_int() when doing install.php

### DIFF
--- a/install.php
+++ b/install.php
@@ -9,7 +9,8 @@ if(!defined('DOKU_INC')) define('DOKU_INC',dirname(__FILE__).'/');
 if(!defined('DOKU_CONF')) define('DOKU_CONF',DOKU_INC.'conf/');
 if(!defined('DOKU_LOCAL')) define('DOKU_LOCAL',DOKU_INC.'conf/');
 
-require_once(DOKU_INC.'inc/PassHash.class.php');
+// load and initialize the core system
+require_once(DOKU_INC.'inc/init.php');
 
 // check for error reporting override or set error reporting to sane values
 if (!defined('DOKU_E_LEVEL')) { error_reporting(E_ALL ^ E_NOTICE); }
@@ -641,21 +642,3 @@ function print_errors(){
         echo '</ul>';
     }
 }
-
-/**
- * remove magic quotes recursivly
- *
- * @author Andreas Gohr <andi@splitbrain.org>
- *
- * @param array $array
- */
-function remove_magic_quotes(&$array) {
-    foreach (array_keys($array) as $key) {
-        if (is_array($array[$key])) {
-            remove_magic_quotes($array[$key]);
-        }else {
-            $array[$key] = stripslashes($array[$key]);
-        }
-    }
-}
-


### PR DESCRIPTION
Otherwise the it will fail with the following error:

	2017/02/20 14:34:57 [error] 16242#0: *59 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Call to undefined function random_int() in /var/www/dokuwiki/inc/PassHash.class.php on line 630" while reading response header from upstream, client: 172.18.35.245, server: _, request: "POST /dokuwiki/install.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php-fpm/php-fpm.sock:", host: "10.5.234.170", referrer: "http://10.5.234.170/dokuwiki/install.php"

Fixes #1852