### PR TITLE
🐛 make getVersion() show the commit date, not checkout date

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -86,8 +86,8 @@ function getVersionData(){
             }
             $subDir = substr($headCommit, 0, 2);
             $fileName = substr($headCommit, 2);
-            $getCommitObject = DOKU_INC . ".git/objects/$subDir/$fileName";
-            $commit = zlib_decode(file_get_contents($getCommitObject));
+            $gitCommitObject = DOKU_INC . ".git/objects/$subDir/$fileName";
+            $commit = zlib_decode(file_get_contents($gitCommitObject));
             $committerLine = explode("\n", $commit)[3];
             $committerData = explode(' ', $committerLine);
             end($committerData);

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -87,13 +87,15 @@ function getVersionData(){
             $subDir = substr($headCommit, 0, 2);
             $fileName = substr($headCommit, 2);
             $gitCommitObject = DOKU_INC . ".git/objects/$subDir/$fileName";
-            $commit = zlib_decode(file_get_contents($gitCommitObject));
-            $committerLine = explode("\n", $commit)[3];
-            $committerData = explode(' ', $committerLine);
-            end($committerData);
-            $ts = prev($committerData);
-            if ($ts && $date = date('Y-m-d', $ts)) {
-                $version['date'] = $date;
+            if (file_exists($gitCommitObject) && method_exists(zlib_decode)) {
+                $commit = zlib_decode(file_get_contents($gitCommitObject));
+                $committerLine = explode("\n", $commit)[3];
+                $committerData = explode(' ', $committerLine);
+                end($committerData);
+                $ts = prev($committerData);
+                if ($ts && $date = date('Y-m-d', $ts)) {
+                    $version['date'] = $date;
+                }
             }
         }
     }else{

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -74,21 +74,8 @@ function getVersionData(){
         $version['type'] = 'Git';
         $version['date'] = 'unknown';
 
-        $inventory = DOKU_INC.'.git/logs/HEAD';
-        if(is_file($inventory)){
-            $sz   = filesize($inventory);
-            $seek = max(0,$sz-2000); // read from back of the file
-            $fh   = fopen($inventory,'rb');
-            fseek($fh,$seek);
-            $chunk = fread($fh,2000);
-            fclose($fh);
-            $chunk = trim($chunk);
-            $chunk = @array_pop(explode("\n",$chunk));   //last log line
-            $chunk = @array_shift(explode("\t",$chunk)); //strip commit msg
-            $chunk = explode(" ",$chunk);
-            array_pop($chunk); //strip timezone
-            $date = date('Y-m-d',array_pop($chunk));
-            if($date) $version['date'] = $date;
+        if ($date = shell_exec("git log -1 --pretty=format:'%cd' --date=short")) {
+            $version['date'] = hsc($date);
         }
     }else{
         global $updateVersion;


### PR DESCRIPTION
Currently, getVersion() shows the date when the HEAD of the local git repository was last changed, not the date of the current commit. This pull request fixes that behavior.

Steps to reproduce:
-------------------------
1. checkout an old DokuWiki commit - say from a month or a year ago
1. go to the admin screen
1. look at the version:
   * without this pull request it will show the date of today
   * with this pull request it will show the date of the commit
