### PR TITLE
print 'you are here' again for startpages

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -800,9 +800,17 @@ function tpl_youarehere($sep = null, $return = false) {
 
     // print current page, skipping start page, skipping for namespace index
     resolve_pageid('', $page, $exists);
-    if(isset($page) && $page == $part.$parts[$i]) return true;
+    if (isset($page) && $page == $part.$parts[$i]) {
+        if($return) return $out;
+        print $out;
+        return true;
+    }
     $page = $part.$parts[$i];
-    if($page == $conf['start']) return true;
+    if($page == $conf['start']) {
+        if($return) return $out;
+        print $out;
+        return true;
+    }
     $out .= $sep;
     $out .= tpl_pagelink($page, null, true);
     if($return) return $out;


### PR DESCRIPTION
This bug was introduced in #2251 / c4a386f17daa381f6a50b7c30e73b316bd321e04 which neglected to handle the early returns.

Fixes #2325