### PR TITLE
show pages where broken links occur: page_id => broken_link

### DIFF
--- a/bin/wantedpages.php
+++ b/bin/wantedpages.php
@@ -12,7 +12,7 @@ class WantedPagesCLI extends DokuCLI {
     const DIR_CONTINUE = 1;
     const DIR_NS       = 2;
     const DIR_PAGE     = 3;
-
+    private $show_pages = false;
     /**
      * Register options and arguments on the given $options object
      *
@@ -28,6 +28,11 @@ class WantedPagesCLI extends DokuCLI {
             'The namespace to lookup. Defaults to root namespace',
             false
         );
+            $options->registerCommand(
+            'show-pages',
+            'Show wiki pages on which broken links (i.e. wanted pages) are found, listed as: wiki_page=>broken_link' 
+        );
+
     }
 
     /**
@@ -39,11 +44,15 @@ class WantedPagesCLI extends DokuCLI {
      * @return void
      */
     protected function main(DokuCLI_Options $options) {
+        global $argc, $argv;
 
         if($options->args) {
             $startdir = dirname(wikiFN($options->args[0].':xxx'));
         } else {
             $startdir = dirname(wikiFN('xxx'));
+        }
+        if($argv[1] == 'show-pages' || $argv[2] == 'show-pages') {
+            $this->show_pages = true;
         }
 
         $this->info("searching $startdir");
@@ -141,7 +150,10 @@ class WantedPagesCLI extends DokuCLI {
                 resolve_pageid($cns, $mid, $exists);
                 if(!$exists) {
                     list($mid) = explode('#', $mid); //record pages without hashs
+                    if($this->show_pages) {
                     $links[] = "$pid => $mid";
+                    }                    
+                    else $links[] = $mid;
                 }
             }
         }

--- a/bin/wantedpages.php
+++ b/bin/wantedpages.php
@@ -44,14 +44,15 @@ class WantedPagesCLI extends DokuCLI {
      * @return void
      */
     protected function main(DokuCLI_Options $options) {
-        global $argc, $argv;
 
         if($options->args) {
             $startdir = dirname(wikiFN($options->args[0].':xxx'));
         } else {
             $startdir = dirname(wikiFN('xxx'));
         }
-        if($argv[1] == 'show-pages' || $argv[2] == 'show-pages') {
+        
+        $cmd = $options->getCmd();
+        if($cmd == 'show-pages') {
             $this->show_pages = true;
         }
 

--- a/bin/wantedpages.php
+++ b/bin/wantedpages.php
@@ -134,13 +134,14 @@ class WantedPagesCLI extends DokuCLI {
         $links        = array();
         $cns          = getNS($page['id']);
         $exists       = false;
+        $pid = $page['id'];
         foreach($instructions as $ins) {
             if($ins[0] == 'internallink' || ($conf['camelcase'] && $ins[0] == 'camelcaselink')) {
                 $mid = $ins[1][0];
                 resolve_pageid($cns, $mid, $exists);
                 if(!$exists) {
                     list($mid) = explode('#', $mid); //record pages without hashs
-                    $links[] = $mid;
+                    $links[] = "$pid => $mid";
                 }
             }
         }


### PR DESCRIPTION
wantedpaged.php lists links to non-extistent pages, but it doesn't say where those links are. This slight revision lists the Page where the Broken Link is found next to the name of the broken link,  For instance:
```
     Page  Id             =>   Broken Link
     wiki:instructions=>plugins:plugin_types

```
