### PR TITLE
PassHash.class.php: in case of brcrypt, use the most recent variant $2y$

### DIFF
--- a/inc/PassHash.class.php
+++ b/inc/PassHash.class.php
@@ -537,7 +537,7 @@ class PassHash {
 
         if(is_null($salt)) {
             if($compute < 4 || $compute > 31) $compute = 8;
-            $salt = '$2a$'.str_pad($compute, 2, '0', STR_PAD_LEFT).'$'.
+            $salt = '$2y$'.str_pad($compute, 2, '0', STR_PAD_LEFT).'$'.
                 $this->gen_salt(22);
         }
 


### PR DESCRIPTION
This change breaks compatibility with php 5.3.6, but a standing
requirement for at least php 5.6 is declared in composer.json.

If the php documentation is to be believed, this change increases
security against pass-the-hash type attacks. (I do not have the knowledge
to assess the security differences between $2a$ and $2y$).

As a Sidenote: htpasswd shipped with apache2 2.4.10 (and probably,
other versions), when used with the -B (=bcrypt) option, produces hashes
marked with $2y$.

Nonewithstanding the actual support or non-support of $2a$ by the
apache2 'AuthUserFile' directive, the apache 2.4 documentation only
asserts support for the $2y$ bcrypt variant.
Therefore, this commit would make it possible for dokuwiki and apache2
basic authentication to share the same password file, in the case when
bcrypt is used.