### PR TITLE
fix: workaround premature metadata generation on page save 🐛

### DIFF
--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -104,7 +104,7 @@ function addLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', $extr
     if (!$wasRemoved) {
         $oldmeta = p_read_metadata($id);
         $meta    = array();
-        if ($wasCreated && empty($oldmeta['persistent']['date']['created'])){ // newly created
+        if ($wasCreated && (empty($oldmeta['persistent']['date']['created']) || $oldmeta['persistent']['date']['created'] === $created)){ // newly created
             $meta['date']['created'] = $created;
             if ($user){
                 $meta['creator'] = $INFO['userinfo']['name'];


### PR DESCRIPTION
This fixes a bug where the creator of a new page was not saved to metadata.
That could happen if a plugin calls `pageinfo()` in the `IO_WIKIPAGE_WRITE`
event's AFTER handler. This creates a new `.meta` file for the page with the
page's mtime as the creation timestamp. That caused the if clause
changed in this commit to evaluate as false and thus the creator key was
not saved.

This commit now also treats the page as newly created if the created
date in the metadata is equal to the file's current mtime.