### PR TITLE
Better draft handling

### DIFF
--- a/inc/Action/Draftdel.php
+++ b/inc/Action/Draftdel.php
@@ -19,16 +19,18 @@ class Draftdel extends AbstractAction {
     }
 
     /**
-     * Delete an existing draft if any
+     * Delete an existing draft for the current page and user if any
      *
-     * Reads draft information from $INFO. Redirects to show, afterwards.
+     * Redirects to show, afterwards.
      *
      * @throws ActionAbort
      */
     public function preProcess() {
-        global $INFO;
-        @unlink($INFO['draft']);
-        $INFO['draft'] = null;
+        global $INFO, $ID;
+        $draft = new \dokuwiki\Draft($ID, $INFO['client']);
+        if ($draft->isDraftAvailable()) {
+            $draft->deleteDraft();
+        }
 
         throw new ActionAbort('redirect');
     }

--- a/inc/Action/Preview.php
+++ b/inc/Action/Preview.php
@@ -29,29 +29,13 @@ class Preview extends Edit {
      * Saves a draft on preview
      */
     protected function savedraft() {
-        global $INFO;
-        global $ID;
-        global $INPUT;
-        global $conf;
-
-        if(!$conf['usedraft']) return;
-        if(!$INPUT->post->has('wikitext')) return;
-
-        // ensure environment (safeguard when used via AJAX)
-        assert(isset($INFO['client']), 'INFO.client should have been set');
-        assert(isset($ID), 'ID should have been set');
-
-        $draft = array(
-            'id' => $ID,
-            'prefix' => substr($INPUT->post->str('prefix'), 0, -1),
-            'text' => $INPUT->post->str('wikitext'),
-            'suffix' => $INPUT->post->str('suffix'),
-            'date' => $INPUT->post->int('date'),
-            'client' => $INFO['client'],
-        );
-        $cname = getCacheName($draft['client'] . $ID, '.draft');
-        if(io_saveFile($cname, serialize($draft))) {
-            $INFO['draft'] = $cname;
+        global $ID, $INFO;
+        $draft = new \dokuwiki\Draft($ID, $INFO['client']);
+        if (!$draft->saveDraft()) {
+            $errors = $draft->getErrors();
+            foreach ($errors as $error) {
+                msg(hsc($error), -1);
+            }
         }
     }
 

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -119,7 +119,6 @@ class Ajax {
      * Andreas Gohr <andi@splitbrain.org>
      */
     protected function call_lock() {
-        global $lang;
         global $ID;
         global $INFO;
         global $INPUT;
@@ -129,20 +128,29 @@ class Ajax {
 
         $INFO = pageinfo();
 
+        $response = [
+            'errors' => [],
+            'lock' => '0',
+            'draft' => '',
+        ];
         if(!$INFO['writable']) {
-            echo 'Permission denied';
+            $response['errors'][] = 'Permission to write this page has been denied.';
+            echo json_encode($response);
             return;
         }
 
         if(!checklock($ID)) {
             lock($ID);
-            echo 1;
+            $response['lock'] = '1';
         }
 
         $draft = new Draft($ID, $INFO['client']);
         if ($draft->saveDraft()) {
-            echo $draft->getDraftMessage();
+            $response['draft'] = $draft->getDraftMessage();
+        } else {
+            $response['errors'] = array_merge($response['errors'], $draft->getErrors());
         }
+        echo json_encode($response);
     }
 
     /**

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -119,7 +119,6 @@ class Ajax {
      * Andreas Gohr <andi@splitbrain.org>
      */
     protected function call_lock() {
-        global $conf;
         global $lang;
         global $ID;
         global $INFO;
@@ -140,24 +139,10 @@ class Ajax {
             echo 1;
         }
 
-        if($conf['usedraft'] && $INPUT->post->str('wikitext')) {
-            $client = $_SERVER['REMOTE_USER'];
-            if(!$client) $client = clientIP(true);
-
-            $draft = array(
-                'id' => $ID,
-                'prefix' => substr($INPUT->post->str('prefix'), 0, -1),
-                'text' => $INPUT->post->str('wikitext'),
-                'suffix' => $INPUT->post->str('suffix'),
-                'date' => $INPUT->post->int('date'),
-                'client' => $client,
-            );
-            $cname = getCacheName($draft['client'] . $ID, '.draft');
-            if(io_saveFile($cname, serialize($draft))) {
-                echo $lang['draftdate'] . ' ' . dformat();
-            }
+        $draft = new Draft($ID, $INFO['client']);
+        if ($draft->saveDraft()) {
+            echo $draft->getDraftMessage();
         }
-
     }
 
     /**

--- a/inc/Draft.php
+++ b/inc/Draft.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace dokuwiki;
+
+/**
+ * Class Draft
+ *
+ * @package dokuwiki
+ */
+class Draft
+{
+
+    protected $errors = [];
+    protected $cname;
+    protected $id;
+    protected $client;
+
+    public function __construct($ID, $client)
+    {
+        $this->id = $ID;
+        $this->client = $client;
+        $this->cname = getCacheName($client.$ID, '.draft');
+        if(file_exists($this->cname) && file_exists(wikiFN($ID))) {
+            if (filemtime($this->cname) < filemtime(wikiFN($ID))) {
+                // remove stale draft
+                $this->deleteDraft();
+            }
+        }
+    }
+
+    /**
+     * Get the filename for this draft (whether or not it exists)
+     *
+     * @return string
+     */
+    public function getDraftFilename()
+    {
+        return $this->cname;
+    }
+
+    /**
+     * Checks if this draft exists on the filesystem
+     *
+     * @return bool
+     */
+    public function isDraftAvailable()
+    {
+        return file_exists($this->cname);
+    }
+
+    /**
+     * Save a draft of a current edit session
+     *
+     * The draft will not be saved if
+     *   - drafts are deactivated in the config
+     *   - or the editarea is empty and there are no event handlers registered
+     *   - or the event is prevented
+     *
+     * @triggers DRAFT_SAVE
+     *
+     * @return bool whether has the draft been saved
+     */
+    public function saveDraft()
+    {
+        global $INPUT, $INFO, $EVENT_HANDLER, $conf;
+        if (!$conf['usedraft']) {
+            return false;
+        }
+        if (!$INPUT->post->has('wikitext') &&
+            !$EVENT_HANDLER->hasHandlerForEvent('DRAFT_SAVE')) {
+            return false;
+        }
+        $draft = [
+            'id' => $this->id,
+            'prefix' => substr($INPUT->post->str('prefix'), 0, -1),
+            'text' => $INPUT->post->str('wikitext'),
+            'suffix' => $INPUT->post->str('suffix'),
+            'date' => $INPUT->post->int('date'),
+            'client' => $this->client,
+            'cname' => $this->cname,
+            'errors' => [],
+        ];
+        $event = new \Doku_Event('DRAFT_SAVE', $draft);
+        if ($event->advise_before()) {
+            $draft['hasBeenSaved'] = io_saveFile($draft['cname'], serialize($draft));
+            if ($draft['hasBeenSaved']) {
+                $INFO['draft'] = $draft['cname'];
+            }
+        } else {
+            $draft['hasBeenSaved'] = false;
+        }
+        $event->advise_after();
+
+        $this->errors = $draft['errors'];
+
+        return $draft['hasBeenSaved'];
+    }
+
+    /**
+     * Get the text from the draft file
+     *
+     * @throws \RuntimeException if the draft file doesn't exist
+     *
+     * @return string
+     */
+    public function getDraftText()
+    {
+        if (!file_exists($this->cname)) {
+            throw new \RuntimeException(
+                "Draft for page $this->id and user $this->client doesn't exist at $this->cname."
+            );
+        }
+        $draft = unserialize(io_readFile($this->cname,false));
+        return cleanText(con($draft['prefix'],$draft['text'],$draft['suffix'],true));
+    }
+
+    /**
+     * Remove the draft from the filesystem
+     *
+     * Also sets $INFO['draft'] to null
+     */
+    public function deleteDraft()
+    {
+        global $INFO;
+        @unlink($this->cname);
+        $INFO['draft'] = null;
+    }
+
+    /**
+     * Get a formatted message stating when the draft was saved
+     *
+     * @return string
+     */
+    public function getDraftMessage()
+    {
+        global $lang;
+        return $lang['draftdate'] . ' ' . dformat(filemtime($this->cname));
+    }
+
+    /**
+     * Retrieve the errors that occured when saving the draft
+     *
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/inc/Draft.php
+++ b/inc/Draft.php
@@ -15,6 +15,12 @@ class Draft
     protected $id;
     protected $client;
 
+    /**
+     * Draft constructor.
+     *
+     * @param string $ID the page id for this draft
+     * @param string $client the client identification (username or ip or similar) for this draft
+     */
     public function __construct($ID, $client)
     {
         $this->id = $ID;

--- a/inc/common.php
+++ b/inc/common.php
@@ -287,14 +287,9 @@ function pageinfo() {
     }
 
     // draft
-    $draft = getCacheName($info['client'].$ID, '.draft');
-    if(file_exists($draft)) {
-        if(@filemtime($draft) < @filemtime(wikiFN($ID))) {
-            // remove stale draft
-            @unlink($draft);
-        } else {
-            $info['draft'] = $draft;
-        }
+    $draft = new \dokuwiki\Draft($ID, $info['client']);
+    if ($draft->isDraftAvailable()) {
+        $info['draft'] = $draft->getDraftFilename();
     }
 
     return $info;

--- a/inc/html.php
+++ b/inc/html.php
@@ -307,8 +307,8 @@ function html_draft(){
     global $INFO;
     global $ID;
     global $lang;
-    $draft = unserialize(io_readFile($INFO['draft'],false));
-    $text  = cleanText(con($draft['prefix'],$draft['text'],$draft['suffix'],true));
+    $draft = new \dokuwiki\Draft($ID, $INFO['client']);
+    $text  = $draft->getDraftText();
 
     print p_locale_xhtml('draft');
     html_diff($text, false);
@@ -1833,7 +1833,14 @@ function html_edit(){
     <div class="editBox" role="application">
 
     <div class="toolbar group">
-        <div id="draft__status" class="draft__status"><?php if(!empty($INFO['draft'])) echo $lang['draftdate'].' '.dformat();?></div>
+        <div id="draft__status" class="draft__status">
+            <?php
+                $draft = new \dokuwiki\Draft($ID, $INFO['client']);
+                if ($draft->isDraftAvailable()) {
+                    echo $draft->getDraftMessage();
+                }
+            ?>
+        </div>
         <div id="tool__bar" class="tool__bar"><?php if ($wr && $data['media_manager']){?><a href="<?php echo DOKU_BASE?>lib/exe/mediamanager.php?ns=<?php echo $INFO['namespace']?>"
             target="_blank"><?php echo $lang['mediaselect'] ?></a><?php }?></div>
     </div>

--- a/inc/html.php
+++ b/inc/html.php
@@ -1833,16 +1833,16 @@ function html_edit(){
     <div class="editBox" role="application">
 
     <div class="toolbar group">
-        <div id="draft__status" class="draft__status">
-            <?php
-                $draft = new \dokuwiki\Draft($ID, $INFO['client']);
-                if ($draft->isDraftAvailable()) {
-                    echo $draft->getDraftMessage();
-                }
-            ?>
-        </div>
         <div id="tool__bar" class="tool__bar"><?php if ($wr && $data['media_manager']){?><a href="<?php echo DOKU_BASE?>lib/exe/mediamanager.php?ns=<?php echo $INFO['namespace']?>"
             target="_blank"><?php echo $lang['mediaselect'] ?></a><?php }?></div>
+    </div>
+    <div id="draft__status" class="draft__status">
+        <?php
+        $draft = new \dokuwiki\Draft($ID, $INFO['client']);
+        if ($draft->isDraftAvailable()) {
+            echo $draft->getDraftMessage();
+        }
+        ?>
     </div>
     <?php
 

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -104,7 +104,7 @@ var dw_locktimer = {
         var now = new Date(),
             params = 'call=lock&id=' + dw_locktimer.pageid + '&';
 
-        // refresh every minute only
+        // refresh every half minute only
         if(now.getTime() - dw_locktimer.lasttime.getTime() <= 30*1000) {
             return;
         }
@@ -118,7 +118,7 @@ var dw_locktimer = {
             DOKU_BASE + 'lib/exe/ajax.php',
             params,
             null,
-            'html'
+            'json'
         ).done(function dwLocktimerRefreshDoneHandler(data) {
             dw_locktimer.callbacks.forEach(
                 function (callback) {
@@ -133,11 +133,16 @@ var dw_locktimer = {
      * Callback. Resets the warning timer
      */
     refreshed: function(data){
-        var error = data.charAt(0);
-        data = data.substring(1);
+        if (data.errors.length) {
+            data.errors.forEach(function(error) {
+                jQuery('#draft__status').after(
+                    jQuery('<div class="error"></div>').text(error)
+                );
+            })
+        }
 
-        jQuery('#draft__status').html(data);
-        if(error != '1') {
+        jQuery('#draft__status').html(data.draft);
+        if(data.lock !== '1') {
             return; // locking failed
         }
         dw_locktimer.reset();

--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -8,6 +8,13 @@ var dw_locktimer = {
     lasttime: null,
     msg: LANG.willexpire,
     pageid: '',
+    fieldsToSaveAsDraft: [
+        'input[name=prefix]',
+        'textarea[name=wikitext]',
+        'input[name=suffix]',
+        'input[name=date]',
+    ],
+    callbacks: [],
 
     /**
      * Initialize the lock timer
@@ -40,6 +47,26 @@ var dw_locktimer = {
         $edit.keypress(dw_locktimer.refresh);
         // start timer
         dw_locktimer.reset();
+    },
+
+    /**
+     * Add another field of the editform to be posted to the server when a draft is saved
+     */
+    addField: function(selector) {
+        dw_locktimer.fieldsToSaveAsDraft.push(selector);
+    },
+
+    /**
+     * Add a callback that is executed when the post request to renew the lock and save the draft returns successfully
+     *
+     * If the user types into the edit-area, then dw_locktimer will regularly send a post request to the DokuWiki server
+     * to extend the page's lock and update the draft. When this request returns successfully, then the draft__status
+     * is updated. This method can be used to add further callbacks to be executed at that moment.
+     *
+     * @param {function} callback the only param is the data returned by the server
+     */
+    addRefreshCallback: function(callback) {
+        dw_locktimer.callbacks.push(callback);
     },
 
     /**
@@ -84,18 +111,21 @@ var dw_locktimer = {
 
         // POST everything necessary for draft saving
         if(dw_locktimer.draft && jQuery('#dw__editform').find('textarea[name=wikitext]').length > 0){
-            params += jQuery('#dw__editform').find('input[name=prefix], ' +
-                                                   'textarea[name=wikitext], ' +
-                                                   'input[name=suffix], ' +
-                                                   'input[name=date]').serialize();
+            params += jQuery('#dw__editform').find(dw_locktimer.fieldsToSaveAsDraft.join(', ')).serialize();
         }
 
         jQuery.post(
             DOKU_BASE + 'lib/exe/ajax.php',
             params,
-            dw_locktimer.refreshed,
+            null,
             'html'
-        );
+        ).done(function dwLocktimerRefreshDoneHandler(data) {
+            dw_locktimer.callbacks.forEach(
+                function (callback) {
+                    callback(data);
+                }
+            );
+        });
         dw_locktimer.lasttime = now;
     },
 
@@ -113,3 +143,4 @@ var dw_locktimer = {
         dw_locktimer.reset();
     }
 };
+dw_locktimer.callbacks.push(dw_locktimer.refreshed);

--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -12,6 +12,7 @@
 /*____________ toolbar ____________*/
 
 .dokuwiki div.toolbar {
+    display: inline-block;
     margin-bottom: .5em;
 }
 #draft__status {


### PR DESCRIPTION
This implements many of the same features as #2413, but in a cleaner way. 
This adds a new `Draft` class and uses that for all draft-related actions. The new event is now named `DRAFT_SAVE`

Thus this replaces #2413