### PR TITLE
Fix PHP Notices: Reduce error log noise

### DIFF
--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -839,12 +839,18 @@ class Doku_Renderer extends DokuWiki_Plugin {
                                     return rawurlencode($match[0]);
                                   }, $reference), $url);
             $parsed = parse_url($reference);
-            if(!$parsed['port']) $parsed['port'] = 80;
-            $url = str_replace('{SCHEME}', $parsed['scheme'], $url);
-            $url = str_replace('{HOST}', $parsed['host'], $url);
-            $url = str_replace('{PORT}', $parsed['port'], $url);
-            $url = str_replace('{PATH}', $parsed['path'], $url);
-            $url = str_replace('{QUERY}', $parsed['query'], $url);
+            if (empty($parsed['scheme'])) $parsed['scheme'] = '';
+            if (empty($parsed['host'])) $parsed['host'] = '';
+            if (empty($parsed['port'])) $parsed['port'] = 80;
+            if (empty($parsed['path'])) $parsed['path'] = '';
+            if (empty($parsed['query'])) $parsed['query'] = '';
+            $url = strtr($url,[
+                '{SCHEME}' => $parsed['scheme'],
+                '{HOST}' => $parsed['host'],
+                '{PORT}' => $parsed['port'],
+                '{PATH}' => $parsed['path'],
+                '{QUERY}' => $parsed['query'] ,
+            ]);
         } else {
             //default
             $url = $url.rawurlencode($reference);

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1133,7 +1133,9 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
     function internalmedia($src, $title = null, $align = null, $width = null,
                            $height = null, $cache = null, $linking = null, $return = false) {
         global $ID;
-        list($src, $hash) = explode('#', $src, 2);
+        if (strpos($src, '#') !== false) {
+            list($src, $hash) = explode('#', $src, 2);
+        }
         resolve_mediaid(getNS($ID), $src, $exists, $this->date_at, true);
 
         $noLink = false;
@@ -1154,7 +1156,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             if($exists) $link['title'] .= ' ('.filesize_h(filesize(mediaFN($src))).')';
         }
 
-        if($hash) $link['url'] .= '#'.$hash;
+        if (!empty($hash)) $link['url'] .= '#'.$hash;
 
         //markup non existing files
         if(!$exists) {

--- a/inc/search.php
+++ b/inc/search.php
@@ -333,14 +333,14 @@ function search_allpages(&$data,$base,$file,$type,$lvl,$opts){
 
     $item = array();
     $item['id']   = pathID($file);
-    if(!$opts['skipacl'] && auth_quickaclcheck($item['id']) < AUTH_READ){
+    if(isset($opts['skipacl']) && !$opts['skipacl'] && auth_quickaclcheck($item['id']) < AUTH_READ){
         return false;
     }
 
     $item['rev']   = filemtime($base.'/'.$file);
     $item['mtime'] = $item['rev'];
     $item['size']  = filesize($base.'/'.$file);
-    if($opts['hash']){
+    if(!empty($opts['hash'])){
         $item['hash'] = md5(trim(rawWiki($item['id'])));
     }
 

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -530,7 +530,7 @@ function css_datauri($match){
     if($size && $size < $conf['cssdatauri']){
         $data = base64_encode(file_get_contents($local));
     }
-    if($data){
+    if (!empty($data)){
         $url = 'data:image/'.$ext.';base64,'.$data;
     }else{
         $url = $base.$url;


### PR DESCRIPTION
The core still throws some notices. Even though DokuWiki suppresses them, I think they are worth fixing.

Especially the changes in `/inc/parser/renderer.php` could be refactored into nicer code once we reach PHP 7 and can access the `??` operator.

However, there are still many Notices being thrown by plugins.

PS: I wrote a [small Plugin](https://www.dokuwiki.org/plugin:showphperrors) to display notices and other errors suppressed by DokuWiki. I find it helpful during development.