### PR TITLE
Added bottom margin to prevent overlapping buttons

### DIFF
--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -123,6 +123,7 @@ div.picker button.toolbutton {
 .dokuwiki .secedit {
     float: right;
     margin-top: -1.4em;
+    margin-bottom: 1.4em;
 }
 [dir=rtl] .dokuwiki .secedit {
     float: left;


### PR DESCRIPTION
Fixes issue #1954

When using a plugin such as https://www.dokuwiki.org/plugin:include, you can end up with several empty sections each of which has an edit button. In this case, because the buttons have been given a -1.4em top margin, they effectively take up no space, so Chrome and Firefox (not tested in IE) overlap them, one on top of each other. By adding back a 1.4em bottom margin to each secedit block, the floats now take up space again and will not get in each other's way.