### PR TITLE
move class DokuHTTPClient behind HTTPClient

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -9,77 +9,6 @@
 
 define('HTTP_NL',"\r\n");
 
-
-/**
- * Adds DokuWiki specific configs to the HTTP client
- *
- * @author Andreas Goetz <cpuidle@gmx.de>
- */
-class DokuHTTPClient extends HTTPClient {
-
-    /**
-     * Constructor.
-     *
-     * @author Andreas Gohr <andi@splitbrain.org>
-     */
-    function __construct(){
-        global $conf;
-
-        // call parent constructor
-        parent::__construct();
-
-        // set some values from the config
-        $this->proxy_host   = $conf['proxy']['host'];
-        $this->proxy_port   = $conf['proxy']['port'];
-        $this->proxy_user   = $conf['proxy']['user'];
-        $this->proxy_pass   = conf_decodeString($conf['proxy']['pass']);
-        $this->proxy_ssl    = $conf['proxy']['ssl'];
-        $this->proxy_except = $conf['proxy']['except'];
-
-        // allow enabling debugging via URL parameter (if debugging allowed)
-        if($conf['allowdebug']) {
-            if(
-                isset($_REQUEST['httpdebug']) ||
-                (
-                    isset($_SERVER['HTTP_REFERER']) &&
-                    strpos($_SERVER['HTTP_REFERER'], 'httpdebug') !== false
-                )
-            ) {
-                $this->debug = true;
-            }
-        }
-    }
-
-
-    /**
-     * Wraps an event around the parent function
-     *
-     * @triggers HTTPCLIENT_REQUEST_SEND
-     * @author   Andreas Gohr <andi@splitbrain.org>
-     */
-    /**
-     * @param string $url
-     * @param string|array $data the post data either as array or raw data
-     * @param string $method
-     * @return bool
-     */
-    function sendRequest($url,$data='',$method='GET'){
-        $httpdata = array('url'    => $url,
-                          'data'   => $data,
-                          'method' => $method);
-        $evt = new Doku_Event('HTTPCLIENT_REQUEST_SEND',$httpdata);
-        if($evt->advise_before()){
-            $url    = $httpdata['url'];
-            $data   = $httpdata['data'];
-            $method = $httpdata['method'];
-        }
-        $evt->advise_after();
-        unset($evt);
-        return parent::sendRequest($url,$data,$method);
-    }
-
-}
-
 /**
  * Class HTTPClientException
  */
@@ -936,6 +865,77 @@ class HTTPClient {
     function _uniqueConnectionId($server, $port) {
         return "$server:$port";
     }
+}
+
+
+/**
+ * Adds DokuWiki specific configs to the HTTP client
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+class DokuHTTPClient extends HTTPClient {
+
+    /**
+     * Constructor.
+     *
+     * @author Andreas Gohr <andi@splitbrain.org>
+     */
+    function __construct(){
+        global $conf;
+
+        // call parent constructor
+        parent::__construct();
+
+        // set some values from the config
+        $this->proxy_host   = $conf['proxy']['host'];
+        $this->proxy_port   = $conf['proxy']['port'];
+        $this->proxy_user   = $conf['proxy']['user'];
+        $this->proxy_pass   = conf_decodeString($conf['proxy']['pass']);
+        $this->proxy_ssl    = $conf['proxy']['ssl'];
+        $this->proxy_except = $conf['proxy']['except'];
+
+        // allow enabling debugging via URL parameter (if debugging allowed)
+        if($conf['allowdebug']) {
+            if(
+                isset($_REQUEST['httpdebug']) ||
+                (
+                    isset($_SERVER['HTTP_REFERER']) &&
+                    strpos($_SERVER['HTTP_REFERER'], 'httpdebug') !== false
+                )
+            ) {
+                $this->debug = true;
+            }
+        }
+    }
+
+
+    /**
+     * Wraps an event around the parent function
+     *
+     * @triggers HTTPCLIENT_REQUEST_SEND
+     * @author   Andreas Gohr <andi@splitbrain.org>
+     */
+    /**
+     * @param string $url
+     * @param string|array $data the post data either as array or raw data
+     * @param string $method
+     * @return bool
+     */
+    function sendRequest($url,$data='',$method='GET'){
+        $httpdata = array('url'    => $url,
+                          'data'   => $data,
+                          'method' => $method);
+        $evt = new Doku_Event('HTTPCLIENT_REQUEST_SEND',$httpdata);
+        if($evt->advise_before()){
+            $url    = $httpdata['url'];
+            $data   = $httpdata['data'];
+            $method = $httpdata['method'];
+        }
+        $evt->advise_after();
+        unset($evt);
+        return parent::sendRequest($url,$data,$method);
+    }
+
 }
 
 //Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
2 different people reported errors that seems to be solved when following the "If a class extends another, then the parent class must be declared before the child class structure." of http://php.net/manual/en/language.oop5.inheritance.php
Couldn't exactly reproduce under which php/environment the problem occurs, but following the MUST of the PHP documentation seems not to be wrong..

https://github.com/Flyspray/flyspray/pull/647