### PR TITLE
switch extensions if stylesheet in style.ini doesn't exist (backwards compatibility)

### DIFF
--- a/inc/StyleUtils.php
+++ b/inc/StyleUtils.php
@@ -42,7 +42,18 @@ class StyleUtils
 
             // stylesheets
             if(is_array($data['stylesheets'])) foreach($data['stylesheets'] as $file => $mode){
-                $stylesheets[$mode][$incbase.$file] = $webbase;
+                if (!file_exists($incbase . $file)) {
+                    list($extension, $basename) = array_map('strrev', explode('.', strrev($file), 2));
+                    $newExtension = $extension === 'css' ? 'less' : 'css';
+                    if (file_exists($incbase . $basename . '.' . $newExtension)) {
+                        $stylesheets[$mode][$incbase . $basename . '.' . $newExtension] = $webbase;
+                        if ($conf['allowdebug']) {
+                            msg("Stylesheet $file not found, using $basename.$newExtension instead. Please contact developer of \"{$conf['template']}\" template.", 2);
+                        }
+                        continue;
+                    }
+                }
+                $stylesheets[$mode][$incbase . $file] = $webbase;
             }
 
             // replacements


### PR DESCRIPTION
This should give us some backwards compatibility for changing files in dokuwiki template from `.css` to `.less`. This way template authors get a warning to adjust their template, it won't break right away.

This should prevent breaking search pages in other templates due to pull request #2286 .