### PR TITLE
Workaround for broken authplaincas.

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -240,7 +240,12 @@ function init_session() {
     session_set_cookie_params(DOKU_SESSION_LIFETIME, DOKU_SESSION_PATH, DOKU_SESSION_DOMAIN, ($conf['securecookie'] && is_ssl()), true);
 
     // make sure the session cookie contains a valid session ID
-    if(isset($_COOKIE[DOKU_SESSION_NAME]) && !preg_match('/^[-,a-zA-Z0-9]{22,256}$/', $_COOKIE[DOKU_SESSION_NAME])) {
+    // Originally, the session ID was required to have at least 22 characters
+    // (see commit 924e477e), but this broke the
+    // [authplaincas](https://www.dokuwiki.org/plugin:authplaincas) plugin,
+    // because it replaces the session ID by a string of 13 characters.
+    // So I lowered the lower bound in the regex.
+    if(isset($_COOKIE[DOKU_SESSION_NAME]) && !preg_match('/^[-,a-zA-Z0-9]{13,256}$/', $_COOKIE[DOKU_SESSION_NAME])) {
         unset($_COOKIE[DOKU_SESSION_NAME]);
     }
 


### PR DESCRIPTION
This is a workaround for an issue with the [authplaincas](https://www.dokuwiki.org/plugin:authplaincas) plugin and dokuwiki 2017-02-19b "Frusterick Manners".

Authplaincas stopped working. If you click on the link to authenticate, you are redirected to the authentication server (which is expected). Once you are logged in on the authentication server, you are redirected back to the correct dokuwiki page (which is also expected), but you're not authenticated (that's the problem).

The problem is caused by commit 924e477e. Authplaincas does some ugly things with the
session ID, which results in session ID's that are shorter than
the ones dokuwiki likes. So dokuwiki creates a new session, and phpCAS doesn't know who you are.

I'm not sure if it is a good idea to merge this pull request, because it is working around an issue with an extension. And it isn't even an issue with authplaincas itself, the problem is caused by the way [phpCAS](https://wiki.jasig.org/display/casc/phpcas) behaves.

But I post this anyway, maybe it can be helpful for others facing the same problem.