### PR TITLE
Let `utf8_substr` use `utf8_strlen` 

### DIFF
--- a/inc/utf8.php
+++ b/inc/utf8.php
@@ -212,7 +212,7 @@ if(!function_exists('utf8_substr')){
 
         // normalise -ve offsets (we could use a tail anchored pattern, but they are horribly slow!)
         if ($offset < 0) {
-            $strlen = strlen(utf8_decode($str));        // see notes
+            $strlen = utf8_strlen($str);        // see notes
             $offset = $strlen + $offset;
             if ($offset < 0) $offset = 0;
         }
@@ -233,7 +233,7 @@ if(!function_exists('utf8_substr')){
             $length_pattern = '(.*)$';                  // the rest of the string
         } else {
 
-            if (!isset($strlen)) $strlen = strlen(utf8_decode($str));    // see notes
+            if (!isset($strlen)) $strlen = utf8_strlen($str);    // see notes
             if ($offset > $strlen) return '';           // another trivial case
 
             if ($length > 0) {


### PR DESCRIPTION
`utf8` provides a separate [function](https://github.com/splitbrain/dokuwiki/blob/master/inc/utf8.php#L151) with multiple fallbacks for calculating the string length. But in [some places](https://github.com/splitbrain/dokuwiki/blob/master/inc/utf8.php#L215,L236) only its first option was being used (which may be unavailable).