### PR TITLE
support adding noreferrer for external links

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -70,6 +70,7 @@ $conf['remoteuser']  = '!!not set!!';    //user/groups that have access to remot
 /* Antispam Features */
 $conf['usewordblock']= 1;                //block spam based on words? 0|1
 $conf['relnofollow'] = 1;                //use rel="nofollow" for external links?
+$conf['relnoreferrer'] = 0;              //use rel="noreferrer" for external links?
 $conf['indexdelay']  = 60*60*24*5;       //allow indexing after this time (seconds) default is 5 days
 $conf['mailguard']   = 'hex';            //obfuscate email addresses against spam harvesters?
                                          //valid entries are:

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -961,6 +961,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['name']  = $name;
         $link['title'] = $this->_xmlEntities($url);
         if($conf['relnofollow']) $link['rel'] .= ' nofollow';
+        if($conf['relnoreferrer']) $link['rel'] .= ' noreferrer';
         if($conf['target']['extern']) $link['rel'] .= ' noopener';
 
         //output formatted

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -268,7 +268,10 @@ class DokuWiki_Plugin {
         $link = htmlentities($link);
         if (!$title) $title = $link;
         if (!$target) $target = $conf['target']['extern'];
-        if ($conf['relnofollow']) $more .= ' rel="nofollow"';
+        $rel = array();
+        if ($conf['relnofollow']) $rel[] = "nofollow";
+        if ($conf['relnoreferrer']) $rel[] = "noreferrer";
+        if (!empty($rel)) $more .= ' rel="'.join(' ', $rel).'"';
 
         if ($class) $class = " class='$class'";
         if ($target) $target = " target='$target'";

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -157,6 +157,7 @@ $meta['remoteuser']   = array('string');
 $meta['_anti_spam']  = array('fieldset');
 $meta['usewordblock']= array('onoff');
 $meta['relnofollow'] = array('onoff');
+$meta['relnoreferrer'] = array('onoff');
 $meta['indexdelay']  = array('numeric');
 $meta['mailguard']   = array('multichoice','_choices' => array('visible','hex','none'));
 $meta['iexssprotect']= array('onoff','_caution' => 'security');


### PR DESCRIPTION
Stopping browser from sending referrer header apparently is a popular function, and there are several plugins trying to do this via redirect trick (e.g. [linkprefix](https://www.dokuwiki.org/plugin:linkprefix) and [refererremove](https://www.dokuwiki.org/plugin:refererremove)).

Nowadays, mainstream browsers [all support `rel="noreferrer"`](http://caniuse.com/#feat=rel-noreferrer), so the simplest way to just add `noreferrer` to `rel` attribute of external links like `nofollow`.