### PR TITLE
Fix invalid HTML

### DIFF
--- a/inc/Form/ButtonElement.php
+++ b/inc/Form/ButtonElement.php
@@ -28,7 +28,7 @@ class ButtonElement extends Element {
      * @return string
      */
     public function toHTML() {
-        return '<button ' . buildAttributes($this->attrs()) . '>'.$this->content.'</button>';
+        return '<button ' . buildAttributes($this->attrs(), true) . '>'.$this->content.'</button>';
     }
 
 }

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -584,18 +584,16 @@ class Search extends Ui
             if ($cnt !== 0) {
                 $resultHeader[] = $cnt . ' ' . $lang['hits'];
                 if ($num < FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
-                    $snippet = '<dd>' . ft_snippet($id, $highlight) . '</dd>';
-                    $lastMod = '<span class="search_results__lastmod">' . $lang['lastmod'] . ' ';
+                    $snippet = '<dd class="snippet">' . ft_snippet($id, $highlight) . '</dd>';
+                    $lastMod = $lang['lastmod'] . ' ';
                     $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
-                    $lastMod .= '</span>';
                 }
                 $num++;
             }
 
-            $metaLine = '<div class="search_results__metaLine">';
+            $metaLine = '<dd class="lastmod">';
             $metaLine .= $lastMod;
-            $metaLine .= '</div>';
-
+            $metaLine .= '</dd>';
 
             $eventData = [
                 'resultHeader' => $resultHeader,
@@ -603,10 +601,8 @@ class Search extends Ui
                 'page' => $id,
             ];
             trigger_event('SEARCH_RESULT_FULLPAGE', $eventData);
-            $html .= '<div class="search_fullpage_result">';
             $html .= '<dt>' . implode(' ', $eventData['resultHeader']) . '</dt>';
             $html .= implode('', $eventData['resultBody']);
-            $html .= '</div>';
         }
         $html .= '</dl>';
 

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -587,7 +587,7 @@ class Search extends Ui
             $lastMod = '<span class="lastmod">' . $lang['lastmod'] . '</span> ';
             $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
             if ($cnt !== 0) {
-                $hits = '<span class="hits">' . $cnt . ' ' . $lang['hits'] . '</span>';
+                $hits = '<span class="hits">' . $cnt . ' ' . $lang['hits'] . '</span>, ';
                 if ($num < FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
                     $snippet = ft_snippet($id, $highlight);
                 }

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -522,7 +522,7 @@ class Search extends Ui
         global $lang;
 
         $html = '<div class="search_quickresult">';
-        $html .= '<h3>' . $lang['quickhits'] . ':</h3>';
+        $html .= '<h2>' . $lang['quickhits'] . ':</h2>';
         $html .= '<ul class="search_quickhits">';
         foreach ($data as $id => $title) {
             $name = null;
@@ -562,7 +562,7 @@ class Search extends Ui
         }
 
         $html = '<div class="search_fulltextresult">';
-        $html .= '<h3>' . $lang['search_fullresults'] . ':</h3>';
+        $html .= '<h2>' . $lang['search_fullresults'] . ':</h2>';
 
         $html .= '<dl class="search_results">';
         $num = 1;

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -565,8 +565,8 @@ class Search extends Ui
         $html .= '<h2>' . $lang['search_fullresults'] . ':</h2>';
 
         $html .= '<dl class="search_results">';
-        $num = 1;
-        $position = 1;
+        $num = 0;
+        $position = 0;
 
         foreach ($data as $id => $cnt) {
             $position += 1;
@@ -586,12 +586,12 @@ class Search extends Ui
             $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
             $resultBody['meta'] = $lastMod;
             if ($cnt !== 0) {
+                $num++;
                 $hits = '<span class="hits">' . $cnt . ' ' . $lang['hits'] . '</span>, ';
                 $resultBody['meta'] = $hits . $resultBody['meta'];
-                if ($num < FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
+                if ($num <= FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
                     $resultBody['snippet'] = ft_snippet($id, $highlight);
                 }
-                $num++;
             }
 
             $eventData = [

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -579,30 +579,37 @@ class Search extends Ui
             }
 
             $snippet = '';
-            $lastMod = '';
+            $hits = '';
+            $resultBody = [];
             $mtime = filemtime(wikiFN($id));
+            $lastMod = '<span class="lastmod">' . $lang['lastmod'] . '</span> ';
+            $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
             if ($cnt !== 0) {
-                $resultHeader[] = $cnt . ' ' . $lang['hits'];
+                $hits = '<span class="hits">' . $cnt . ' ' . $lang['hits'] . '</span>';
                 if ($num < FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
-                    $snippet = '<dd class="snippet">' . ft_snippet($id, $highlight) . '</dd>';
-                    $lastMod = $lang['lastmod'] . ' ';
-                    $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
+                    $snippet = ft_snippet($id, $highlight);
                 }
                 $num++;
             }
 
-            $metaLine = '<dd class="lastmod">';
-            $metaLine .= $lastMod;
-            $metaLine .= '</dd>';
+            $resultBody['meta'] = $hits . $lastMod;
+
+            if ($snippet) {
+                $resultBody['snippet'] = $snippet;
+            }
 
             $eventData = [
                 'resultHeader' => $resultHeader,
-                'resultBody' => [$metaLine, $snippet],
+                'resultBody' => $resultBody,
                 'page' => $id,
             ];
             trigger_event('SEARCH_RESULT_FULLPAGE', $eventData);
+            $html .= '<div class="search_fullpage_result">';
             $html .= '<dt>' . implode(' ', $eventData['resultHeader']) . '</dt>';
-            $html .= implode('', $eventData['resultBody']);
+            foreach ($eventData['resultBody'] as $class => $htmlContent) {
+                $html .= "<dd class=\"$class\">$htmlContent</dd>";
+            }
+            $html .= '</div>';
         }
         $html .= '</dl>';
 

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -580,24 +580,18 @@ class Search extends Ui
                 $resultHeader[] = $restrictQueryToNSLink;
             }
 
-            $snippet = '';
-            $hits = '';
             $resultBody = [];
             $mtime = filemtime(wikiFN($id));
             $lastMod = '<span class="lastmod">' . $lang['lastmod'] . '</span> ';
             $lastMod .= '<time datetime="' . date_iso8601($mtime) . '" title="'.dformat($mtime).'">' . dformat($mtime, '%f') . '</time>';
+            $resultBody['meta'] = $lastMod;
             if ($cnt !== 0) {
                 $hits = '<span class="hits">' . $cnt . ' ' . $lang['hits'] . '</span>, ';
+                $resultBody['meta'] = $hits . $resultBody['meta'];
                 if ($num < FT_SNIPPET_NUMBER) { // create snippets for the first number of matches only
-                    $snippet = ft_snippet($id, $highlight);
+                    $resultBody['snippet'] = ft_snippet($id, $highlight);
                 }
                 $num++;
-            }
-
-            $resultBody['meta'] = $hits . $lastMod;
-
-            if ($snippet) {
-                $resultBody['snippet'] = $snippet;
             }
 
             $eventData = [

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -566,8 +566,10 @@ class Search extends Ui
 
         $html .= '<dl class="search_results">';
         $num = 1;
+        $position = 1;
 
         foreach ($data as $id => $cnt) {
+            $position += 1;
             $resultLink = html_wikilink(':' . $id, null, $highlight);
 
             $resultHeader = [$resultLink];
@@ -602,6 +604,7 @@ class Search extends Ui
                 'resultHeader' => $resultHeader,
                 'resultBody' => $resultBody,
                 'page' => $id,
+                'position' => $position,
             ];
             trigger_event('SEARCH_RESULT_FULLPAGE', $eventData);
             $html .= '<div class="search_fullpage_result">';

--- a/inc/Ui/SearchState.php
+++ b/inc/Ui/SearchState.php
@@ -136,6 +136,6 @@ class SearchState
         }
 
         $href = wl($ID, $hrefAttributes, false, '&');
-        return "<a href='$href' " . buildAttributes($tagAttributes) . ">$label</a>";
+        return "<a href='$href' " . buildAttributes($tagAttributes, true) . ">$label</a>";
     }
 }

