### PR TITLE
Add manifest.json for PWA functionality

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -233,8 +233,8 @@ function tpl_metaheaders($alt = true) {
             'href'=> DOKU_BASE.'lib/exe/opensearch.php', 'title'=> $conf['title']
         );
     }
-
     $head['link'][] = array('rel'=> 'start', 'href'=> DOKU_BASE);
+    $head['link'][] = array('rel'=> 'manifest', 'href'=> DOKU_BASE.'lib/manifest/manifest.json');
     if(actionOK('index')) {
         $head['link'][] = array(
             'rel'  => 'contents', 'href'=> wl($ID, 'do=index', false, '&'),

--- a/lib/manifest/index.html
+++ b/lib/manifest/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; URL=../../" />
+<meta name="robots" content="noindex" />
+<title>nothing here...</title>
+</head>
+<body>
+<!-- this is just here to prevent directory browsing -->
+</body>
+</html>

--- a/lib/manifest/manifest.json
+++ b/lib/manifest/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "DokuWiki",
+    "short_name": "DokuWiki",
+    "start_url": ".",
+    "display": "standalone",
+    "background_color": "#fff",
+    "description": "A simple to use and highly versatile open source wiki software."
+}
+


### PR DESCRIPTION
On phones that support progressive web apps, adding dokuwiki to
home screen will make it open in full screen which is nicer.

fixes #2156 