### PR TITLE
Security: Prevent direct access to /vendor/ via .htaccess

### DIFF
--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,0 +1,7 @@
+<IfModule mod_authz_host>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_host>
+    Order allow,deny
+    Deny from all
+</IfModule>


### PR DESCRIPTION
Direct remote access to the vendor tree is dangerous because composer-installed libraries might contain scripts that are directly executable (cli scripts, documentation examples etc.). Since moving the vendor tree outside the document root isn't an option for DokuWiki, access to the directory should at least be prevented via a .htaccess, which is added by this PR. Since there should never be a reason for direct remote access to the vendor tree (in fact, many projects using composer put it outside the document root), this shouldn't present any issues.

Note that AFAICT at the moment there appear to be no dangerous scripts below `/vendor/`, so there is no imminent security problem. This might change in the future however, as more composer dependencies might be added or existing ones updated (in fact, the lesserphp upstream package contains a potentially dangerous `tests/sort.php`, which was excluded from DokuWiki when the switch to lesserphp was done, but might come back later if someone updates lesserphp).