### PR TITLE
link the old version in MM when view it

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1391,7 +1391,8 @@ function tpl_mediaFileDetails($image, $rev) {
     list($ext) = mimetype($image, false);
     $class    = preg_replace('/[^_\-a-z0-9]+/i', '_', $ext);
     $class    = 'select mediafile mf_'.$class;
-    $tabTitle = '<strong><a href="'.ml($image).'" class="'.$class.'" title="'.$lang['mediaview'].'">'.$image.'</a>'.'</strong>';
+    $attributes = $rev ? ['rev' => $rev] : [];
+    $tabTitle = '<strong><a href="'.ml($image, $attributes).'" class="'.$class.'" title="'.$lang['mediaview'].'">'.$image.'</a>'.'</strong>';
     if($opened_tab === 'view' && $rev) {
         printf($lang['media_viewold'], $tabTitle, dformat($rev));
     } else {


### PR DESCRIPTION
This commit fixes a bug in the media manager when viewing an old version of a media file. While, in case of an image, the old image would be displayed in the third pane, the link above would still link to the current version.

Steps to reproduce the bug:
1. find a MediaFile which has multiple versions, ideally an image to make it more obvious
2. go to the media manager and find the file there
3. go to the history tab in the third pane and select an old version of the file

Actual Result:
Now you may see the old image in the third pane, but the link in the header, just below the tabs, still links to the current version.

Expected Result:
That link links to the selected old version of that file.

This pull request fixes this behavior.