### PR TITLE
introduce INFO_DEPRECATION_LOG event

### DIFF
--- a/inc/events.php
+++ b/inc/events.php
@@ -234,6 +234,24 @@ class Doku_Event_Handler {
             }
         }
     }
+
+    /**
+     * Check if an event has any registered handlers
+     *
+     * When $advise is empty, both BEFORE and AFTER events will be considered,
+     * otherwise only the given advisory is checked
+     *
+     * @param string $name Name of the event
+     * @param string $advise BEFORE, AFTER or empty
+     * @return bool
+     */
+    public function hasHandlerForEvent($name, $advise = '') {
+        if($advise) {
+            return isset($this->_hooks[$name . '_' . $advise]);
+        } else {
+            return isset($this->_hooks[$name . '_BEFORE']) || isset($this->_hooks[$name . '_AFTER']);
+        }
+    }
 }
 
 /**

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -441,8 +441,16 @@ function dbglog($msg,$header=''){
  * Log accesses to deprecated fucntions to the debug log
  *
  * @param string $alternative The function or method that should be used instead
+ * @triggers INFO_DEPRECATION_LOG
  */
 function dbg_deprecated($alternative = '') {
+    global $conf;
+    global $EVENT_HANDLER;
+    if(!$conf['allowdebug'] && !$EVENT_HANDLER->hasHandlerForEvent('INFO_DEPRECATION_LOG')) {
+        // avoid any work if no one cares
+        return;
+    }
+
     $backtrace = debug_backtrace();
     array_shift($backtrace);
     $self = $backtrace[0];

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -443,24 +443,30 @@ function dbglog($msg,$header=''){
  * @param string $alternative The function or method that should be used instead
  */
 function dbg_deprecated($alternative = '') {
-    global $conf;
-    if(!$conf['allowdebug']) return;
-
     $backtrace = debug_backtrace();
     array_shift($backtrace);
-    $self = array_shift($backtrace);
-    $call = array_shift($backtrace);
+    $self = $backtrace[0];
+    $call = $backtrace[1];
 
-    $called = trim($self['class'].'::'.$self['function'].'()', ':');
-    $caller = trim($call['class'].'::'.$call['function'].'()', ':');
+    $data = [
+        'trace' => $backtrace,
+        'alternative' => $alternative,
+        'called' => trim($self['class'] . '::' . $self['function'] . '()', ':'),
+        'caller' => trim($call['class'] . '::' . $call['function'] . '()', ':'),
+        'file' => $call['file'],
+        'line' => $call['line'],
+    ];
 
-    $msg = $called.' is deprecated. It was called from ';
-    $msg .= $caller.' in '.$call['file'].':'.$call['line'];
-    if($alternative) {
-        $msg .= ' '.$alternative.' should be used instead!';
+    $event = new Doku_Event('INFO_DEPRECATION_LOG', $data);
+    if($event->advise_before()) {
+        $msg = $event->data['called'] . ' is deprecated. It was called from ';
+        $msg .= $event->data['caller'] . ' in ' . $event->data['file'] . ':' . $event->data['line'];
+        if($event->data['alternative']) {
+            $msg .= ' ' . $event->data['alternative'] . ' should be used instead!';
+        }
+        dbglog($msg);
     }
-
-    dbglog($msg);
+    $event->advise_after();
 }
 
 /**


### PR DESCRIPTION
This adds an event to dbg_deprecated(). This allows plugins to handle deprecation warnings. One example would be https://github.com/cosmocode/dokuwiki-plugin-sentry

One thing I don't like, but don't know how to avaoid is that this function used to abort super early when $conf['allowdebug'] wasn't set.

However for the sentry plugin you probably would want logs, but still do not show any debugging to end users (which allow debug would do).

So now the backtrace is always built, the event triggered and then everything is sent to dbglog() which may simply throw everything away.

Suggestions on how to improve this welcome.