### PR TITLE
try to display an error when installer is run without php

### DIFF
--- a/install.php
+++ b/install.php
@@ -1,4 +1,13 @@
 <?php
+/*><div style="width:60%; margin: auto; background-color: #fcc;
+                border: 1px solid #faa; padding: 0.5em 1em;">
+    <h1 style="font-size: 120%">No PHP Support</h1>
+
+    It seems this server has no PHP support enabled. You will need to
+    enable PHP before you can install and run DokuWiki. Contact your hosting
+    provider if you're unsure what this means.
+
+</div>*/
 /**
  * Dokuwiki installation assistance
  *


### PR DESCRIPTION
When a server has no PHP support enabled, it will either prompt to
download a PHP file or may display it as HTML instead. When a user tries
to run install.php with a server that does the latter, they will see
some weird garbage with the browser trying to interpret raw PHP as HTML.
This pathc adds a warning at the top, telling the user what is going on.