### PR TITLE
Create valid empty option in tpl_actiondropdown

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1645,7 +1645,7 @@ function tpl_mediaTree() {
  * @param string $empty empty option label
  * @param string $button submit button label
  */
-function tpl_actiondropdown($empty = '', $button = '&gt;') {
+function tpl_actiondropdown($empty = '&nbsp;', $button = '&gt;') {
     global $ID;
     global $REV;
     global $lang;


### PR DESCRIPTION
An option element without `label`-attribute and without text content is invalid HTML.

The [HTML-spec](https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element) specifies:

> If the element has no label attribute and is not a child of a datalist element: Text that is not inter-element whitespace.

So a non-breaking space is valid solution.