### PR TITLE
Fix p_set_metadata damaging contributors numeric ID

### DIFF
--- a/_test/tests/inc/parserutils_set_metadata.test.php
+++ b/_test/tests/inc/parserutils_set_metadata.test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Unit Test for inc/common.php - pageinfo()
+ *
+ * @author Christopher Smith <chris@jalakai.co.uk>
+ */
+class parserutils_set_metadata_test extends DokuWikiTest {
+    // the id used for this test case
+    private $id;
+
+    function helper_prepare_users($id = 1){
+        global $INFO, $USERINFO;
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        if($id == 2){
+            $USERINFO = array(
+               'pass' => '179ad45c6ce2cb97cf1029e212046e81',
+               'name' => 'Tester2',
+               'mail' => 'tester2@example.com',
+               'grps' => array ('user'),
+            );
+            $INFO['userinfo'] = $USERINFO;
+            $_SERVER['REMOTE_USER'] = 'tester2';
+        }else{
+            global $USERINFO, $INFO;
+            $USERINFO = array(
+               'pass' => '179ad45c6ce2cb97cf1029e212046e81',
+               'name' => 'Tester1',
+               'mail' => 'tester1@example.com',
+               'grps' => array ('admin','user'),
+            );
+            $INFO['userinfo'] = $USERINFO;
+            $_SERVER['REMOTE_USER'] = '1';
+        }
+    }
+    /**
+     *  test array merge, including contributors with numeric keys and array data overwritting
+     */
+    function test_array_replace(){
+        // prepare user
+        $this->helper_prepare_users(1);
+
+        // prepare page
+        $this->id = 'test:set_metadata_array_replace';
+        saveWikiText($this->id, 'Test', 'Test data setup');
+        $meta = p_get_metadata($this->id);
+
+        $this->assertEquals('1', $meta['user'], 'Initial page has wrong user ID');
+        // $this->assertEquals(empty($meta['contributor']), true, 'Initial page should have no contributors');
+
+        // first revision with numeric user
+        saveWikiText($this->id, 'Test1', 'Test first edit');
+        $meta = p_get_metadata($this->id);
+
+        $last_edit_date = $meta['date']['modified'];
+        $this->assertEquals(array('1'=>'Tester1'), $meta['contributor'], 'First edit contributors error');
+
+        // second revision with alphabetic user
+        sleep(1); // To generate a different timestamp
+        $this->helper_prepare_users(2);
+        saveWikiText($this->id, 'Test2', 'Test second edit');
+        $meta = p_get_metadata($this->id);
+
+        $this->assertNotEquals($last_edit_date, $meta['date']['modified'], 'First edit date merge error');
+        $this->assertEquals(array('tester2'=>'Tester2', '1'=>'Tester1'), $meta['contributor'], 'Second edit contributors error');
+
+        // third revision with the first user
+        $this->helper_prepare_users(1);
+        saveWikiText($this->id, 'Test3', 'Test third edit');
+        $meta = p_get_metadata($this->id);
+
+        $this->assertEquals(array('tester2'=>'Tester2', '1'=>'Tester1'), $meta['contributor'], 'Third edit contributors error');
+    }
+}
+
+//Setup VIM: ex: et ts=4 :

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -337,13 +337,13 @@ function p_set_metadata($id, $data, $render=false, $persistent=true){
 
             foreach ($value as $subkey => $subvalue){
                 if(isset($meta['current'][$key][$subkey]) && is_array($meta['current'][$key][$subkey])) {
-                    $meta['current'][$key][$subkey] = array_merge($meta['current'][$key][$subkey], (array)$subvalue);
+                    $meta['current'][$key][$subkey] = array_replace($meta['current'][$key][$subkey], (array)$subvalue);
                 } else {
                     $meta['current'][$key][$subkey] = $subvalue;
                 }
                 if($persistent) {
                     if(isset($meta['persistent'][$key][$subkey]) && is_array($meta['persistent'][$key][$subkey])) {
-                        $meta['persistent'][$key][$subkey] = array_merge($meta['persistent'][$key][$subkey], (array)$subvalue);
+                        $meta['persistent'][$key][$subkey] = array_replace($meta['persistent'][$key][$subkey], (array)$subvalue);
                     } else {
                         $meta['persistent'][$key][$subkey] = $subvalue;
                     }
@@ -355,10 +355,10 @@ function p_set_metadata($id, $data, $render=false, $persistent=true){
 
             // these keys, must have subkeys - a legitimate value must be an array
             if (is_array($value)) {
-                $meta['current'][$key] = !empty($meta['current'][$key]) ? array_merge((array)$meta['current'][$key],$value) : $value;
+                $meta['current'][$key] = !empty($meta['current'][$key]) ? array_replace((array)$meta['current'][$key],$value) : $value;
 
                 if ($persistent) {
-                    $meta['persistent'][$key] = !empty($meta['persistent'][$key]) ? array_merge((array)$meta['persistent'][$key],$value) : $value;
+                    $meta['persistent'][$key] = !empty($meta['persistent'][$key]) ? array_replace((array)$meta['persistent'][$key],$value) : $value;
                 }
             }
 


### PR DESCRIPTION
A test is provided as well to ensure the correct array-merging behavior in `p_set_metadata()`. In original code [the test fails](https://travis-ci.org/phy25/dokuwiki/builds/268325932).

Ref: #2087