### PR TITLE
Fixed broken link rendering for external links at start of line

### DIFF
--- a/_test/tests/inc/parser/parser_links.test.php
+++ b/_test/tests/inc/parser/parser_links.test.php
@@ -153,6 +153,35 @@ class TestOfDoku_Parser_Links extends TestOfDoku_Parser {
         $this->assertEquals(array_map('stripByteIndex',$this->H->calls),$calls);
     }
 
+    function testExternalWWWLinkStartOfLine() {
+        // Regression test for issue #2399
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('externallink',array('http://www.google.com', 'www.google.com')),
+            array('cdata',array(' Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $instructions = p_get_instructions("www.google.com Bar");
+        $this->assertEquals(array_map('stripByteIndex',$instructions),$calls);
+    }
+
+    function testExternalWWWLinkInRoundBrackets() {
+        $this->P->addMode('externallink',new Doku_Parser_Mode_ExternalLink());
+        $this->P->parse("Foo (www.google.com) Bar");
+        $calls = array (
+            array('document_start',array()),
+            array('p_open',array()),
+            array('cdata',array("\n".'Foo (')),
+            array('externallink',array('http://www.google.com', 'www.google.com')),
+            array('cdata',array(') Bar')),
+            array('p_close',array()),
+            array('document_end',array()),
+        );
+        $this->assertEquals(array_map('stripByteIndex',$this->H->calls),$calls);
+    }
+
     function testExternalWWWLinkInPath() {
         $this->P->addMode('externallink',new Externallink());
         // See issue #936. Should NOT generate a link!

--- a/_test/tests/inc/parser/parser_links.test.php
+++ b/_test/tests/inc/parser/parser_links.test.php
@@ -168,7 +168,7 @@ class TestOfDoku_Parser_Links extends TestOfDoku_Parser {
     }
 
     function testExternalWWWLinkInRoundBrackets() {
-        $this->P->addMode('externallink',new Doku_Parser_Mode_ExternalLink());
+        $this->P->addMode('externallink',new ExternalLink());
         $this->P->parse("Foo (www.google.com) Bar");
         $calls = array (
             array('document_start',array()),

--- a/inc/Parsing/ParserMode/Externallink.php
+++ b/inc/Parsing/ParserMode/Externallink.php
@@ -23,8 +23,10 @@ class Externallink extends AbstractMode
             $this->patterns[] = '\b(?i)'.$scheme.'(?-i)://['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
         }
 
-        $this->patterns[] = '(?<![/\\\\])\b(?i)www?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
-        $this->patterns[] = '(?<![/\\\\])\b(?i)ftp?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+        $this->patterns[] = '(?<![/\\\\])\b(?i)www?(?-i)\.['.$host.']+?\.'.
+                            '['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+        $this->patterns[] = '(?<![/\\\\])\b(?i)ftp?(?-i)\.['.$host.']+?\.'.
+                            '['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Externallink.php
+++ b/inc/Parsing/ParserMode/Externallink.php
@@ -23,8 +23,8 @@ class Externallink extends AbstractMode
             $this->patterns[] = '\b(?i)'.$scheme.'(?-i)://['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
         }
 
-        $this->patterns[] = '(?<=\s)(?i)www?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
-        $this->patterns[] = '(?<=\s)(?i)ftp?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+        $this->patterns[] = '(?<![/\\\\])\b(?i)www?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
+        $this->patterns[] = '(?<![/\\\\])\b(?i)ftp?(?-i)\.['.$host.']+?\.['.$host.']+?['.$any.']+?(?=['.$punc.']*[^'.$any.'])';
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
External links at the start of line like ```www.example.com``` were not rendered as links any more. The issue was introduced with PR #1988. Fixes #2399.