### PR TITLE
Add simple catch-all to left install.php div

### DIFF
--- a/install.php
+++ b/install.php
@@ -103,24 +103,28 @@ header('Content-Type: text/html; charset=utf-8');
 
     <div style="float: left; width: 58%;">
         <?php
-            if(! (check_functions() && check_permissions()) ){
-                echo '<p>'.$lang['i_problems'].'</p>';
-                print_errors();
-                print_retry();
-            }elseif(!check_configs()){
-                echo '<p>'.$lang['i_modified'].'</p>';
-                print_errors();
-            }elseif(check_data($_REQUEST['d'])){
-                // check_data has sanitized all input parameters
-                if(!store_data($_REQUEST['d'])){
-                    echo '<p>'.$lang['i_failure'].'</p>';
+            try {
+                if(! (check_functions() && check_permissions()) ){
+                    echo '<p>'.$lang['i_problems'].'</p>';
                     print_errors();
+                    print_retry();
+                }elseif(!check_configs()){
+                    echo '<p>'.$lang['i_modified'].'</p>';
+                    print_errors();
+                }elseif(check_data($_REQUEST['d'])){
+                    // check_data has sanitized all input parameters
+                    if(!store_data($_REQUEST['d'])){
+                        echo '<p>'.$lang['i_failure'].'</p>';
+                        print_errors();
+                    }else{
+                        echo '<p>'.$lang['i_success'].'</p>';
+                    }
                 }else{
-                    echo '<p>'.$lang['i_success'].'</p>';
+                    print_errors();
+                    print_form($_REQUEST['d']);
                 }
-            }else{
-                print_errors();
-                print_form($_REQUEST['d']);
+            } catch (Exception $e) {
+                echo 'Caught exception: ',  $e->getMessage(), "\n";
             }
         ?>
     </div>


### PR DESCRIPTION
Background: I was trying to install DokuWiki in my chrooted OpenBSD webserver. The install seemed funky (generated config but not ACLs), and the installer page, instead of even showing any errors, was just blank after submitting initial parameters. Long story short, I edited install.php to approximately this effect, and finally got a visible error, which let me find out that I needed to create $CHROOT/dev/{a,u,s,}random. I would have found that out a lot sooner and torn out a lot less of my beautiful hair if something like this were already in place. After all, the installation phase is where one expects many edge cases and whatnot. Would help newcomers with strange environments to make more actionable and informative forum posts crying for help. Please consider.