### PR TITLE
Replace old call to css_styleini

### DIFF
--- a/lib/tpl/index.php
+++ b/lib/tpl/index.php
@@ -46,7 +46,8 @@ require_once(DOKU_INC.'inc/init.php');
 // get merged style.ini
 define('SIMPLE_TEST', true); // hack to prevent css output and headers
 require_once(DOKU_INC.'lib/exe/css.php');
-$ini = css_styleini($conf['template']);
+$styleUtils = new \dokuwiki\StyleUtils();
+$ini = $styleUtils->cssStyleini($conf['template']);
 
 if ($ini) {
     echo '<table>';


### PR DESCRIPTION
This fixes a call to the no longer existing `css_styleini()` function

fixes #2330 
