### PR TITLE
Added support for additional geshi options using an extendable options array.

### DIFF
--- a/_test/tests/inc/parser/parser_code.test.php
+++ b/_test/tests/inc/parser/parser_code.test.php
@@ -1,6 +1,11 @@
 <?php
 require_once 'parser.inc.php';
 
+/**
+ * Tests to ensure functionality of the <code> syntax tag.
+ *
+ * @group parser_code
+ */
 class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
 
     function setUp() {
@@ -68,5 +73,291 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
         );
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
+
+    function testCodeOptionsArray_OneOption() {
+        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '5585858532b5e05a615a00b936bde16a',
+                                     'enable_line_numbers' => 1
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_TwoOptions() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="3"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'acc4b062686a5e93b70811478e3556e8',
+                                     'enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(3)
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_UnknownOption() {
+        $this->P->parse('Foo <code C [unknown="I will be deleted/ignored!"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null, null)),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers1() {
+        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '5585858532b5e05a615a00b936bde16a',
+                                     'enable_line_numbers' => 1
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers2() {
+        $this->P->parse('Foo <code C [enable_line_numbers="GESHI_NORMAL_LINE_NUMBERS"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '3c620e51c2e8e3af4920c538179177aa',
+                                     'enable_line_numbers' => 1
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers3() {
+        $this->P->parse('Foo <code C [enable_line_numbers="GESHI_FANCY_LINE_NUMBERS"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '8b7d3e7fba49c8df82d7c3c273296444',
+                                     'enable_line_numbers' => 0
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers4() {
+        $this->P->parse('Foo <code C [enable_line_numbers="GESHI_NO_LINE_NUMBERS"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '80bd88409e303f141e7d1e1500080905',
+                                     'enable_line_numbers' => 0
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra1() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="42, 123, 456, 789"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '50fbd6c074a35cbee0e76731819fb085',
+                                     'enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(42, 123, 456, 789)
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra2() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'bfd1d8290b79b27923c63114aeed3ee6',
+                                     'enable_line_numbers' => 1
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra3() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra=""]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'e9423868eaa15e33b6bc189f53412c3a',
+                                     'enable_line_numbers' => 1
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt1() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at="42"]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'f82658c3e9157076e3af310ae9640951',
+                                     'enable_line_numbers' => 1,
+                                     'start_line_numbers_at' => 42
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt2() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'ef59b4dc711f8949dc0115140a52457e',
+                                     'enable_line_numbers' => 1,
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt3() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at=""]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '9842cb5060cfc74d4e6a74b7580a7dcb',
+                                     'enable_line_numbers' => 1,
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableKeywordLinks1() {
+        $this->P->parse('Foo <code C [enable_keyword_links="false"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => '7419a9eed9c667c3d31aaa2bd8df496e',
+                                     'enable_keyword_links' => false
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableKeywordLinks2() {
+        $this->P->parse('Foo <code C [enable_keyword_links="true"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('md5' => 'c96401aa5cbdf6bbe108028cb0550d83',
+                                     'enable_keyword_links' => true
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
 }
 

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -371,6 +371,7 @@ class Doku_Handler {
      */
     protected function parse_highlight_options ($options) {
         $result = array();
+        $concatenated = '';
         preg_match_all('/(\w+(?:="[^"]*"))|(\w+[^=,])(?:,*)/', $options, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
             $equal_sign = strpos($match [0], '=');
@@ -387,6 +388,7 @@ class Doku_Handler {
 
         // Check for supported options
         foreach ($result as $key => $value) {
+            $concatenated .= $key.$value;
             switch ($key) {
                 case 'enable_line_numbers':
                     $numbering_params = $value;
@@ -430,6 +432,7 @@ class Doku_Handler {
                 break;
             }
         }
+        $result['md5'] = md5($concatenated);
 
         return $result;
     }

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -414,7 +414,11 @@ class Doku_Handler {
                 break;
                 case 'start_line_numbers_at':
                     $concatenated .= $key.$value;
-                    $result['start_line_numbers_at'] = intval($value);
+                    if ($value !== true && !empty($value)) {
+                        $result['start_line_numbers_at'] = intval($value);
+                    } else {
+                        unset($result[$key]);
+                    }
                 break;
                 case 'highlight_lines_extra':
                     $concatenated .= $key.$value;

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -388,9 +388,9 @@ class Doku_Handler {
 
         // Check for supported options
         foreach ($result as $key => $value) {
-            $concatenated .= $key.$value;
             switch ($key) {
                 case 'enable_line_numbers':
+                    $concatenated .= $key.$value;
                     $numbering_params = $value;
                     if ($numbering_params === true) {
                         $result['enable_line_numbers'] = 1; // GESHI_NORMAL_LINE_NUMBERS;
@@ -413,9 +413,11 @@ class Doku_Handler {
                     }
                 break;
                 case 'start_line_numbers_at':
+                    $concatenated .= $key.$value;
                     $result['start_line_numbers_at'] = intval($value);
                 break;
                 case 'highlight_lines_extra':
+                    $concatenated .= $key.$value;
                     $numbers = array();
                     $number_strings = explode (',', $value);
                     foreach ($number_strings as $number) {
@@ -424,6 +426,7 @@ class Doku_Handler {
                     $result['highlight_lines_extra'] = $numbers;
                 break;
                 case 'enable_keyword_links':
+                    $concatenated .= $key.$value;
                     $result['enable_keyword_links'] = ($value != 'false');
                 break;
                 default:
@@ -432,8 +435,11 @@ class Doku_Handler {
                 break;
             }
         }
-        $result['md5'] = md5($concatenated);
+        if (empty($concatenated)) {
+            return null;
+        }
 
+        $result['md5'] = md5($concatenated);
         return $result;
     }
 

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -420,10 +420,14 @@ class Doku_Handler {
                     $concatenated .= $key.$value;
                     $numbers = array();
                     $number_strings = explode (',', $value);
-                    foreach ($number_strings as $number) {
-                        $numbers [] = intval($number);
+                    if (count($number_strings) > 0 && $value !== true && !empty($value)) {
+                        foreach ($number_strings as $number) {
+                            $numbers [] = intval($number);
+                        }
+                        $result['highlight_lines_extra'] = $numbers;
+                    } else {
+                        unset($result[$key]);
                     }
-                    $result['highlight_lines_extra'] = $numbers;
                 break;
                 case 'enable_keyword_links':
                     $concatenated .= $key.$value;

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -372,7 +372,7 @@ class Doku_Handler {
     protected function parse_highlight_options ($options) {
         $result = array();
         $concatenated = '';
-        preg_match_all('/(\w+(?:="[^"]*"))|(\w+[^=,])(?:,*)/', $options, $matches, PREG_SET_ORDER);
+        preg_match_all('/(\w+(?:="[^"]*"))|(\w+[^=,\]])(?:,*)/', $options, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
             $equal_sign = strpos($match [0], '=');
             if ($equal_sign === false) {

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -384,6 +384,53 @@ class Doku_Handler {
                 $result [$key] = $value;
             }
         }
+
+        // Check for supported options
+        foreach ($result as $key => $value) {
+            switch ($key) {
+                case 'enable_line_numbers':
+                    $numbering_params = $value;
+                    if ($numbering_params === true) {
+                        $result['enable_line_numbers'] = 1; // GESHI_NORMAL_LINE_NUMBERS;
+                    } else {
+                        // Split params by comma
+                        $numbering_params = explode (',', $numbering_params);
+                        switch ($numbering_params [0]) {
+                            case 'GESHI_NORMAL_LINE_NUMBERS':
+                                $result['enable_line_numbers'] = 1; // GESHI_NORMAL_LINE_NUMBERS
+                            break;
+                            // Out commented/not supported for now:
+                            // Setting fancy line numbering and styles did not show any effect on Geshi's output
+                            //case 'GESHI_FANCY_LINE_NUMBERS':
+                            //    $result['enable_line_numbers'] = 2; // GESHI_FANCY_LINE_NUMBERS
+                            //break;
+                            default:
+                                $result['enable_line_numbers'] = 0; // GESHI_NO_LINE_NUMBERS
+                            break;
+                        }
+                    }
+                break;
+                case 'start_line_numbers_at':
+                    $result['start_line_numbers_at'] = intval($value);
+                break;
+                case 'highlight_lines_extra':
+                    $numbers = array();
+                    $number_strings = explode (',', $value);
+                    foreach ($number_strings as $number) {
+                        $numbers [] = intval($number);
+                    }
+                    $result['highlight_lines_extra'] = $numbers;
+                break;
+                case 'enable_keyword_links':
+                    $result['enable_keyword_links'] = ($value != 'false');
+                break;
+                default:
+                    // Unknown, erase it
+                    unset($result[$key]);
+                break;
+            }
+        }
+
         return $result;
     }
 

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -601,9 +601,10 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function file($text, $language = null, $filename = null) {
-        $this->_highlight('file', $text, $language, $filename);
+    function file($text, $language = null, $filename = null, $options=null) {
+        $this->_highlight('file', $text, $language, $filename, $options);
     }
 
     /**
@@ -612,9 +613,10 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function code($text, $language = null, $filename = null) {
-        $this->_highlight('code', $text, $language, $filename);
+    function code($text, $language = null, $filename = null, $options=null) {
+        $this->_highlight('code', $text, $language, $filename, $options);
     }
 
     /**
@@ -625,8 +627,9 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function _highlight($type, $text, $language = null, $filename = null) {
+    function _highlight($type, $text, $language = null, $filename = null, $options = null) {
         global $ID;
         global $lang;
 
@@ -655,7 +658,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $class = 'code'; //we always need the code class to make the syntax highlighting apply
             if($type != 'code') $class .= ' '.$type;
 
-            $this->doc .= "<pre class=\"$class $language\">".p_xhtml_cached_geshi($text, $language, '').'</pre>'.DOKU_LF;
+            $this->doc .= "<pre class=\"$class $language\">".p_xhtml_cached_geshi($text, $language, '', $options).'</pre>'.DOKU_LF;
         }
 
         if($filename) {

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -785,6 +785,9 @@ function p_parse_geshi_options(&$geshi, array $options) {
         }
         $geshi->highlight_lines_extra($numbers);
     }
+    if (array_key_exists('enable_keyword_links', $options)) {
+        $geshi->enable_keyword_links($options['enable_keyword_links'] != 'false');
+    }
 }
 
 /**

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -752,13 +752,16 @@ function p_xhtml_cached_geshi($code, $language, $wrapper='pre', array $options=n
     // remove any leading or trailing blank lines
     $code = preg_replace('/^\s*?\n|\s*?\n$/','',$code);
 
-    $cache = getCacheName($language.$code,".code");
+    $optionsmd5 = '';
+    if ($options != null) {
+        $optionsmd5 = $options['md5'];
+    }
+    $cache = getCacheName($language.$code.$optionsmd5,".code");
     $ctime = @filemtime($cache);
     if($ctime && !$INPUT->bool('purge') &&
             $ctime > filemtime(DOKU_INC.'vendor/composer/installed.json') &&  // libraries changed
             $ctime > filemtime(reset($config_cascade['main']['default']))){ // dokuwiki changed
         $highlighted_code = io_readFile($cache, false);
-
     } else {
 
         $geshi = new GeSHi($code, $language);

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -735,62 +735,6 @@ function p_get_first_heading($id, $render=METADATA_RENDER_USING_SIMPLE_CACHE){
 }
 
 /**
- * Helper function for p_xhtml_cached_geshi:
- * Parses additional options from options array and applies them to the
- * given geshi instance.
- * 
- * The actually supported options are:
- * - enable_line_numbers or enable_line_numbers=[GESHI_NORMAL_LINE_NUMBERS|GESHI_NO_LINE_NUMBERS]
- * - start_line_numbers_at=integer
- * - highlight_lines_extra="integer1,integer2..."
- *
- * @param  GeSHi    $geshi      Geshi instance/object
- * @param  Array    $options    Options array
- *
- * @author LarsDW223
- */
-function p_parse_geshi_options(&$geshi, array $options) {
-    // Check for supported options
-    if (array_key_exists('enable_line_numbers', $options)) {
-        $numbering_params = $options ['enable_line_numbers'];
-        if ($numbering_params === true) {
-            $geshi->enable_line_numbers(GESHI_NORMAL_LINE_NUMBERS);
-        } else {
-            // Split params by comma
-            $numbering_params = explode (',', $numbering_params);
-            switch ($numbering_params [0]) {
-                case 'GESHI_NORMAL_LINE_NUMBERS':
-                    $flag = GESHI_NORMAL_LINE_NUMBERS;
-                break;
-                // Out commented/not supported for now:
-                // Setting fancy line numbering and styles did not show any effect on Geshi's output
-                //case 'GESHI_FANCY_LINE_NUMBERS':
-                //    $flag = GESHI_FANCY_LINE_NUMBERS;
-                //break;
-                default:
-                    $flag = GESHI_NO_LINE_NUMBERS;
-                break;
-            }
-            $geshi->enable_line_numbers($flag, intval($numbering_params [1]));
-        }
-    }
-    if (array_key_exists('start_line_numbers_at', $options)) {
-        $geshi->start_line_numbers_at(intval($options['start_line_numbers_at']));
-    }
-    if (array_key_exists('highlight_lines_extra', $options)) {
-        $numbers = array();
-        $number_strings = explode (',', $options['highlight_lines_extra']);
-        foreach ($number_strings as $number) {
-            $numbers [] = intval($number);
-        }
-        $geshi->highlight_lines_extra($numbers);
-    }
-    if (array_key_exists('enable_keyword_links', $options)) {
-        $geshi->enable_keyword_links($options['enable_keyword_links'] != 'false');
-    }
-}
-
-/**
  * Wrapper for GeSHi Code Highlighter, provides caching of its output
  *
  * @param  string   $code       source code to be highlighted
@@ -823,7 +767,22 @@ function p_xhtml_cached_geshi($code, $language, $wrapper='pre', array $options=n
         $geshi->set_header_type(GESHI_HEADER_PRE);
         $geshi->set_link_target($conf['target']['extern']);
         if ($options !== null) {
-            p_parse_geshi_options($geshi, $options);
+            foreach ($options as $function => $params) {
+                switch ($function) {
+                    case 'enable_line_numbers':
+                        $geshi->enable_line_numbers($params);
+                    break;
+                    case 'start_line_numbers_at':
+                        $geshi->start_line_numbers_at($params);
+                    break;
+                    case 'highlight_lines_extra':
+                        $geshi->highlight_lines_extra($params);
+                    break;
+                    case 'enable_keyword_links':
+                        $geshi->enable_keyword_links($params);
+                    break;
+                }
+            }
         }
 
         // remove GeSHi's wrapper element (we'll replace it with our own later)

--- a/lib/styles/geshi.less
+++ b/lib/styles/geshi.less
@@ -124,4 +124,13 @@
     .re1, .st0, .st_h {
         color: #ff0000;
     }
+
+    li, .li1 {
+        font-weight: normal;
+        vertical-align:top;
+    }
+
+    .ln-xtra {
+        background-color: #ffc;
+    }
 }


### PR DESCRIPTION
Also see the feature request in issue #1625.

I extended the syntax for the ```code``` and ```file``` tags in the following way:
- additional options for geshi can be specified in square brackets
- options have to be separated by commas
- strings can be enclosed in ```'``` or ```"```

The actually implemented additional options are named after their corresponding Geshi functions:
- enable_line_numbers
- start_line_numbers_at
- highlight_lines_extra

Here are some syntax examples:

Example 1, normal code tag, unchanged behaviour:
```
<code C Hello.c>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 2, enable line numbers:
```
<code C Hello.c [enable_line_numbers]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 3, highlight a specific line:
```
<code C Hello.c [highlight_lines_extra="2"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 4, start at specific line number (requires two options):
```
<code C Hello.c [enable_line_numbers, start_line_numbers_at="42"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```
Example 5, highlight specific line**s**:
```
<code C Hello.c [highlight_lines_extra="2,3"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

**Implementation details:**
In function ```code``` in file ```handler.php``` options get cut off the match and are parsed in function ```parse_highlight_options```. The function searches for ```key=value``` pairs separated by commas. Each found pair is added to the options array like ```$options[$key] = $value;```. If the value was enclosed in ```"``` or ```'``` then this will be stripped off. If there is just a key without value then it will be added like ```$options[$key] = true;```.

The options array is passed through as a additional parameter in functions ```code```, ```file``` and ```_highlight``` in file ```xhtml.php```. And finally its passed to ```p_xhtml_cached_geshi```.

The function ```p_xhtml_cached_geshi``` in file ```parserutils.php``` is doing a more semantic parsing by calling ```p_parse_geshi_options```. That function will modify the Geshi object as required by the given options. In this way new options can be added at any time and are passed through transparently. For Geshi options which would be added in the future only a change in function ```p_parse_geshi_options``` would be required. Unknown options are simply ignored.

Remarks:
Changing Geshi options in ```code``` and ```file``` tags require a ```purge=true``` to take effect.