### PR TITLE
Mark inputs of styling plugin as required

### DIFF
--- a/lib/plugins/styling/admin.php
+++ b/lib/plugins/styling/admin.php
@@ -86,7 +86,7 @@ class admin_plugin_styling extends DokuWiki_Admin_Plugin
                 echo '<tr>';
                 echo '<td><label for="tpl__'.hsc($key).'">'.$name.'</label></td>';
                 echo '<td><input type="'.$this->colorType($value).'" name="tpl['.hsc($key).']" id="tpl__'.hsc($key).'"
-                    value="'.hsc($this->colorValue($value)).'" dir="ltr" /></td>';
+                    value="'.hsc($this->colorValue($value)).'" dir="ltr" required="required"/></td>';
                 echo '</tr>';
             }
             echo '</tbody></table>';


### PR DESCRIPTION
As recommended by @Klap-in. While this cannot ensure that the value is valid, it should prevent accidental saving of an empty field, which crashes the less compiler.

I am not aware of any use cases where saving an empty field would be valid/desirable. However, that doesn't mean that there aren't any. **Thoughts?**

Fixes #2246