### PR TITLE
Fix section edit buttons for tables etc. 

### DIFF
--- a/_test/tests/inc/html_secedit_pattern.test.php
+++ b/_test/tests/inc/html_secedit_pattern.test.php
@@ -1,0 +1,58 @@
+<?php
+
+class html_scedit_pattern_test extends DokuWikiTest {
+
+
+    public function dataProviderForTestSecEditPattern() {
+        return [
+            [
+                '<!-- EDIT5 SECTION "Plugins" "plugins" [1406-] -->',
+                [
+                    'secid' => '5',
+                    'target' => 'SECTION',
+                    'name' => 'Plugins',
+                    'hid' => 'plugins',
+                    'range' => '1406-',
+                ],
+                'basic section edit',
+            ],
+            [
+                '<!-- EDIT10 TABLE "" "table4" [11908-14014] -->',
+                [
+                    'secid' => '10',
+                    'target' => 'TABLE',
+                    'name' => '',
+                    'hid' => 'table4',
+                    'range' => '11908-14014',
+                ],
+                'table edit'
+            ],
+            [
+                '<!-- EDIT2 PLUGIN_DATA [27-432] -->',
+                [
+                    'secid' => '2',
+                    'target' => 'PLUGIN_DATA',
+                    'name' => '',
+                    'hid' => '',
+                    'range' => '27-432',
+                ],
+                'data plugin'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestSecEditPattern
+     *
+     * @param $text
+     * @param $expectedMatches
+     * @param $msg
+     */
+    public function testSecEditPattern($text, $expectedMatches, $msg) {
+        preg_match(SEC_EDIT_PATTERN, $text, $matches);
+        foreach ($expectedMatches as $key => $expected_value) {
+            $this->assertSame($expected_value, $matches[$key], $msg);
+        }
+    }
+
+}

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -68,10 +68,10 @@ class ActionRouter {
      * Instantiates the right class, runs permission checks and pre-processing and
      * sets $action
      *
-     * @param string $actionname
+     * @param string $actionname this is passed as a reference to $ACT, for plugin backward compatibility
      * @triggers ACTION_ACT_PREPROCESS
      */
-    protected function setupAction($actionname) {
+    protected function setupAction(&$actionname) {
         $presetup = $actionname;
 
         try {

--- a/inc/ActionRouter.php
+++ b/inc/ActionRouter.php
@@ -75,9 +75,17 @@ class ActionRouter {
         $presetup = $actionname;
 
         try {
-            $this->action = $this->loadAction($actionname);
-            $this->checkAction($this->action);
-            $this->action->preProcess();
+            // give plugins an opportunity to process the actionname
+            $evt = new \Doku_Event('ACTION_ACT_PREPROCESS', $actionname);
+            if ($evt->advise_before()) {
+                $this->action = $this->loadAction($actionname);
+                $this->checkAction($this->action);
+                $this->action->preProcess();
+            } else {
+                // event said the action should be kept, assume action plugin will handle it later
+                $this->action = new Plugin($actionname);
+            }
+            $evt->advise_after();
 
         } catch(ActionException $e) {
             // we should have gotten a new action
@@ -97,21 +105,9 @@ class ActionRouter {
             $this->transitionAction($presetup, $actionname);
 
         } catch(NoActionException $e) {
-            // give plugins an opportunity to process the actionname
-            $evt = new \Doku_Event('ACTION_ACT_PREPROCESS', $actionname);
-            if($evt->advise_before()) {
-                if($actionname == $presetup) {
-                    // no plugin changed the action, complain and switch to show
-                    msg('Action unknown: ' . hsc($actionname), -1);
-                    $actionname = 'show';
-                }
-                $this->transitionAction($presetup, $actionname);
-            } else {
-                // event said the action should be kept, assume action plugin will handle it later
-                $this->action = new Plugin($actionname);
-            }
-            $evt->advise_after();
-
+            msg('Action unknown: ' . hsc($actionname), -1);
+            $actionname = 'show';
+            $this->transitionAction($presetup, $actionname);
         } catch(\Exception $e) {
             $this->handleFatalException($e);
         }

--- a/inc/html.php
+++ b/inc/html.php
@@ -8,6 +8,10 @@
 
 if(!defined('DOKU_INC')) die('meh.');
 if(!defined('NL')) define('NL',"\n");
+if (!defined('SEC_EDIT_PATTERN')) {
+    define('SEC_EDIT_PATTERN', '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#');
+}
+
 
 /**
  * Convenience function to quickly build a wikilink
@@ -91,13 +95,11 @@ function html_denied() {
 function html_secedit($text,$show=true){
     global $INFO;
 
-    $regexp = '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#';
-
     if(!$INFO['writable'] || !$show || $INFO['rev']){
-        return preg_replace($regexp,'',$text);
+        return preg_replace(SEC_EDIT_PATTERN,'',$text);
     }
 
-    return preg_replace_callback($regexp,
+    return preg_replace_callback(SEC_EDIT_PATTERN,
                 'html_secedit_button', $text);
 }
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -91,7 +91,7 @@ function html_denied() {
 function html_secedit($text,$show=true){
     global $INFO;
 
-    $regexp = '#<!-- EDIT(\d+) ([A-Z_]+) (?:"([^"]*)" )(?:"([^"]*)" )?\[(\d+-\d*)\] -->#';
+    $regexp = '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#';
 
     if(!$INFO['writable'] || !$show || $INFO['rev']){
         return preg_replace($regexp,'',$text);
@@ -112,12 +112,16 @@ function html_secedit($text,$show=true){
  * @triggers HTML_SECEDIT_BUTTON
  */
 function html_secedit_button($matches){
-    $data = array('secid'  => $matches[1],
-                  'target' => strtolower($matches[2]),
-                  'hid' => strtolower($matches[4]),
-                  'range'  => $matches[count($matches) - 1]);
-    if (count($matches) === 6) {
-        $data['name'] = $matches[3];
+    $data = array('secid'  => $matches['secid'],
+        'target' => strtolower($matches['target']),
+        'range'  => $matches['range']);
+
+    if (!empty($matches['hid'])) {
+        $data['hid'] = strtolower($matches['hid']);
+    }
+
+    if (!empty($matches['name'])) {
+        $data['name'] = $matches['name'];
     }
 
     return trigger_event('HTML_SECEDIT_BUTTON', $data,

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1339,7 +1339,8 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $class .= ' ' . $classes;
         }
         if($pos !== null) {
-            $class .= ' '.$this->startSectionEdit($pos, 'table');
+            $hid = $this->_headerToLink($class, true);
+            $class .= ' '.$this->startSectionEdit($pos, 'table', '', $hid);
         }
         $this->doc .= '<div class="'.$class.'"><table class="inline">'.
             DOKU_LF;


### PR DESCRIPTION
#1966 or 2571786c763e04c7abbf27c2245a5720878dc3f1 respectively broke the section edit buttons for sections that did not provide a title. This stopped the editbuttons of the edittable plugin from being generated.

The wrap plugin is likely affected by this as well, since it too uses `\Doku_Renderer_xhtml::startSectionEdit` with only two arguments. (cc @selfthinker )

Further, the above commit broke saving a table with the edittable plugin. However I have not yet checked whether this has to be fixed in the edittable plugin or within in DokuWiki-core as well. This may also affect the data plugin.

Known Issues:
* since both title and hid are optional, a hid may be misinterpreted as a title if the title is not generated.