### PR TITLE
Fix .htaccess files for Apache 2.4 (and 2.2)

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -4,10 +4,10 @@
 
 ## make sure nobody gets the htaccess, README, COPYING or VERSION files
 <Files ~ "^([\._]ht|README$|VERSION$|COPYING$)">
-    <IfModule mod_authz_host>
+    <IfModule mod_authz_core.c>
         Require all denied
     </IfModule>
-    <IfModule !mod_authz_host>
+    <IfModule !mod_authz_core.c>
         Order allow,deny
         Deny from all
     </IfModule>

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,7 +1,7 @@
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>

--- a/conf/.htaccess
+++ b/conf/.htaccess
@@ -1,8 +1,8 @@
 ## no access to the conf directory
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,7 +1,7 @@
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>

--- a/inc/.htaccess
+++ b/inc/.htaccess
@@ -1,8 +1,8 @@
 ## no access to the inc directory
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>

--- a/inc/lang/.htaccess
+++ b/inc/lang/.htaccess
@@ -1,8 +1,8 @@
 ## no access to the lang directory
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,7 +1,7 @@
-<IfModule mod_authz_host>
+<IfModule mod_authz_core.c>
     Require all denied
 </IfModule>
-<IfModule !mod_authz_host>
+<IfModule !mod_authz_core.c>
     Order allow,deny
     Deny from all
 </IfModule>


### PR DESCRIPTION
Refer to module by suitable file name (mod_*.c).
Test for mod_authz_core.c (instead of mod_authz_host.c) to properly
detect Apache 2.4 and avoid false positive for Apache 2.2.

Closes #2428.