### PR TITLE
Trigger a new event to pre-process upgrade msg

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -42,6 +42,7 @@ function checkUpdateMessages(){
     }
 
     $data = io_readFile($cf);
+    trigger_event('UPGRADE_MSG_PREPROCESS', $data);
     // show messages through the usual message mechanism
     $msgs = explode("\n%\n",$data);
     foreach($msgs as $msg){


### PR DESCRIPTION
There is no way for Upgrade plugin to process upgrade messages before they are shown as checkUpdateMessages() function shows them right after collecting new messages.

The final goal here is to provide a PR for Upgrade plugin to change links pointing to official download page into links pointing to Upgrade plugin's page.