### PR TITLE
Add unittest for deleteUsers remote API call

### DIFF
--- a/_test/tests/inc/remoteapicore.test.php
+++ b/_test/tests/inc/remoteapicore.test.php
@@ -445,6 +445,20 @@ You can use up to five different levels of',
         $this->assertEquals(0, count($versions));
     }
 
+    public function test_deleteUser()
+    {
+        global $conf, $auth;
+        $auth = new Mock_Auth_Plugin();
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = 'testuser';
+        $_SERVER['REMOTE_USER'] = 'testuser';
+        $params = [
+            ['testuser']
+        ];
+        $actualCallResult = $this->remote->call('dokuwiki.deleteUsers', $params);
+        $this->assertTrue($actualCallResult);
+    }
+
     public function test_aclCheck() {
         $id = 'aclpage';
 


### PR DESCRIPTION
Remote API calls should have at least some unittest, as this test would have caught the bug that was introduced in 96d46bf41a428b555c02f30f1bb496535d41bc5d and fixed in ebf1744911831ec6d15325039a040effa41e466c