### PR TITLE
Fix Locked-Page not showing page content

### DIFF
--- a/inc/Action/Locked.php
+++ b/inc/Action/Locked.php
@@ -19,6 +19,7 @@ class Locked extends AbstractAction {
     /** @inheritdoc */
     public function tplContent() {
         html_locked();
+        html_edit();
     }
 
 }


### PR DESCRIPTION
While refactoring into inc/Action/Locked, the fall-through call
to html_edit was missed.
See 952acff90985f4576de0558a58a167372392e21c

This removed the edit box from the locked page, which is needed
for users to get the page source or by etherpad lite plugin.

This change re-adds the call to html_edit for the locked action.

Signed-off-by: Michael Braun <michael-dev@fami-braun.de>