### PR TITLE
improve search to create new pages with odd name

### DIFF
--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -498,8 +498,13 @@ class Search extends Ui
      */
     public function createPagenameFromQuery($parsedQuery)
     {
+        GLOBAL $conf;
+
         $cleanedQuery = cleanID($parsedQuery['query']);
         if ($cleanedQuery === $parsedQuery['query']) {
+            return ':' . $cleanedQuery;
+        }
+        if ($cleanedQuery === utf8_strtolower(str_replace(' ',$conf['sepchar'],$parsedQuery['query']))) {
             return ':' . $cleanedQuery;
         }
         $pagename = '';


### PR DESCRIPTION
If search query contains white space and upper case letters, createQueryPageLink is created with unwanted pagename.

search query: Doku Wiki:Hello World
new pagename with this fix: doku_wiki:hello_world
new pagename without this: doku_wiki_hello_world (namespace not applied)