### PR TITLE
Fix more PHP Notices

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -297,10 +297,15 @@ class HTTPClient {
 
         if($method == 'POST'){
             if(is_array($data)){
-                if($headers['Content-Type'] == 'multipart/form-data'){
-                    $headers['Content-Type']   = 'multipart/form-data; boundary='.$this->boundary;
+                if (empty($headers['Content-Type'])) {
+                    $headers['Content-Type'] = null;
+                }
+                switch ($headers['Content-Type']) {
+                case 'multipart/form-data':
+                    $headers['Content-Type']   = 'multipart/form-data; boundary=' . $this->boundary;
                     $data = $this->_postMultipartEncode($data);
-                }else{
+                    break;
+                default:
                     $headers['Content-Type']   = 'application/x-www-form-urlencoded';
                     $data = $this->_postEncode($data);
                 }

--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -221,6 +221,9 @@ function linesToHash($lines, $lower=false) {
         if(empty($line)) continue;
         $line = preg_split('/\s+/',$line,2);
         // Build the associative array
+        if (empty($line[1])) {
+            $line[1] = '';
+        }
         if($lower){
             $conf[strtolower($line[0])] = $line[1];
         }else{

--- a/inc/html.php
+++ b/inc/html.php
@@ -1046,7 +1046,8 @@ function html_buildlist($data,$class,$func,$lifunc='html_li_default',$forcewrapp
         return '';
     }
 
-    $start_level = $data[0]['level'];
+    $firstElement = reset($data);
+    $start_level = $firstElement['level'];
     $level = $start_level;
     $ret   = '';
     $open  = 0;

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -863,7 +863,11 @@ class Doku_Renderer extends DokuWiki_Plugin {
         }
         //handle as wiki links
         if($url{0} === ':') {
-            list($id, $urlparam) = explode('?', $url, 2);
+            $urlparam = null;
+            $id = $url;
+            if (strpos($url, '?') !== false) {
+                list($id, $urlparam) = explode('?', $url, 2);
+            }
             $url    = wl(cleanID($id), $urlparam);
             $exists = page_exists($id);
         }

--- a/lib/plugins/extension/helper/extension.php
+++ b/lib/plugins/extension/helper/extension.php
@@ -340,7 +340,7 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin {
      * @return array The names of the conflicting extensions
      */
     public function getConflicts() {
-        if (!empty($this->remoteInfo['conflicts'])) return $this->remoteInfo['dependencies'];
+        if (!empty($this->remoteInfo['conflicts'])) return $this->remoteInfo['conflicts'];
         return array();
     }
 

--- a/lib/plugins/extension/helper/list.php
+++ b/lib/plugins/extension/helper/list.php
@@ -340,9 +340,9 @@ class helper_plugin_extension_list extends DokuWiki_Plugin {
         $link = parse_url($url);
 
         $base = $link['host'];
-        if($link['port']) $base .= $base.':'.$link['port'];
+        if(!empty($link['port'])) $base .= $base.':'.$link['port'];
         $long = $link['path'];
-        if($link['query']) $long .= $link['query'];
+        if(!empty($link['query'])) $long .= $link['query'];
 
         $name = shorten($base, $long, 55);
 


### PR DESCRIPTION
Some more notices fixed.

9edb4cd fixes a bug, that the extension manager wasn't showing the conflicting packages. That being said, there seems to be still a bug with the display of the similar packages and how do we actually set the dependencies?

7eeb415 refactors the content-type handling in the HTTPClient to fix the notice. It would be cool if we could also post JSON here.