### PR TITLE
Change `const` use to `var` for Safari 9 (on iOS)

### DIFF
--- a/lib/scripts/search.js
+++ b/lib/scripts/search.js
@@ -1,12 +1,12 @@
 jQuery(function () {
     'use strict';
 
-    const $searchForm = jQuery('.search-results-form');
+    var $searchForm = jQuery('.search-results-form');
     if (!$searchForm.length) {
         return;
     }
 
-    const $toggleAssistanceButton = jQuery('<button>')
+    var $toggleAssistanceButton = jQuery('<button>')
         .addClass('toggleAssistant')
         .attr('type', 'button')
         .attr('aria-expanded', 'false')


### PR DESCRIPTION
Safari 9 in iOS does not support the use of `const` in strict mode. Unfortunately, some of us are stuck with Safari 9 due to not being able to upgrade.

I am a big fan of progressive enhancement, but because all javascript code is packed together and sent off to the client, this small incompatibility breaks all javascript for safari 9 browsers. Switching these two keywords makes everything work again.

There are no other uses of `const` in the codebase as far as I can find. This change has little to no impact on anything else, but slighlty extends the range of supported browsers.

(I could not find a specific listing of supported browsers on https://www.dokuwiki.org/browser. While I agree that Safari 9 is not exactly "an up-to-date version", it seems to me that this was an accidental incompatibility.)