### PR TITLE
feat: canonically provide $ACT to javascript

### DIFF
--- a/doku.php
+++ b/doku.php
@@ -90,10 +90,6 @@ if($DATE_AT) {
 //make infos about the selected page available
 $INFO = pageinfo();
 
-//export minimal info to JS, plugins can add more
-$JSINFO['id']        = $ID;
-$JSINFO['namespace'] = (string) $INFO['namespace'];
-
 // handle debugging
 if($conf['allowdebug'] && $ACT == 'debug') {
     html_debug();

--- a/inc/common.php
+++ b/inc/common.php
@@ -301,6 +301,23 @@ function pageinfo() {
 }
 
 /**
+ * Initialize and/or fill global $JSINFO with some basic info to be given to javascript
+ */
+function jsinfo() {
+    global $JSINFO, $ID, $INFO, $ACT;
+
+    if (!is_array($JSINFO)) {
+        $JSINFO = [];
+    }
+    //export minimal info to JS, plugins can add more
+    $JSINFO['id']                    = $ID;
+    $JSINFO['namespace']             = (string) $INFO['namespace'];
+    $JSINFO['ACT']                   = act_clean($ACT);
+    $JSINFO['useHeadingNavigation']  = (int) useHeading('navigation');
+    $JSINFO['useHeadingContent']     = (int) useHeading('content');
+}
+
+/**
  * Return information about the current media item as an associative array.
  *
  * @return array with info about current media item

--- a/inc/template.php
+++ b/inc/template.php
@@ -331,6 +331,8 @@ function tpl_metaheaders($alt = true) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
     $JSINFO['ACT'] = act_clean($ACT);
+    $JSINFO['DOKU_UHN'] = (int) useHeading('navigation');
+    $JSINFO['DOKU_UHC'] = (int) useHeading('content');
     $script .= 'var JSINFO = '.$json->encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -352,7 +352,7 @@ function tpl_metaheaders($alt = true) {
 }
 
 function _tpl_ensureJSINFO() {
-    global $JSINFO, $ID, $INFO;
+    global $JSINFO, $ID, $INFO, $ACT;
 
     if (!is_array($JSINFO)) {
         $JSINFO = [];

--- a/inc/template.php
+++ b/inc/template.php
@@ -324,14 +324,12 @@ function tpl_metaheaders($alt = true) {
         'href'=> DOKU_BASE.'lib/exe/css.php?t='.rawurlencode($conf['template']).'&tseed='.$tseed
     );
 
-    // make $INFO and other vars available to JavaScripts
-    $json   = new JSON();
     $script = "var NS='".$INFO['namespace']."';";
     if($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
     _tpl_ensureJSINFO();
-    $script .= 'var JSINFO = '.$json->encode($JSINFO).';';
+    $script .= 'var JSINFO = ' . json_encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 
     // load jquery

--- a/inc/template.php
+++ b/inc/template.php
@@ -328,7 +328,7 @@ function tpl_metaheaders($alt = true) {
     if($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
-    _tpl_ensureJSINFO();
+    jsinfo();
     $script .= 'var JSINFO = ' . json_encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 
@@ -349,20 +349,6 @@ function tpl_metaheaders($alt = true) {
     // trigger event here
     trigger_event('TPL_METAHEADER_OUTPUT', $head, '_tpl_metaheaders_action', true);
     return true;
-}
-
-function _tpl_ensureJSINFO() {
-    global $JSINFO, $ID, $INFO, $ACT;
-
-    if (!is_array($JSINFO)) {
-        $JSINFO = [];
-    }
-    //export minimal info to JS, plugins can add more
-    $JSINFO['id']                    = $ID;
-    $JSINFO['namespace']             = (string) $INFO['namespace'];
-    $JSINFO['ACT']                   = act_clean($ACT);
-    $JSINFO['useHeadingNavigation']  = (int) useHeading('navigation');
-    $JSINFO['useHeadingContent']     = (int) useHeading('content');
 }
 
 /**

--- a/inc/template.php
+++ b/inc/template.php
@@ -330,9 +330,7 @@ function tpl_metaheaders($alt = true) {
     if($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
-    $JSINFO['ACT'] = act_clean($ACT);
-    $JSINFO['DOKU_UHN'] = (int) useHeading('navigation');
-    $JSINFO['DOKU_UHC'] = (int) useHeading('content');
+    _tpl_ensureJSINFO();
     $script .= 'var JSINFO = '.$json->encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 
@@ -353,6 +351,20 @@ function tpl_metaheaders($alt = true) {
     // trigger event here
     trigger_event('TPL_METAHEADER_OUTPUT', $head, '_tpl_metaheaders_action', true);
     return true;
+}
+
+function _tpl_ensureJSINFO() {
+    global $JSINFO, $ID, $INFO;
+
+    if (!is_array($JSINFO)) {
+        $JSINFO = [];
+    }
+    //export minimal info to JS, plugins can add more
+    $JSINFO['id']                    = $ID;
+    $JSINFO['namespace']             = (string) $INFO['namespace'];
+    $JSINFO['ACT']                   = act_clean($ACT);
+    $JSINFO['DOKU_UHN']              = (int) useHeading('navigation');
+    $JSINFO['DOKU_UHC']              = (int) useHeading('content');
 }
 
 /**

--- a/inc/template.php
+++ b/inc/template.php
@@ -330,6 +330,7 @@ function tpl_metaheaders($alt = true) {
     if($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
+    $JSINFO['ACT'] = act_clean($ACT);
     $script .= 'var JSINFO = '.$json->encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -363,8 +363,8 @@ function _tpl_ensureJSINFO() {
     $JSINFO['id']                    = $ID;
     $JSINFO['namespace']             = (string) $INFO['namespace'];
     $JSINFO['ACT']                   = act_clean($ACT);
-    $JSINFO['DOKU_UHN']              = (int) useHeading('navigation');
-    $JSINFO['DOKU_UHC']              = (int) useHeading('content');
+    $JSINFO['useHeadingNavigation']  = (int) useHeading('navigation');
+    $JSINFO['useHeadingContent']     = (int) useHeading('content');
 }
 
 /**

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -99,8 +99,8 @@ function js_out(){
                  'secure' => $conf['securecookie'] && is_ssl()
             )).";";
     // FIXME: Move those to JSINFO
-    print "var DOKU_UHN    = ".((int) useHeading('navigation')).";";
-    print "var DOKU_UHC    = ".((int) useHeading('content')).";";
+    print "Object.defineProperty(window, 'DOKU_UHN', { get: function() { console.warn('Using DOKU_UHN is deprecated. Please use JSINFO.DOKU_UHN instead'); return JSINFO.DOKU_UHN; } });";
+    print "Object.defineProperty(window, 'DOKU_UHC', { get: function() { console.warn('Using DOKU_UHC is deprecated. Please use JSINFO.DOKU_UHC instead'); return JSINFO.DOKU_UHC; } });";
 
     // load JS specific translations
     $lang['js']['plugins'] = js_pluginstrings();

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -99,8 +99,8 @@ function js_out(){
                  'secure' => $conf['securecookie'] && is_ssl()
             )).";";
     // FIXME: Move those to JSINFO
-    print "Object.defineProperty(window, 'DOKU_UHN', { get: function() { console.warn('Using DOKU_UHN is deprecated. Please use JSINFO.DOKU_UHN instead'); return JSINFO.DOKU_UHN; } });";
-    print "Object.defineProperty(window, 'DOKU_UHC', { get: function() { console.warn('Using DOKU_UHC is deprecated. Please use JSINFO.DOKU_UHC instead'); return JSINFO.DOKU_UHC; } });";
+    print "Object.defineProperty(window, 'DOKU_UHN', { get: function() { console.warn('Using DOKU_UHN is deprecated. Please use JSINFO.useHeadingNavigation instead'); return JSINFO.useHeadingNavigation; } });";
+    print "Object.defineProperty(window, 'DOKU_UHC', { get: function() { console.warn('Using DOKU_UHC is deprecated. Please use JSINFO.useHeadingContent instead'); return JSINFO.useHeadingContent; } });";
 
     // load JS specific translations
     $lang['js']['plugins'] = js_pluginstrings();


### PR DESCRIPTION
It would be helpful if there were a reliable way to determine the current mode in javascript, for example, if we only want to execute some javascript in `show` or `preview` modes. This writes the final mode to the `$JSINFO` object right before it is written out as a header, so we can hopefully capture the actual mode without a plugin changing it later on.

## To Do/Discuss
- [x] I would like to initialize $JSINFO in `lib/exe/detail.php` as well. Which keys should be included?
- [x] There are several lines in `lib/exe/js.php` that might be suitable to be included in `JSINFO` (see below). Which one should we include in `JSINFO` and can we somehow show a deprecation notice if the old variables are used?

https://github.com/splitbrain/dokuwiki/blob/479b8450994e5a47eff744c623b3ae14afcee19c/lib/exe/js.php#L94-L103