### PR TITLE
feat: make auth salt static in test environments

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -309,7 +309,7 @@ function auth_browseruid() {
  */
 function auth_cookiesalt($addsession = false, $secure = false) {
     if (defined('SIMPLE_TEST')) {
-        return '';
+        return 'test';
     }
     global $conf;
     $file = $conf['metadir'].'/_htcookiesalt';

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -308,6 +308,9 @@ function auth_browseruid() {
  * @return  string
  */
 function auth_cookiesalt($addsession = false, $secure = false) {
+    if (defined('SIMPLE_TEST')) {
+        return '';
+    }
     global $conf;
     $file = $conf['metadir'].'/_htcookiesalt';
     if ($secure || !file_exists($file)) {


### PR DESCRIPTION
There are circumstances where we may want to test generated content that
uses the auth salt, for example when one tests the rendering of external
images where the URL contains a token from media_get_token