### PR TITLE
Fix sanitation of $language for code highlighting (fixes #2080)

### DIFF
--- a/inc/parser/code.php
+++ b/inc/parser/code.php
@@ -21,6 +21,7 @@ class Doku_Renderer_code extends Doku_Renderer {
     function code($text, $language = null, $filename = '') {
         global $INPUT;
         if(!$language) $language = 'txt';
+        $language = preg_replace(PREG_PATTERN_VALID_LANGUAGE, '', $language);
         if(!$filename) $filename = 'snippet.'.$language;
         $filename = utf8_basename($filename);
         $filename = utf8_stripspecials($filename, '_');

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -8,6 +8,12 @@
 if(!defined('DOKU_INC')) die('meh.');
 
 /**
+ * Allowed chars in $language for code highlighting
+ * @see GeSHi::set_language()
+ */
+define('PREG_PATTERN_VALID_LANGUAGE', '#[^a-zA-Z0-9\-_]#');
+
+/**
  * An empty renderer, produces no output
  *
  * Inherits from DokuWiki_Plugin for giving additional functions to render plugins

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -630,6 +630,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         global $ID;
         global $lang;
 
+        $language = preg_replace(PREG_PATTERN_VALID_LANGUAGE, '', $language);
+
         if($filename) {
             // add icon
             list($ext) = mimetype($filename, false);


### PR DESCRIPTION
This patch uses the remove-chars approach at the renderer side. For the XSS issue, `<code abc"onmouseover="alert(1)>` becomes `<pre class="code abconmouseoveralert1">` with this patch.

Please check whether the implementation is fit.