### PR TITLE
feat: add optionally an SVG to html_btn

### DIFF
--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -171,7 +171,6 @@ abstract class AbstractItem {
      *
      * Uses html_btn()
      *
-     * @todo this does currently not support the SVG icon
      * @return string
      */
     public function asHtmlButton() {
@@ -182,7 +181,8 @@ abstract class AbstractItem {
             $this->getParams(),
             $this->method,
             $this->getTitle(),
-            $this->getLabel()
+            $this->getLabel(),
+            inlineSVG($this->getSvg())
         );
     }
 

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -182,7 +182,7 @@ abstract class AbstractItem {
             $this->method,
             $this->getTitle(),
             $this->getLabel(),
-            inlineSVG($this->getSvg())
+            $this->getSvg()
         );
     }
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -188,9 +188,10 @@ function html_topbtn(){
  * @param string         $method
  * @param string         $tooltip
  * @param bool|string    $label  label text, false: lookup btn_$name in localization
+ * @param string $inlineSVG (optional) inlineSVG code, inserted into the button
  * @return string
  */
-function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label=false){
+function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label=false, $inlineSVG=null){
     global $conf;
     global $lang;
 
@@ -233,7 +234,12 @@ function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label
         $ret .= 'accesskey="'.$akey.'" ';
     }
     $ret .= 'title="'.$tip.'">';
-    $ret .= hsc($label);
+    if ($inlineSVG) {
+        $ret .= '<span>' . hsc($label) . '</span>';
+        $ret .= $inlineSVG;
+    } else {
+        $ret .= hsc($label);
+    }
     $ret .= '</button>';
     $ret .= '</div></form>';
 

--- a/inc/html.php
+++ b/inc/html.php
@@ -188,10 +188,10 @@ function html_topbtn(){
  * @param string         $method
  * @param string         $tooltip
  * @param bool|string    $label  label text, false: lookup btn_$name in localization
- * @param string $inlineSVG (optional) inlineSVG code, inserted into the button
+ * @param string         $svg (optional) svg code, inserted into the button
  * @return string
  */
-function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label=false, $inlineSVG=null){
+function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label=false, $svg=null){
     global $conf;
     global $lang;
 
@@ -234,9 +234,9 @@ function html_btn($name, $id, $akey, $params, $method='get', $tooltip='', $label
         $ret .= 'accesskey="'.$akey.'" ';
     }
     $ret .= 'title="'.$tip.'">';
-    if ($inlineSVG) {
+    if ($svg) {
         $ret .= '<span>' . hsc($label) . '</span>';
-        $ret .= $inlineSVG;
+        $ret .= inlineSVG($svg);
     } else {
         $ret .= hsc($label);
     }


### PR DESCRIPTION
Adding SVG support to the html_button class to make it more useful.

Also, I noticed that in the current DokuWiki template the logout-link is an `<a>` tag as well, but should IMHO be a button with a `POST`-action, because it changes the server state?