### PR TITLE
Allow editing user style files through styling plugin

### DIFF
--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -78,13 +78,17 @@ function css_out(){
         if(!empty($config_cascade['userstyle'][$mediatype])) {
             foreach($config_cascade['userstyle'][$mediatype] as $userstyle) {
                 $files[$userstyle] = DOKU_BASE;
+                if($INPUT->bool('preview')) {
+                    $userstyle = str_replace(DOKU_CONF, $conf['cachedir'].'/', $userstyle);
+                    $files[$userstyle] = DOKU_BASE;
+                }
             }
         }
 
         // Let plugins decide to either put more styles here or to remove some
         $media_files[$mediatype] = css_filewrapper($mediatype, $files);
         $CSSEvt = new Doku_Event('CSS_STYLES_INCLUDED', $media_files[$mediatype]);
-    
+
         // Make it preventable.
         if ( $CSSEvt->advise_before() ) {
             $cache_files = array_merge($cache_files, array_keys($media_files[$mediatype]['files']));
@@ -92,7 +96,7 @@ function css_out(){
             // unset if prevented. Nothing will be printed for this mediatype.
             unset($media_files[$mediatype]);
         }
-        
+
         // finish event.
         $CSSEvt->advise_after();
     }
@@ -108,7 +112,7 @@ function css_out(){
 
     // start output buffering
     ob_start();
-    
+
     // Fire CSS_STYLES_INCLUDED for one last time to let the
     // plugins decide whether to include the DW default styles.
     // This can be done by preventing the Default.
@@ -124,19 +128,19 @@ function css_out(){
         }
 
         $cssData = $media_files[$mediatype];
-        
+
         // Print the styles.
         print NL;
         if ( $cssData['encapsulate'] === true ) print $cssData['encapsulationPrefix'] . ' {';
         print '/* START '.$cssData['mediatype'].' styles */'.NL;
-    
+
         // load files
         foreach($cssData['files'] as $file => $location){
             $display = str_replace(fullpath(DOKU_INC), '', fullpath($file));
             print "\n/* XXXXXXXXX $display XXXXXXXXX */\n";
             print css_loadfile($file, $location);
         }
-        
+
         print NL;
         if ( $cssData['encapsulate'] === true ) print '} /* /@media ';
         else print '/*';

--- a/lib/plugins/styling/lang/en/lang.php
+++ b/lib/plugins/styling/lang/en/lang.php
@@ -19,6 +19,11 @@ $lang['btn_save']    = 'Save changes';
 $lang['btn_reset']   = 'Reset current changes';
 $lang['btn_revert']  = 'Revert styles back to template\'s default';
 
+$lang['userstyle'] = 'Edit <code>conf/userstyle</code> for style to be applaied in screen mode';
+$lang['userprint'] = 'Edit <code>conf/userprint</code> for style to be applaied when a page is printed';
+$lang['userfeed'] = 'Edit <code>conf/userfeed</code> for style to be applaied when displaying the feed';
+$lang['userall'] = 'Edit <code>conf/userall</code> for style to be applaied in all display modes';
+
 // default guaranteed placeholders
 $lang['__text__']           = 'Main text color';
 $lang['__background__']     = 'Main background color';


### PR DESCRIPTION
Below the final result:
![styling](https://user-images.githubusercontent.com/10964663/33803393-5fae2620-dd8f-11e7-836b-ee387b45e172.png)

According to https://www.dokuwiki.org/devel:css#user_styles now the user can edit the various user style files in a more practical way, see the preview, eventually save or discard the changes (all the functionalities offered by Styling plugin are preserved).

If the extension is not specified, it's assumed to be `.css`.

In the preview mode, all these files are saved in `$conf[cachedir]`, otherwise in `DOKU_CONF`.

I've tested in local and it works, but advices and revisions are necessary. 