### PR TITLE
Add name as title in internal links

### DIFF
--- a/_test/tests/inc/parser/renderer_xhtml.test.php
+++ b/_test/tests/inc/parser/renderer_xhtml.test.php
@@ -267,7 +267,7 @@ class renderer_xhtml_test extends DokuWikiTest {
         $this->assertSame('0', $header);
 
         $this->R->internallink($id);
-        $expected = '<a href="/./doku.php?id='.$id.'" class="wikilink1" title="'.$id.'">0</a>';
+        $expected = '<a href="/./doku.php?id='.$id.'" class="wikilink1">0</a>';
         $this->assertEquals($expected, trim($this->R->doc));
     }
 }

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -893,7 +893,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         }
         $link['url']    = wl($id, $params);
         $link['name']   = $name;
-        $link['title']  = $id;
+        $link['title']  = $name;
         //add search string
         if($search) {
             ($conf['userewrite']) ? $link['url'] .= '?' : $link['url'] .= '&amp;';


### PR DESCRIPTION
I think it would have more meaning for a link title to contain the name of the link instead of the page id.
