### PR TITLE
Add cache for _getUserData in authldap

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -160,7 +160,10 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
      */
     protected function _getUserData($user, $inbind = false) {
         global $conf;
+        static $userCache = array();
+
         if(!$this->_openLDAP()) return false;
+        if(isset($userCache[$user])) return $userCache[$user];
 
         // force superuser bind if wanted and not bound as superuser yet
         if($this->getConf('binddn') && $this->getConf('bindpw') && $this->bound < 2) {
@@ -291,6 +294,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin {
         if(!$info['grps'] or !in_array($conf['defaultgroup'], $info['grps'])) {
             $info['grps'][] = $conf['defaultgroup'];
         }
+        $userCache[$user] = $info;
         return $info;
     }
 


### PR DESCRIPTION
Stop askin LDAP server 20 times with same query - ask once and remember returned data. Better performance.