### PR TITLE
Keep an '&' as it is and do not convert it to '&amp;' in an email link.

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1095,7 +1095,30 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $link['class'] = 'media';
         }
 
-        $address = $this->_xmlEntities($address);
+        // Extra handling if 'mailguard' option is not 'none'
+        // and if more than one request param is present
+        $extra = false;
+        if($conf['mailguard'] != 'none') {
+            $qm_pos = strpos($address, '?');
+            if ($qm_pos !== false) {
+                $amp_pos = strpos($address, '&');
+                if ($amp_pos !== false && $amp_pos > $qm_pos) {
+                    $extra = true;
+                }
+            }
+        }
+        if (!$extra) {
+            // No.
+            $address = $this->_xmlEntities($address);
+        } else {
+            // Yes, keep '&' after '?'
+            $url = substr($address, 0, $qm_pos+1);
+            $url = $this->_xmlEntities($url);
+            $params = substr($address, $qm_pos+1);
+            $params = $this->_xmlEntities($params);
+            $params = str_replace('&amp;', '&', $params);
+            $address = $url.$params;
+        }
         $address = obfuscate($address);
         $title   = $address;
 


### PR DESCRIPTION
But only if option 'mailguard' is not 'none' and if more than one parameter is given.

So in case option 'mailguard' is not 'none' the following example would cause an extra handling to keep the ```&``` after the ```?```:
```
[[documentation@example.com?body=Please write a detailed message.&subject=DOC REQUEST|With body and subject]]
```
The next two examples would never require an extra handling because they only have one parameter (no ```&``` after the ```?```):
```
[[documentation@example.com?subject=DOC REQUEST|With subject only]]
```
```
[[documentation@example.com?body=Please write a detailed message.|With body only]]
```