### PR TITLE
Update check supports HTTPS (without fallback)

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -6,7 +6,14 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 if(!defined('DOKU_INC')) die('meh.');
-if(!defined('DOKU_MESSAGEURL')) define('DOKU_MESSAGEURL','http://update.dokuwiki.org/check/');
+
+if(!defined('DOKU_MESSAGEURL')){
+    if(in_array('ssl', stream_get_transports())) {
+        define('DOKU_MESSAGEURL','https://update.dokuwiki.org/check/');
+    }else{
+        define('DOKU_MESSAGEURL','http://update.dokuwiki.org/check/');
+    }
+}
 
 /**
  * Check for new messages from upstream
@@ -22,11 +29,12 @@ function checkUpdateMessages(){
 
     $cf = getCacheName($updateVersion, '.updmsg');
     $lm = @filemtime($cf);
+    $is_http = substr(DOKU_MESSAGEURL, 0, 5) != 'https';
 
     // check if new messages needs to be fetched
     if($lm < time()-(60*60*24) || $lm < @filemtime(DOKU_INC.DOKU_SCRIPT)){
         @touch($cf);
-        dbglog("checkUpdateMessages(): downloading messages to ".$cf);
+        dbglog("checkUpdateMessages(): downloading messages to ".$cf.($is_http?' (without SSL)':' (with SSL)'));
         $http = new DokuHTTPClient();
         $http->timeout = 12;
         $resp = $http->get(DOKU_MESSAGEURL.$updateVersion);


### PR DESCRIPTION
Before merging this, please make sure update.dokuwiki.org supports HTTPS correctly. **I want to report that currently visits to https://update.dokuwiki.org/check/ is redirected to bugs.dokuwiki.org and shows a not-found error.**

_Note: If SSL is not supported, a HTTP request will be made. In the log the request type will be indicated, but on the frontend no additional message would be shown (I think it's better to notify admins about non-SSL situations, but currently when this fetch encounter error, no error message will be shown, so it's better not to add any warning)._