### PR TITLE
Fix test failing due to wrong function signature in PHPUnit

### DIFF
--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -156,7 +156,7 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
      * @param string $originalClassName
      * @return PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createMock($originalClassName) {
+    protected function createMock($originalClassName):MockObject{
         if(is_callable(array('parent', 'createMock'))) {
             return parent::createMock($originalClassName);
         } else {
@@ -171,7 +171,7 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
      * @param array $methods
      * @return PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createPartialMock($originalClassName, array $methods) {
+    protected function createPartialMock($originalClassName, array $methods):MockObject{
         if(is_callable(array('parent', 'createPartialMock'))) {
             return parent::createPartialMock($originalClassName, $methods);
         } else {

--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -1,5 +1,5 @@
 <?php
-
+use PHPUnit\Framework\MockObject\MockObject;
 
 if(!class_exists('PHPUnit_Framework_TestCase')) {
     /**
@@ -17,14 +17,46 @@ if(!class_exists('PHPUnit_Framework_TestCase')) {
             }
         }
     }
+    class PHPUnit_Framework_TestCase_Compat extends PHPUnit_Framework_TestCase {
+
+    }
+}else{
+    class PHPUnit_Framework_TestCase_Compat extends PHPUnit_Framework_TestCase {
+        /**
+         * Compatibility for older PHPUnit versions (<5.2)
+         *
+         * @param string $originalClassName
+         * @return PHPUnit_Framework_MockObject_MockObject
+         */
+        protected function createMock($originalClassName) {
+            if(is_callable(array('parent', 'createMock'))) {
+                return parent::createMock($originalClassName);
+            } else {
+                return $this->getMock($originalClassName);
+            }
+        }
+
+        /**
+         * Compatibility for older PHPUnit versions (<5.2)
+         *
+         * @param string $originalClassName
+         * @param array $methods
+         * @return PHPUnit_Framework_MockObject_MockObject
+         */
+        protected function createPartialMock($originalClassName, array $methods) {
+            if(is_callable(array('parent', 'createPartialMock'))) {
+                return parent::createPartialMock($originalClassName, $methods);
+            } else {
+                return $this->getMock($originalClassName, $methods);
+            }
+        }
+    }
 }
-
-
 
 /**
  * Helper class to provide basic functionality for tests
  */
-abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
+abstract class DokuWikiTest extends PHPUnit_Framework_TestCase_Compat {
 
     /**
      * tests can override this
@@ -148,35 +180,6 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
 
         global $INPUT;
         $INPUT = new Input();
-    }
-
-    /**
-     * Compatibility for older PHPUnit versions
-     *
-     * @param string $originalClassName
-     * @return PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createMock($originalClassName):MockObject{
-        if(is_callable(array('parent', 'createMock'))) {
-            return parent::createMock($originalClassName);
-        } else {
-            return $this->getMock($originalClassName);
-        }
-    }
-
-    /**
-     * Compatibility for older PHPUnit versions
-     *
-     * @param string $originalClassName
-     * @param array $methods
-     * @return PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createPartialMock($originalClassName, array $methods):MockObject{
-        if(is_callable(array('parent', 'createPartialMock'))) {
-            return parent::createPartialMock($originalClassName, $methods);
-        } else {
-            return $this->getMock($originalClassName, $methods);
-        }
     }
 
     /**

--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -23,7 +23,7 @@ if(!class_exists('PHPUnit_Framework_TestCase')) {
 }else{
     class PHPUnit_Framework_TestCase_Compat extends PHPUnit_Framework_TestCase {
         /**
-         * Compatibility for older PHPUnit versions (<5.2)
+         * Compatibility for older PHPUnit versions (<5.4)
          *
          * @param string $originalClassName
          * @return PHPUnit_Framework_MockObject_MockObject
@@ -37,7 +37,7 @@ if(!class_exists('PHPUnit_Framework_TestCase')) {
         }
 
         /**
-         * Compatibility for older PHPUnit versions (<5.2)
+         * Compatibility for older PHPUnit versions (<5.4)
          *
          * @param string $originalClassName
          * @param array $methods


### PR DESCRIPTION
Since https://travis-ci.org/splitbrain/dokuwiki/jobs/341425911 the tests on PHP 7.2 have failed because of the following error. I don't understand why this happened as we stick PHPUnit to 5.7 and there is no return type hinting in its source code.

> Fatal error: Declaration of DokuWikiTest::createMock($originalClassName) must be compatible with PHPUnit\Framework\TestCase::createMock($originalClassName): PHPUnit\Framework\MockObject\MockObject in /home/travis/build/splitbrain/dokuwiki/_test/core/DokuWikiTest.php on line 27

This is a patch to let the test passing by moving the old `createMock` polyfill to a new class `PHPUnit_Framework_TestCase_Compat`, which would not execute in the new PHPUnit version with return type hinting.

Out of this patch, we have another option of removing the polyfill and [drop support below PHPUnit 5.4](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0#new-features), which simplifies things.