### PR TITLE
Install remembers status if submit fails

### DIFF
--- a/install.php
+++ b/install.php
@@ -149,7 +149,7 @@ function print_form($d){
     $d = array_map('hsc',$d);
 
     if(!isset($d['acl'])) $d['acl']=1;
-    if(!isset($d['pop'])) $d['pop']=1;
+    if(!isset($d['pop']) &&!isset($_REQUEST['submit'])) $d['pop']=1;
 
     ?>
     <form action="" method="post">
@@ -197,8 +197,8 @@ function print_form($d){
         <fieldset>
             <p><?php echo $lang['i_license']?></p>
             <?php
-            array_push($license,array('name' => $lang['i_license_none'], 'url'=>''));
-            if(empty($d['license'])) $d['license'] = 'cc-by-sa';
+            $license['none'] = array('name' => $lang['i_license_none'], 'url'=>'');
+            if(!isset($d['license'])) $d['license'] = 'cc-by-sa';
             foreach($license as $key => $lic){
                 echo '<label for="lic_'.$key.'">';
                 echo '<input type="radio" name="d[license]" value="'.hsc($key).'" id="lic_'.$key.'"'.


### PR DESCRIPTION
When the installer gives an "illegal or empty value" error, it reloads the page. During this it clears the password fields, ticks "Enable ACL" and the anonymous usage data. The license is also set to "CC Attribution-Share Alike 4.0 International" when "Do not show any license information" was selected.

This remembers the license regardless of which was selected and remembers the anonymous data collection checkbox. "Enable ACL" is still set to checked every time.