### PR TITLE
Auth capability 'login' missing

### DIFF
--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -343,7 +343,7 @@ function actionOK($action){
         if (is_null($auth) || !$auth->canDo('delUser')) {
             $disabled[] = 'profile_delete';
         }
-        if (is_null($auth)) {
+        if (is_null($auth) || !$auth->canDo('login')) {
             $disabled[] = 'login';
         }
         if (is_null($auth) || !$auth->canDo('logout')) {

--- a/inc/html.php
+++ b/inc/html.php
@@ -43,30 +43,35 @@ function html_login(){
     global $ID;
     global $INPUT;
 
-    print p_locale_xhtml('login');
-    print '<div class="centeralign">'.NL;
-    $form = new Doku_Form(array('id' => 'dw__login'));
-    $form->startFieldset($lang['btn_login']);
-    $form->addHidden('id', $ID);
-    $form->addHidden('do', 'login');
-    $form->addElement(form_makeTextField('u', ((!$INPUT->bool('http_credentials')) ? $INPUT->str('u') : ''), $lang['user'], 'focus__this', 'block'));
-    $form->addElement(form_makePasswordField('p', $lang['pass'], '', 'block'));
-    if($conf['rememberme']) {
-        $form->addElement(form_makeCheckboxField('r', '1', $lang['remember'], 'remember__me', 'simple'));
-    }
-    $form->addElement(form_makeButton('submit', '', $lang['btn_login']));
-    $form->endFieldset();
+    if(actionOK('login')){
+        print tpl_actionlink('login','','','',true);
+    }else{
 
-    if(actionOK('register')){
-        $form->addElement('<p>'.$lang['reghere'].': '.tpl_actionlink('register','','','',true).'</p>');
-    }
+        print p_locale_xhtml('login');
+        print '<div class="centeralign">'.NL;
+        $form = new Doku_Form(array('id' => 'dw__login'));
+        $form->startFieldset($lang['btn_login']);
+        $form->addHidden('id', $ID);
+        $form->addHidden('do', 'login');
+        $form->addElement(form_makeTextField('u', ((!$INPUT->bool('http_credentials')) ? $INPUT->str('u') : ''), $lang['user'], 'focus__this', 'block'));
+        $form->addElement(form_makePasswordField('p', $lang['pass'], '', 'block'));
+        if($conf['rememberme']) {
+            $form->addElement(form_makeCheckboxField('r', '1', $lang['remember'], 'remember__me', 'simple'));
+        }
+        $form->addElement(form_makeButton('submit', '', $lang['btn_login']));
+        $form->endFieldset();
 
-    if (actionOK('resendpwd')) {
-        $form->addElement('<p>'.$lang['pwdforget'].': '.tpl_actionlink('resendpwd','','','',true).'</p>');
-    }
+        if(actionOK('register')){
+            $form->addElement('<p>'.$lang['reghere'].': '.tpl_actionlink('register','','','',true).'</p>');
+        }
 
-    html_form('login', $form);
-    print '</div>'.NL;
+        if (actionOK('resendpwd')) {
+            $form->addElement('<p>'.$lang['pwdforget'].': '.tpl_actionlink('resendpwd','','','',true).'</p>');
+        }
+
+        html_form('login', $form);
+        print '</div>'.NL;
+    }
 }
 
 

--- a/lib/plugins/auth.php
+++ b/lib/plugins/auth.php
@@ -32,6 +32,7 @@ class DokuWiki_Auth_Plugin extends DokuWiki_Plugin {
         'getUserCount' => false, // can the number of users be retrieved?
         'getGroups'    => false, // can a list of available groups be retrieved?
         'external'     => false, // does the module do external auth checking?
+        'login'        => false, // does the module do logins? (replacing the default form)
         'logout'       => true, // can the user logout again? (eg. not possible with HTTP auth)
     );
 


### PR DESCRIPTION
In regards to #797, this PR is supposed to add some sort of 'login' capability to an Auth Plugin to allow for custom Login Forms to be presented instead of the default login, that may or may not be used by the plugin.

**This is a work in progress. Please don't judge**