### PR TITLE
Across workflow 'show - sectionedit - save/cancel' explicitly transmit header id to the server.

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -477,13 +477,18 @@ function act_revert($act){
 function act_redirect($id,$preact){
     global $PRE;
     global $TEXT;
+    global $INPUT;
 
     $opts = array(
             'id'       => $id,
             'preact'   => $preact
             );
     //get section name when coming from section edit
-    if($PRE && preg_match('/^\s*==+([^=\n]+)/',$TEXT,$match)){
+    if ($INPUT->has('hid')) {
+        // Use explicitly transmitted header id
+        $opts['fragment'] = $INPUT->str('hid');
+    } else if($PRE && preg_match('/^\s*==+([^=\n]+)/',$TEXT,$match)){
+        // Fallback to old mechanism
         $check = false; //Byref
         $opts['fragment'] = sectionID($match[0], $check);
     }

--- a/inc/html.php
+++ b/inc/html.php
@@ -91,7 +91,7 @@ function html_denied() {
 function html_secedit($text,$show=true){
     global $INFO;
 
-    $regexp = '#<!-- EDIT(\d+) ([A-Z_]+) (?:"([^"]*)" )?\[(\d+-\d*)\] -->#';
+    $regexp = '#<!-- EDIT(\d+) ([A-Z_]+) (?:"([^"]*)" )(?:"([^"]*)" )?\[(\d+-\d*)\] -->#';
 
     if(!$INFO['writable'] || !$show || $INFO['rev']){
         return preg_replace($regexp,'',$text);
@@ -114,8 +114,9 @@ function html_secedit($text,$show=true){
 function html_secedit_button($matches){
     $data = array('secid'  => $matches[1],
                   'target' => strtolower($matches[2]),
+                  'hid' => strtolower($matches[4]),
                   'range'  => $matches[count($matches) - 1]);
-    if (count($matches) === 5) {
+    if (count($matches) === 6) {
         $data['name'] = $matches[3];
     }
 
@@ -1866,6 +1867,9 @@ function html_edit(){
     }
 
     $form->addHidden('target', $data['target']);
+    if ($INPUT->has('hid')) {
+        $form->addHidden('hid', $INPUT->str('hid'));
+    }
     $form->addElement(form_makeOpenTag('div', array('id'=>'wiki__editbar', 'class'=>'editBar')));
     $form->addElement(form_makeOpenTag('div', array('id'=>'size__ctl')));
     $form->addElement(form_makeCloseTag('div'));

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -66,8 +66,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      *
      * @author Adrian Lang <lang@cosmocode.de>
      */
-    public function startSectionEdit($start, $type, $title = null) {
-        $this->sectionedits[] = array(++$this->lastsecid, $start, $type, $title);
+    public function startSectionEdit($start, $type, $title = null, $hid = null) {
+        $this->sectionedits[] = array(++$this->lastsecid, $start, $type, $title, $hid);
         return 'sectionedit'.$this->lastsecid;
     }
 
@@ -78,14 +78,17 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      *
      * @author Adrian Lang <lang@cosmocode.de>
      */
-    public function finishSectionEdit($end = null) {
-        list($id, $start, $type, $title) = array_pop($this->sectionedits);
+    public function finishSectionEdit($end = null, $hid = null) {
+        list($id, $start, $type, $title, $hid) = array_pop($this->sectionedits);
         if(!is_null($end) && $end <= $start) {
             return;
         }
         $this->doc .= "<!-- EDIT$id ".strtoupper($type).' ';
         if(!is_null($title)) {
             $this->doc .= '"'.str_replace('"', '', $title).'" ';
+        }
+        if(!is_null($hid)) {
+            $this->doc .= '"'.$hid.'" ';
         }
         $this->doc .= "[$start-".(is_null($end) ? '' : $end).'] -->';
     }
@@ -217,7 +220,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         // write the header
         $this->doc .= DOKU_LF.'<h'.$level;
         if($level <= $conf['maxseclevel']) {
-            $this->doc .= ' class="'.$this->startSectionEdit($pos, 'section', $text).'"';
+            $this->doc .= ' class="'.$this->startSectionEdit($pos, 'section', $text, $hid).'"';
         }
         $this->doc .= ' id="'.$hid.'">';
         $this->doc .= $this->_xmlEntities($text);


### PR DESCRIPTION
So the server can always redirect to the correct section even if headings have the same name. Fixes #1364.

The workflow of the change is as follows:
- on rendering, get header id and put it as hidden field ```hid``` into the section edit button(s)
- the user clicks an section edit button, the ```hid``` field is transmitted to the server
- the server again sends the hidden field ```hid``` back to the client on rendering the editor form
- the field is transmitted back to the server when the user clicks on ```Save``` or ```Cancel```
- the server receives the field and can redirect to the correct section

Remarks:
Even if the title of two headings might be the same, their header id (```<h id="...">```) will always be different.