### PR TITLE
Adjusted pattern for matching media links to properly handle a single '}' in the link text.

### DIFF
--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -4,6 +4,7 @@ require_once 'parser.inc.php';
 /**
  * Tests for the implementation of audio and video files
  *
+ * @group parser_media
  * @author  Michael Große <grosse@cosmocode.de>
 */
 class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
@@ -130,5 +131,65 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $rest = '</video>'."\n";
         $substr_start = strlen($url) - strlen($rest);
         $this->assertEquals($rest, substr($url, $substr_start));
+    }
+
+    function testSimpleLinkText() {
+        $file = 'wiki:dokuwiki-128.png';
+        $parser_response = p_get_instructions('{{' . $file . '|This is a simple text.}}');
+
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('internalmedia',array($file,'This is a simple text.',null,null,null,'cache','details')),
+            array('cdata',array(null)),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$parser_response),$calls);
+    }
+
+    function testLinkTextWithWavedBrackets_1() {
+        $file = 'wiki:dokuwiki-128.png';
+        $parser_response = p_get_instructions('{{' . $file . '|We got a { here.}}');
+
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('internalmedia',array($file,'We got a { here.',null,null,null,'cache','details')),
+            array('cdata',array(null)),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$parser_response),$calls);
+    }
+
+    function testLinkTextWithWavedBrackets_2() {
+        $file = 'wiki:dokuwiki-128.png';
+        $parser_response = p_get_instructions('{{' . $file . '|We got a } here.}}');
+
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('internalmedia',array($file,'We got a } here.',null,null,null,'cache','details')),
+            array('cdata',array(null)),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$parser_response),$calls);
+    }
+
+    function testLinkTextWithWavedBrackets_3() {
+        $file = 'wiki:dokuwiki-128.png';
+        $parser_response = p_get_instructions('{{' . $file . '|We got a { and a } here.}}');
+
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('internalmedia',array($file,'We got a { and a } here.',null,null,null,'cache','details')),
+            array('cdata',array(null)),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$parser_response),$calls);
     }
 }

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -916,7 +916,7 @@ class Doku_Parser_Mode_media extends Doku_Parser_Mode {
 
     function connectTo($mode) {
         // Word boundaries?
-        $this->Lexer->addSpecialPattern("\{\{[^\}]+\}\}",$mode,'media');
+        $this->Lexer->addSpecialPattern("\{\{(?:[^\}]|(?:\}[^\}]))+\}\}",$mode,'media');
     }
 
     function getSort() {


### PR DESCRIPTION
Fixes #1587.