### PR TITLE
Added support for additional geshi options using an extendable options array (PR-2).

### DIFF
--- a/_test/tests/inc/parser/parser_code.test.php
+++ b/_test/tests/inc/parser/parser_code.test.php
@@ -1,6 +1,11 @@
 <?php
 require_once 'parser.inc.php';
 
+/**
+ * Tests to ensure functionality of the <code> syntax tag.
+ *
+ * @group parser_code
+ */
 class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
 
     function setUp() {
@@ -68,5 +73,281 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
         );
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
+
+    function testCodeOptionsArray_OneOption() {
+        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_TwoOptions() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="3"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(3)
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_UnknownOption() {
+        $this->P->parse('Foo <code C [unknown="I will be deleted/ignored!"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null, null)),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers1() {
+        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers2() {
+        $this->P->parse('Foo <code C [enable_line_numbers="1"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers3() {
+        $this->P->parse('Foo <code C [enable_line_numbers="0"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 0)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableLineNumbers4() {
+        $this->P->parse('Foo <code C [enable_line_numbers=""]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra1() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="42, 123, 456, 789"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(42, 123, 456, 789)
+                               ))),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra2() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(1))
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_HighlightLinesExtra3() {
+        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra=""]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'highlight_lines_extra' => array(1))
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt1() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at="42"]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'start_line_numbers_at' => 42)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt2() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'start_line_numbers_at' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_StartLineNumbersAt3() {
+        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at=""]]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_line_numbers' => 1,
+                                     'start_line_numbers_at' => 1)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableKeywordLinks1() {
+        $this->P->parse('Foo <code C [enable_keyword_links="false"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_keyword_links' => false)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
+    function testCodeOptionsArray_EnableKeywordLinks2() {
+        $this->P->parse('Foo <code C [enable_keyword_links="true"]>Test</code> Bar');
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo ')),
+            array('p_close',array()),
+            array('code',array('Test','C', null,
+                               array('enable_keyword_links' => true)
+                               )),
+            array('p_open',array()),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
+    }
+
 }
 

