### PR TITLE
fix: prevent two selected options, b/c apparently 'String' == 0  🤦

### DIFF
--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -130,6 +130,21 @@ class form_dropdownelement_test extends DokuWikiTest {
     }
 
     /**
+     * Prevent double select that might occur because `'Auto' == 0` is true
+     */
+    public function test_doubleselect() {
+        $form = new Form\Form();
+        $form->addDropdown('foo', ['Auto', 0, 1]);
+
+        $html = $form->toHTML();
+
+        $pq = phpQuery::newDocumentXHTML($html);
+        $selected = $pq->find('option[selected=selected]');
+        $this->assertEquals(1, $selected->length);
+        $this->assertEquals('Auto', $selected->text());
+    }
+
+    /**
      * Ensure that there is always only a single one selected option
      */
     public function test_optgroups_doubleselect() {

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -88,7 +88,7 @@ class OptGroup extends Element {
     protected function renderOptions() {
         $html = '';
         foreach($this->options as $key => $val) {
-            $selected = ($key == $this->value) ? ' selected="selected"' : '';
+            $selected = ((string)$key === (string)$this->value) ? ' selected="selected"' : '';
             $attrs = '';
             if (!empty($val['attrs']) && is_array($val['attrs'])) {
                 $attrs = buildAttributes($val['attrs']);


### PR DESCRIPTION
There is a bug, where the options array `['Auto', 0, 1]` would result in HTML `option`-tags where both the `'Auto'` and the `0` option were selected.