### PR TITLE
Refactored section edit

### DIFF
--- a/_test/tests/inc/html_secedit_pattern.test.php
+++ b/_test/tests/inc/html_secedit_pattern.test.php
@@ -6,9 +6,9 @@ class html_scedit_pattern_test extends DokuWikiTest {
     public function dataProviderForTestSecEditPattern() {
         return [
             [
-                '<!-- EDIT5 SECTION "Plugins" "plugins" [1406-] -->',
+                '<!-- EDIT{"target":"SECTION","name":"Plugins","hid":"plugins","codeblockOffset":0,"secid":5,"range":"1406-"} -->',
                 [
-                    'secid' => '5',
+                    'secid' => 5,
                     'target' => 'SECTION',
                     'name' => 'Plugins',
                     'hid' => 'plugins',
@@ -17,9 +17,9 @@ class html_scedit_pattern_test extends DokuWikiTest {
                 'basic section edit',
             ],
             [
-                '<!-- EDIT10 TABLE "" "table4" [11908-14014] -->',
+                '<!-- EDIT{"target":"TABLE","name":"","hid":"table4","codeblockOffset":0,"secid":10,"range":"11908-14014"} -->',
                 [
-                    'secid' => '10',
+                    'secid' => 10,
                     'target' => 'TABLE',
                     'name' => '',
                     'hid' => 'table4',
@@ -28,9 +28,9 @@ class html_scedit_pattern_test extends DokuWikiTest {
                 'table edit'
             ],
             [
-                '<!-- EDIT2 PLUGIN_DATA [27-432] -->',
+                '<!-- EDIT{"target":"PLUGIN_DATA","name":"","hid":"","codeblockOffset":0,"secid":2,"range":"27-432"} -->',
                 [
-                    'secid' => '2',
+                    'secid' => 2,
                     'target' => 'PLUGIN_DATA',
                     'name' => '',
                     'hid' => '',
@@ -50,8 +50,9 @@ class html_scedit_pattern_test extends DokuWikiTest {
      */
     public function testSecEditPattern($text, $expectedMatches, $msg) {
         preg_match(SEC_EDIT_PATTERN, $text, $matches);
+        $data = json_decode($matches[1], true);
         foreach ($expectedMatches as $key => $expected_value) {
-            $this->assertSame($expected_value, $matches[$key], $msg);
+            $this->assertSame($expected_value, $data[$key], $msg);
         }
     }
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -9,7 +9,7 @@
 if(!defined('DOKU_INC')) die('meh.');
 if(!defined('NL')) define('NL',"\n");
 if (!defined('SEC_EDIT_PATTERN')) {
-    define('SEC_EDIT_PATTERN', '#<!-- EDIT(?<secid>\d+) (?<target>[A-Z_]+) (?:"(?<name>[^"]*)" )?(?:"(?<hid>[^"]*)" )?\[(?<range>\d+-\d*)\] -->#');
+    define('SEC_EDIT_PATTERN', '#<!-- EDIT({.*}) -->#');
 }
 
 
@@ -114,17 +114,12 @@ function html_secedit($text,$show=true){
  * @triggers HTML_SECEDIT_BUTTON
  */
 function html_secedit_button($matches){
-    $data = array('secid'  => $matches['secid'],
-        'target' => strtolower($matches['target']),
-        'range'  => $matches['range']);
-
-    if (!empty($matches['hid'])) {
-        $data['hid'] = strtolower($matches['hid']);
+    $data = json_decode($matches[1], true);
+    if ($data == NULL) {
+        return;
     }
-
-    if (!empty($matches['name'])) {
-        $data['name'] = $matches['name'];
-    }
+    $data ['target'] = strtolower($data['target']);
+    $data ['hid'] = strtolower($data['hid']);
 
     return trigger_event('HTML_SECEDIT_BUTTON', $data,
                          'html_secedit_get_button');
@@ -1859,6 +1854,9 @@ function html_edit(){
     $form->addHidden('target', $data['target']);
     if ($INPUT->has('hid')) {
         $form->addHidden('hid', $INPUT->str('hid'));
+    }
+    if ($INPUT->has('codeblockOffset')) {
+        $form->addHidden('codeblockOffset', $INPUT->str('codeblockOffset'));
     }
     $form->addElement(form_makeOpenTag('div', array('id'=>'wiki__editbar', 'class'=>'editBar')));
     $form->addElement(form_makeOpenTag('div', array('id'=>'size__ctl')));


### PR DESCRIPTION
The data for the section edit button is now passed as an assoziative array which is
encoded in the '#<!-- EDIT(.*) -->#' placeholder as an JSON array.

This also already includes the fix for issue #741.

This PR needs to be reviewed and it needs to be examined which plugins might need an adjustment.