--- a/_test/tests/inc/parser/parser_code.test.php
+++ b/_test/tests/inc/parser/parser_code.test.php
@@ -75,7 +75,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_OneOption() {
-        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_line_numbers":true}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -93,7 +93,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_TwoOptions() {
-        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="3"]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_line_numbers":true, "highlight_lines_extra":[3]}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -112,7 +112,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_UnknownOption() {
-        $this->P->parse('Foo <code C [unknown="I will be deleted/ignored!"]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"unknown":"I will be deleted/ignored!"}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -128,7 +128,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_EnableLineNumbers1() {
-        $this->P->parse('Foo <code C [enable_line_numbers]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_line_numbers":true}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -146,25 +146,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_EnableLineNumbers2() {
-        $this->P->parse('Foo <code C [enable_line_numbers="1"]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1)
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
-    function testCodeOptionsArray_EnableLineNumbers3() {
-        $this->P->parse('Foo <code C [enable_line_numbers="0"]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_line_numbers":false}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -181,26 +163,8 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
 
-    function testCodeOptionsArray_EnableLineNumbers4() {
-        $this->P->parse('Foo <code C [enable_line_numbers=""]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1)
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
-    function testCodeOptionsArray_HighlightLinesExtra1() {
-        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra="42, 123, 456, 789"]>Test</code> Bar');
+    function testCodeOptionsArray_HighlightLinesExtra() {
+        $this->P->parse('Foo <code C {"enable_line_numbers":true, "highlight_lines_extra":[42, 123, 456, 789]}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -218,46 +182,8 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
 
-    function testCodeOptionsArray_HighlightLinesExtra2() {
-        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1,
-                                     'highlight_lines_extra' => array(1))
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
-    function testCodeOptionsArray_HighlightLinesExtra3() {
-        $this->P->parse('Foo <code C [enable_line_numbers, highlight_lines_extra=""]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1,
-                                     'highlight_lines_extra' => array(1))
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
     function testCodeOptionsArray_StartLineNumbersAt1() {
-        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at="42"]]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_line_numbers":true, "start_line_numbers_at":42}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -275,46 +201,8 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
         $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
     }
 
-    function testCodeOptionsArray_StartLineNumbersAt2() {
-        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at]]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1,
-                                     'start_line_numbers_at' => 1)
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
-    function testCodeOptionsArray_StartLineNumbersAt3() {
-        $this->P->parse('Foo <code C [enable_line_numbers, [enable_line_numbers, start_line_numbers_at=""]]>Test</code> Bar');
-        $calls = array (
-            array('document_start',array()),
-            array('p_open',array()),
-            array('cdata',array("\n".'Foo ')),
-            array('p_close',array()),
-            array('code',array('Test','C', null,
-                               array('enable_line_numbers' => 1,
-                                     'start_line_numbers_at' => 1)
-                               )),
-            array('p_open',array()),
-            array('cdata',array(' Bar')),
-            array('p_close',array()),
-            array('document_end',array()),
-        );
-        $this->assertEquals(array_map('stripbyteindex',$this->H->calls),$calls);
-    }
-
     function testCodeOptionsArray_EnableKeywordLinks1() {
-        $this->P->parse('Foo <code C [enable_keyword_links="false"]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_keyword_links":false}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),
@@ -332,7 +220,7 @@ class TestOfDoku_Parser_Code extends TestOfDoku_Parser {
     }
 
     function testCodeOptionsArray_EnableKeywordLinks2() {
-        $this->P->parse('Foo <code C [enable_keyword_links="true"]>Test</code> Bar');
+        $this->P->parse('Foo <code C {"enable_keyword_links":true}>Test</code> Bar');
         $calls = array (
             array('document_start',array()),
             array('p_open',array()),

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -376,23 +376,9 @@ class Doku_Handler {
      *                        or null if no entries found
      */
     protected function parse_highlight_options ($options) {
-        $result = array();
-        preg_match_all('/(\w+(?:="[^"]*"))|(\w+[^=,\]])(?:,*)/', $options, $matches, PREG_SET_ORDER);
-        foreach ($matches as $match) {
-            $equal_sign = strpos($match [0], '=');
-            if ($equal_sign === false) {
-                $key = trim($match[0],',');
-                $result [$key] = 1;
-            } else {
-                $key = substr($match[0], 0, $equal_sign);
-                $value = substr($match[0], $equal_sign+1);
-                $value = trim($value, '"');
-                if (strlen($value) > 0) {
-                    $result [$key] = $value;
-                } else {
-                    $result [$key] = 1;
-                }
-            }
+        $result = json_decode($options, true);
+        if ($result === null) {
+            return null;
         }
 
         // Check for supported options
@@ -411,15 +397,13 @@ class Doku_Handler {
             $result['enable_line_numbers'] = (bool) $result['enable_line_numbers'];
         }
         if(isset($result['highlight_lines_extra'])) {
-            $result['highlight_lines_extra'] = array_map('intval', explode(',', $result['highlight_lines_extra']));
-            $result['highlight_lines_extra'] = array_filter($result['highlight_lines_extra']);
             $result['highlight_lines_extra'] = array_unique($result['highlight_lines_extra']);
         }        
         if(isset($result['start_line_numbers_at'])) {
             $result['start_line_numbers_at'] = (int) $result['start_line_numbers_at'];
         }
         if(isset($result['enable_keyword_links'])) {
-            $result['enable_keyword_links'] = ($result['enable_keyword_links'] !== 'false');
+            $result['enable_keyword_links'] = (bool) $result['enable_keyword_links'];
         }
         if (count($result) == 0) {
             return null;
@@ -436,7 +420,7 @@ class Doku_Handler {
         if ( $state == DOKU_LEXER_UNMATCHED ) {
             $matches = explode('>',$match,2);
             // Cut out variable options enclosed in []
-            preg_match('/\[.*\]/', $matches[0], $options);
+            preg_match('/{.*}/', $matches[0], $options);
             if (!empty($options[0])) {
                 $matches[0] = str_replace($options[0], '', $matches[0]);
             }

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -601,9 +601,10 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function file($text, $language = null, $filename = null) {
-        $this->_highlight('file', $text, $language, $filename);
+    function file($text, $language = null, $filename = null, $options=null) {
+        $this->_highlight('file', $text, $language, $filename, $options);
     }
 
     /**
@@ -612,9 +613,10 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function code($text, $language = null, $filename = null) {
-        $this->_highlight('code', $text, $language, $filename);
+    function code($text, $language = null, $filename = null, $options=null) {
+        $this->_highlight('code', $text, $language, $filename, $options);
     }
 
     /**
@@ -625,8 +627,9 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @param string $text     text to show
      * @param string $language programming language to use for syntax highlighting
      * @param string $filename file path label
+     * @param array  $options  assoziative array with additional geshi options
      */
-    function _highlight($type, $text, $language = null, $filename = null) {
+    function _highlight($type, $text, $language = null, $filename = null, $options = null) {
         global $ID;
         global $lang;
 
@@ -655,7 +658,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $class = 'code'; //we always need the code class to make the syntax highlighting apply
             if($type != 'code') $class .= ' '.$type;
 
-            $this->doc .= "<pre class=\"$class $language\">".p_xhtml_cached_geshi($text, $language, '').'</pre>'.DOKU_LF;
+            $this->doc .= "<pre class=\"$class $language\">".p_xhtml_cached_geshi($text, $language, '', $options).'</pre>'.DOKU_LF;
         }
 
         if($filename) {

--- a/lib/styles/geshi.less
+++ b/lib/styles/geshi.less
@@ -132,4 +132,13 @@
     .re1, .st0, .st_h {
         color: #ff0000;
     }
+
+    li, .li1 {
+        font-weight: normal;
+        vertical-align:top;
+    }
+
+    .ln-xtra {
+        background-color: #ffc;
+    }
 }


### PR DESCRIPTION
Also see the feature request in issue #1625.

I extended the syntax for the ```code``` and ```file``` tags in the following way:
- additional options for geshi can be specified in square brackets
- options have to be separated by commas
- values should be enclosed in "

The actually implemented additional options are named after their corresponding Geshi functions:
- enable_line_numbers
- start_line_numbers_at
- highlight_lines_extra
- enable_keyword_links

Here are some syntax examples:

Example 1, normal code tag, unchanged behaviour:
```
<code C Hello.c>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 2, enable line numbers:
```
<code C Hello.c [enable_line_numbers]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 3, highlight a specific line:
```
<code C Hello.c [highlight_lines_extra="2"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

Example 4, start at specific line number (requires two options):
```
<code C Hello.c [enable_line_numbers, start_line_numbers_at="42"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```
Example 5, highlight specific line**s**:
```
<code C Hello.c [highlight_lines_extra="2,3"]>
void main () {
    printf ("Hello World 123!");
    exit 0;
}
</code>
```

**Implementation details:**
In function ```code``` in file ```handler.php``` options get cut off the match and are parsed in function ```parse_highlight_options```. The function searches for ```key=value``` pairs separated by commas. Each found pair is added to the options array like ```$options[$key] = $value;```.

The options array is passed through as a additional parameter in functions ```code```, ```file``` and ```_highlight``` in file ```xhtml.php```. And finally its passed to ```p_xhtml_cached_geshi``` which calls the corresponding functions.
