### PR TITLE
Border underneath `.tabs` drawn in front of the pagetools

### DIFF
--- a/lib/tpl/dokuwiki/css/_tabs.css
+++ b/lib/tpl/dokuwiki/css/_tabs.css
@@ -18,7 +18,6 @@
     bottom: 0;
     left: 0;
     border-bottom: 1px solid @ini_border;
-    z-index: 1;
 }
 
 .dokuwiki .tabs > ul li,


### PR DESCRIPTION
The grey line between "Show page" and "Old revisions" comes from the tabs in the content section. If the pagetools are hovered by the mouse, it can be observed that the line is drawn above the pagetools.

Seen on: `/start?do=admin&page=extension`

![screenshot from 2018-05-10](https://user-images.githubusercontent.com/10872136/39906315-be01bf6a-5496-11e8-81d6-624509d539b1.png)

Remove `z-index:1` on the border underneath tabs. It does not seem to make a difference but fixes the border hovering over the toolbar.