### PR TITLE
bring back the namespace in braces for pagelookup results

### DIFF
--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -525,7 +525,11 @@ class Search extends Ui
         $html .= '<h3>' . $lang['quickhits'] . ':</h3>';
         $html .= '<ul class="search_quickhits">';
         foreach ($data as $id => $title) {
-            $link = html_wikilink(':' . $id);
+            $name = null;
+            if (!useHeading('navigation') && $ns = getNS($id)) {
+                $name = shorten(noNS($id), ' (' . $ns . ')', 30);
+            }
+            $link = html_wikilink(':' . $id, $name);
             $eventData = [
                 'listItemContent' => [$link],
                 'page' => $id,


### PR DESCRIPTION
This was unintentionally removed in 4eab6f7c40ab5e2fbbb5e0efb20d930d4b1730fe

It also should now be clearer what the code does.

This fixes #2305