### PR TITLE
bugfix: empty string is valid for numericopt

### DIFF
--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -982,6 +982,22 @@ if (!class_exists('setting_numericopt')) {
     class setting_numericopt extends setting_numeric {
         // just allow an empty config
         var $_pattern = '/^(|[-]?[0-9]+(?:[-+*][0-9]+)*)$/';
+
+
+        /**
+         * Empty string is valid for numericopt
+         *
+         * @param mixed $input
+         *
+         * @return bool
+         */
+        function update($input) {
+            if ($input === '') {
+                return true;
+            }
+
+            return parent::update($input);
+        }
     }
 }
 


### PR DESCRIPTION
This fixes a bug that the empty string was considered invalid for config entries with type `numericopt` and a `min` or `max` restriction.

Bug Description:
=========
Steps to reproduce
-------------
1. create plugin with config-option `$conf['foobar'] = '';` in default.php and `$meta['foobar']  = array('numericopt', '_min' => 50);` in metadata.php
2. go to config-manager and change that value to 100
3. save
4. change that value back to `''` (empty string)
5. try to save


**actual result:** error message that the entered value is invalid

**expected result:** save is successful, because `numericopt` value is allow to be an empty string
