### PR TITLE
Explicitly transmit codeblock offset accross workflow "Show => Section edit => Preview".

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -127,7 +127,7 @@ function html_secedit_button($matches){
     }
 
     if (!empty($matches['codeblockOffset'])) {
-        $data['codeblockOffset'] = strtolower($matches['codeblockOffset']);
+        $data['codeblockOffset'] = $matches['codeblockOffset'];
     }
 
     return trigger_event('HTML_SECEDIT_BUTTON', $data,

--- a/inc/html.php
+++ b/inc/html.php
@@ -9,7 +9,7 @@
 if(!defined('DOKU_INC')) die('meh.');
 if(!defined('NL')) define('NL',"\n");
 if (!defined('SEC_EDIT_PATTERN')) {
-    define('SEC_EDIT_PATTERN', '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#');
+    define('SEC_EDIT_PATTERN', '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?(?:"(?<codeblockOffset>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#');
 }
 
 
@@ -124,6 +124,10 @@ function html_secedit_button($matches){
 
     if (!empty($matches['name'])) {
         $data['name'] = $matches['name'];
+    }
+
+    if (!empty($matches['codeblockOffset'])) {
+        $data['codeblockOffset'] = strtolower($matches['codeblockOffset']);
     }
 
     return trigger_event('HTML_SECEDIT_BUTTON', $data,
@@ -1859,6 +1863,9 @@ function html_edit(){
     $form->addHidden('target', $data['target']);
     if ($INPUT->has('hid')) {
         $form->addHidden('hid', $INPUT->str('hid'));
+    }
+    if ($INPUT->has('codeblockOffset')) {
+        $form->addHidden('codeblockOffset', $INPUT->str('codeblockOffset'));
     }
     $form->addElement(form_makeOpenTag('div', array('id'=>'wiki__editbar', 'class'=>'editBar')));
     $form->addElement(form_makeOpenTag('div', array('id'=>'size__ctl')));


### PR DESCRIPTION
This helps finding the correct codeblock if a code download is triggered in preview mode. Fixes #741.