### PR TITLE
unlock pages on viewing them

### DIFF
--- a/inc/Action/Cancel.php
+++ b/inc/Action/Cancel.php
@@ -13,7 +13,11 @@ use dokuwiki\Action\Exception\ActionAbort;
  */
 class Cancel extends AbstractAliasAction {
 
+    /** @inheritdoc */
     public function preProcess() {
+        global $ID;
+        unlock($ID);
+
         // continue with draftdel -> redirect -> show
         throw new ActionAbort('draftdel');
     }

--- a/inc/Action/Show.php
+++ b/inc/Action/Show.php
@@ -23,6 +23,12 @@ class Show extends AbstractAction {
     }
 
     /** @inheritdoc */
+    public function preProcess() {
+        global $ID;
+        unlock($ID);
+    }
+
+    /** @inheritdoc */
     public function tplContent() {
         html_show();
     }

--- a/inc/html.php
+++ b/inc/html.php
@@ -1804,7 +1804,7 @@ function html_edit(){
         $form->addElement(form_makeOpenTag('div', array('class'=>'editButtons')));
         $form->addElement(form_makeButton('submit', 'save', $lang['btn_save'], array('id'=>'edbtn__save', 'accesskey'=>'s', 'tabindex'=>'4')));
         $form->addElement(form_makeButton('submit', 'preview', $lang['btn_preview'], array('id'=>'edbtn__preview', 'accesskey'=>'p', 'tabindex'=>'5')));
-        $form->addElement(form_makeButton('submit', 'draftdel', $lang['btn_cancel'], array('tabindex'=>'6')));
+        $form->addElement(form_makeButton('submit', 'cancel', $lang['btn_cancel'], array('tabindex'=>'6')));
         $form->addElement(form_makeCloseTag('div'));
         $form->addElement(form_makeOpenTag('div', array('class'=>'summary')));
         $form->addElement(form_makeTextField('summary', $SUM, $lang['summary'], 'edit__summary', 'nowrap', array('size'=>'50', 'tabindex'=>'2')));


### PR DESCRIPTION
The action refactoring broke unlocking pages when the user did not save their changes. Previously all actions other than edit, preview and recover did trigger an unlock:

https://github.com/splitbrain/dokuwiki/blob/e093d6153781fce2e15460cfc011944e61d37099/inc/actions.php#L154-L159

I think doing it on show should suffice.