### PR TITLE
Disable access to revisions unless user has EDIT privileges.

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -288,6 +288,7 @@ function act_validate($act) {
  * @return string action command
  */
 function act_permcheck($act){
+    global $REV;
     global $INFO;
 
     if(in_array($act,array('save','preview','edit','recover'))){
@@ -302,6 +303,8 @@ function act_permcheck($act){
         }else{
             $permneed = AUTH_CREATE;
         }
+    }elseif($act == 'revisions' && !actionOK('revisionreading')){
+        $permneed = AUTH_EDIT;
     }elseif(in_array($act,array('login','search','recent','profile','profile_delete','index', 'sitemap'))){
         $permneed = AUTH_NONE;
     }elseif($act == 'revert'){
@@ -319,6 +322,8 @@ function act_permcheck($act){
         }else{
             $permneed = AUTH_ADMIN;
         }
+    }elseif($REV && !actionOK('revisionreading')){
+        $permneed = AUTH_EDIT;
     }else{
         $permneed = AUTH_READ;
     }

--- a/inc/template.php
+++ b/inc/template.php
@@ -696,6 +696,7 @@ function tpl_get_action($type) {
             }
             break;
         case 'revisions':
+            if (!$INFO['writable'] && !actionOK('revisionreading')) return false;
             $type      = 'revs';
             $accesskey = 'o';
             break;


### PR DESCRIPTION
This feature is about disabling access to viewing revisions, unless user has EDIT privileges. I.e., a user who merely has READ privileges on a page won't be allowed to see its older revisions or see the list of its older revisions. This may be useful for some sites where you don't want public viewers of the wiki to browse through older versions of content. This is configurable by adding "revisionreading" to the "disableactions" config item.