### PR TITLE
DokuHTTPClient: Add handling for 204: No Content responses

### DIFF
--- a/inc/HTTPClient.php
+++ b/inc/HTTPClient.php
@@ -442,7 +442,9 @@ class HTTPClient {
                 $r_body = $this->_readData($socket, $length, 'response (content-length limited)', true);
             }elseif( !isset($this->resp_headers['transfer-encoding']) && $this->max_bodysize && !$this->keep_alive){
                 $r_body = $this->_readData($socket, $this->max_bodysize, 'response (content-length limited)', true);
-            }else{
+            } elseif ((int)$this->status === 204) {
+                // request has no content
+            } else{
                 // read entire socket
                 while (!feof($socket)) {
                     $r_body .= $this->_readData($socket, 4096, 'response (unlimited)', true);


### PR DESCRIPTION
This fixes a bug that would occur if the DokuHTTPClient receives a 204 response, e.g. as a result for a request to delete something. It would still try to read the body, which fails, thus producing a timeout and
finally throwing an exception.

This fix instructs the HTTPClient to not read the (not existing) body if it receives a 204.

This fixes #2308 