### PR TITLE
reset config directory for every test

### DIFF
--- a/_test/bootstrap.php
+++ b/_test/bootstrap.php
@@ -88,15 +88,9 @@ if (getenv('PRESERVE_TMP') != 'true') {
     echo ">>>> Preserving temporary directory: ".TMP_DIR."\n";
 }
 
-// populate default dirs
-TestUtils::rcopy(TMP_DIR, DOKU_INC.'/conf');
-TestUtils::rcopy(TMP_DIR, dirname(__FILE__).'/conf');
-mkdir(DOKU_TMP_DATA);
-foreach(array(
-    'attic', 'cache', 'index', 'locks', 'media',
-    'media_attic', 'media_meta', 'meta', 'pages', 'tmp') as $dir){
-    mkdir(DOKU_TMP_DATA.'/'.$dir);
-}
+// populate default dirs for initial setup
+DokuWikiTest::setupDataDir();
+DokuWikiTest::setupConfDir();
 
 // disable all non-default plugins by default
 $dh = dir(DOKU_INC.'lib/plugins/');

--- a/_test/core/DokuWikiTest.php
+++ b/_test/core/DokuWikiTest.php
@@ -50,15 +50,8 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
         if(!defined('TMP_DIR')) die('no temporary directory');
         if(!defined('DOKU_TMP_DATA')) die('no temporary data directory');
 
-        // remove any leftovers from the last run
-        if(is_dir(DOKU_TMP_DATA)){
-            // clear indexer data and cache
-            idx_get_indexer()->clear();
-            TestUtils::rdelete(DOKU_TMP_DATA);
-        }
-
-        // populate default dirs
-        TestUtils::rcopy(TMP_DIR, dirname(__FILE__).'/../data/');
+        self::setupDataDir();
+        self::setupConfDir();
     }
 
     /**
@@ -148,6 +141,56 @@ abstract class DokuWikiTest extends PHPUnit_Framework_TestCase {
 
         global $INPUT;
         $INPUT = new Input();
+    }
+
+    /**
+     * Reinitialize the data directory for this class run
+     */
+    public static function setupDataDir() {
+        // remove any leftovers from the last run
+        if(is_dir(DOKU_TMP_DATA)) {
+            // clear indexer data and cache
+            idx_get_indexer()->clear();
+            TestUtils::rdelete(DOKU_TMP_DATA);
+        }
+
+        // populate default dirs
+        TestUtils::rcopy(TMP_DIR, __DIR__ . '/../data/');
+    }
+
+    /**
+     * Reinitialize the conf directory for this class run
+     */
+    public static function setupConfDir() {
+        $defaults = [
+            'acronyms.conf',
+            'dokuwiki.php',
+            'entities.conf',
+            'interwiki.conf',
+            'license.php',
+            'manifest.json',
+            'mediameta.php',
+            'mime.conf',
+            'plugins.php',
+            'plugins.required.php',
+            'scheme.conf',
+            'smileys.conf',
+            'wordblock.conf'
+        ];
+
+        // clear any leftovers
+        if(is_dir(DOKU_CONF)) {
+            TestUtils::rdelete(DOKU_CONF);
+        }
+        mkdir(DOKU_CONF);
+
+        // copy defaults
+        foreach($defaults as $file) {
+            copy(DOKU_INC . '/conf/' . $file, DOKU_CONF . $file);
+        }
+
+        // copy test files
+        TestUtils::rcopy(TMP_DIR, __DIR__ . '/../conf');
     }
 
     /**


### PR DESCRIPTION
Our test suite did not reset the config directory for each test class as it does for the data directory. In addition it copied all files from the main config directory over. Both may create an unpredictable state for tests.

This streamlines the initialization.