--- a/lib/tpl/dokuwiki/css/_search.less
+++ b/lib/tpl/dokuwiki/css/_search.less
@@ -137,8 +137,13 @@
     }
 
     /* last modified line */
-    dd.lastmod {
+    dd.meta {
         margin: 0 0 .2em 0;
+
+        .hits {
+            margin-right: 1em;
+        }
+
     }
 
     /* search snippet */

--- a/lib/tpl/dokuwiki/css/_search.less
+++ b/lib/tpl/dokuwiki/css/_search.less
@@ -136,8 +136,13 @@
         margin-bottom: .2em;
     }
 
+    /* last modified line */
+    dd.lastmod {
+        margin: 0 0 .2em 0;
+    }
+
     /* search snippet */
-    dd {
+    dd.snippet {
         color: @ini_text_alt;
         background-color: inherit;
         margin: 0 0 1.2em 0;

--- a/lib/tpl/dokuwiki/css/_search.less
+++ b/lib/tpl/dokuwiki/css/_search.less
@@ -108,8 +108,6 @@
 .dokuwiki div.search_quickresult {
     margin-bottom: 1.4em;
 
-    h3 {
-    }
     ul {
         padding: 0;
 
@@ -139,11 +137,6 @@
     /* last modified line */
     dd.meta {
         margin: 0 0 .2em 0;
-
-        .hits {
-            margin-right: 1em;
-        }
-
     }
 
     /* search snippet */


### PR DESCRIPTION
This fixes some invalid HTML which mostly sneaked in with #2286.
The semantics of the search results page are a bit tricky. I nearly changed the existing description list to a normal unordered list, but I think it still makes sense the way it is now, i.e. a `dl` with 1 `dt` and 2 `dd`. Semantically I think it might make more sense to move the "[number of] Hits" also into its own `dd` or add it to the 'last modified' line.
