### PR TITLE
Remove inc/lang/.htaccess as inc is already protected

### DIFF
--- a/inc/lang/.htaccess
+++ b/inc/lang/.htaccess
@@ -1,8 +1,0 @@
-## no access to the lang directory
-<IfModule mod_authz_core.c>
-    Require all denied
-</IfModule>
-<IfModule !mod_authz_core.c>
-    Order allow,deny
-    Deny from all
-</IfModule>


### PR DESCRIPTION
13 years ago, the `lang` directory was in the source root: [e4cdc61](https://github.com/splitbrain/dokuwiki/commit/e4cdc61b9e20e450c94b10989bda3d1dec1c995b), but since [bc3b6ae](https://github.com/splitbrain/dokuwiki/commit/bc3b6aec0f5bdef988488010807a94bee0808426) it is under the `inc` directory, which already has an .htaccess file that prevents all access. Therefore, there is no need for extra .htaccess file in `lang` sub-directory. Fixes #2445.