### PR TITLE
Add feature to disable relogin.

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -61,6 +61,7 @@ $conf['superuser']   = '!!not set!!';    //The admin can be user or @group or co
 $conf['manager']     = '!!not set!!';    //The manager can be user or @group or comma separated list user1,@group1,user2
 $conf['profileconfirm'] = 1;             //Require current password to confirm changes to user profile
 $conf['rememberme'] = 1;                 //Enable/disable remember me on login
+$conf['disablerelogin'] = 0;             //Enable/disable relogin credentials in cookie
 $conf['disableactions'] = '';            //comma separated list of actions to disable
 $conf['auth_security_timeout'] = 900;    //time (seconds) auth data is considered valid, set to 0 to recheck on every page view
 $conf['securecookie'] = 1;               //never send HTTPS cookies via HTTP

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -95,6 +95,7 @@ $lang['superuser']   = 'Superuser - group, user or comma separated list user1,@g
 $lang['manager']     = 'Manager - group, user or comma separated list user1,@group1,user2 with access to certain management functions';
 $lang['profileconfirm'] = 'Confirm profile changes with password';
 $lang['rememberme'] = 'Allow permanent login cookies (remember me)';
+$lang['disablerelogin'] = 'Disable relogin (remember me will not work)';
 $lang['disableactions'] = 'Disable DokuWiki actions';
 $lang['disableactions_check'] = 'Check';
 $lang['disableactions_subscription'] = 'Subscribe/Unsubscribe';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -146,6 +146,7 @@ $meta['superuser']   = array('string','_caution' => 'danger');
 $meta['manager']     = array('string');
 $meta['profileconfirm'] = array('onoff');
 $meta['rememberme'] = array('onoff');
+$meta['disablerelogin'] = array('onoff');
 $meta['disableactions'] = array('disableactions',
                                 '_choices' => array('backlink','index','recent','revisions','search','subscription','register','resendpwd','profile','profile_delete','edit','wikicode','check', 'rss'),
                                 '_combine' => array('subscription' => array('subscribe','unsubscribe'), 'wikicode' => array('source','export_raw')));


### PR DESCRIPTION
DoluWiki originally saves the username and password in the browser
cookie, so that user can be automatially re-logged-in when the PHP
session expires. Leaving any data derived from credentials (password
is encrypted, username is base64-encoded) in browser cookies may not
be desirable. This feature replaces that data with a random string.
This causes relogin to be disabled, and further that rememberme will
not work.