### PR TITLE
add config option to show of the page id (default: hide page is)

### DIFF
--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -85,6 +85,7 @@ $lang['deaccent']    = 'How to clean pagenames';
 $lang['useheading']  = 'Use first heading for pagenames';
 $lang['sneaky_index'] = 'By default, DokuWiki will show all namespaces in the sitemap. Enabling this option will hide those where the user doesn\'t have read permissions. This might result in hiding of accessable subnamespaces which may make the index unusable with certain ACL setups.';
 $lang['hidepages']   = 'Hide pages matching this regular expression from search, the sitemap and other automatic indexes';
+$lang['showPageId']  = 'Show the actual page file name at the upper right corner of the text area';
 
 /* Authentication Settings */
 $lang['useacl']      = 'Use access control lists';

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -86,6 +86,7 @@ $lang['useheading']  = 'Use first heading for pagenames';
 $lang['sneaky_index'] = 'By default, DokuWiki will show all namespaces in the sitemap. Enabling this option will hide those where the user doesn\'t have read permissions. This might result in hiding of accessable subnamespaces which may make the index unusable with certain ACL setups.';
 $lang['hidepages']   = 'Hide pages matching this regular expression from search, the sitemap and other automatic indexes';
 $lang['showPageId']  = 'Show the actual page file name at the upper right corner of the text area';
+$lang['showLastEdit'] = 'Show the last \'modified info\' at the bottom of the text area';
 
 /* Authentication Settings */
 $lang['useacl']      = 'Use access control lists';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -133,6 +133,7 @@ $meta['useheading']  = array('multichoice','_choices' => array(0,'navigation','c
 $meta['sneaky_index'] = array('onoff');
 $meta['hidepages']   = array('regex');
 $meta['showPageId']  = array('onoff');
+$meta['showLastEdit'] = array('onoff');
 
 $meta['_authentication'] = array('fieldset');
 $meta['useacl']      = array('onoff','_caution' => 'danger');

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -132,6 +132,7 @@ $meta['deaccent']    = array('multichoice','_choices' => array(0,1,2),'_caution'
 $meta['useheading']  = array('multichoice','_choices' => array(0,'navigation','content',1));
 $meta['sneaky_index'] = array('onoff');
 $meta['hidepages']   = array('regex');
+$meta['showPageId']  = array('onoff');
 
 $meta['_authentication'] = array('fieldset');
 $meta['useacl']      = array('onoff','_caution' => 'danger');

--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -50,7 +50,10 @@ $showSidebar = $hasSidebar && ($ACT=='show');
             <div id="dokuwiki__content"><div class="pad group">
                 <?php html_msgarea() ?>
 
+            <!-- edit: do not show the path and pagename on the upper right corner -->
+            <?php if ( $conf['showPageId'] != '1' ) { print "<!--"; } ?>
                 <div class="pageId"><span><?php echo hsc($ID) ?></span></div>
+            <?php if ( $conf['showPageId'] != '1' ) { print "-->"; } ?>
 
                 <div class="page group">
                     <?php tpl_flush() ?>
@@ -61,7 +64,10 @@ $showSidebar = $hasSidebar && ($ACT=='show');
                     <?php tpl_includeFile('pagefooter.html') ?>
                 </div>
 
+            <!-- edit: do not show the "last modified" line except explicit declared -->
+            <?php if ( $conf['showLastEdit'] != '1' ) { print "<!--"; } ?>
                 <div class="docInfo"><?php tpl_pageinfo() ?></div>
+            <?php if ( $conf['showLastEdit'] != '1' ) { print "-->"; } ?>
 
                 <?php tpl_flush() ?>
             </div></div><!-- /content -->


### PR DESCRIPTION
This is a simple change to hide the Page Id at the upper right corner of the text area of the default template. By default it is hidden, but could be made visible via config option (plugin config). Additional the file main.php contains a similar change to hide the "last modified" info, but not configurable via the config plugin (yet).