### PR TITLE
Auth/Mailer: properly handle usernames including a comma

### DIFF
--- a/_test/tests/inc/mailer.test.php
+++ b/_test/tests/inc/mailer.test.php
@@ -22,6 +22,9 @@ class TestMailer extends Mailer {
 
 }
 
+/**
+ * @group mailer_class
+ */
 class mailer_test extends DokuWikiTest {
 
 
@@ -94,10 +97,20 @@ class mailer_test extends DokuWikiTest {
         $headers = $mail->prop('headers');
         $this->assertEquals('Andreas Gohr <andi@splitbrain.org>', $headers['To']);
 
+        $mail->to('"Andreas Gohr" <andi@splitbrain.org>');
+        $mail->cleanHeaders();
+        $headers = $mail->prop('headers');
+        $this->assertEquals('"Andreas Gohr" <andi@splitbrain.org>', $headers['To']);
+
         $mail->to('Andreas Gohr <andi@splitbrain.org> , foo <foo@example.com>');
         $mail->cleanHeaders();
         $headers = $mail->prop('headers');
         $this->assertEquals('Andreas Gohr <andi@splitbrain.org>, foo <foo@example.com>', $headers['To']);
+
+        $mail->to('"Foo, Dr." <foo@example.com> , foo <foo@example.com>');
+        $mail->cleanHeaders();
+        $headers = $mail->prop('headers');
+        $this->assertEquals('=?UTF-8?B?IkZvbywgRHIuIg==?= <foo@example.com>, foo <foo@example.com>', $headers['To']);
 
         $mail->to('Möp <moep@example.com> , foo <foo@example.com>');
         $mail->cleanHeaders();
@@ -333,6 +346,16 @@ A test mail in <strong>html</strong>
 
         $this->assertRegexp('/' . preg_quote($expected_mail_body, '/') . '/', $dump);
 
+    }
+
+    function test_getCleanName() {
+        $mail = new TestMailer();
+        $name = $mail->getCleanName('Foo Bar');
+        $this->assertEquals('Foo Bar', $name);
+        $name = $mail->getCleanName('Foo, Bar');
+        $this->assertEquals('"Foo, Bar"', $name);
+        $name = $mail->getCleanName('Foo" Bar');
+        $this->assertEquals('"Foo\" Bar"', $name);
     }
 }
 //Setup VIM: ex: et ts=4 :

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -359,10 +359,12 @@ class Mailer {
     public function cleanAddress($addresses) {
         $headers = '';
         if(!is_array($addresses)){
-            preg_match_all('/\s*(?:("[^"]*"[^,]+),*)|([^,]+)\s*,*/', $addresses, $matches, PREG_SET_ORDER);
-            $addresses = array();
-            foreach ($matches as $match) {
-                array_push($addresses, $match[0]);
+            $count = preg_match_all('/\s*(?:("[^"]*"[^,]+),*)|([^,]+)\s*,*/', $addresses, $matches, PREG_SET_ORDER);
+            if ($count !== false && is_array($matches)) {
+                $addresses = array();
+                foreach ($matches as $match) {
+                    array_push($addresses, $match[0]);
+                }
             }
         }
 

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -360,8 +360,8 @@ class Mailer {
         $headers = '';
         if(!is_array($addresses)){
             $count = preg_match_all('/\s*(?:("[^"]*"[^,]+),*)|([^,]+)\s*,*/', $addresses, $matches, PREG_SET_ORDER);
+            $addresses = array();
             if ($count !== false && is_array($matches)) {
-                $addresses = array();
                 foreach ($matches as $match) {
                     array_push($addresses, $match[0]);
                 }

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -827,7 +827,7 @@ function auth_sendPassword($user, $password) {
     );
 
     $mail = new Mailer();
-    $mail->to($userinfo['name'].' <'.$userinfo['mail'].'>');
+    $mail->to($mail->getCleanName($userinfo['name']).' <'.$userinfo['mail'].'>');
     $mail->subject($lang['regpwmail']);
     $mail->setBody($text, $trep);
     return $mail->send();


### PR DESCRIPTION
Prevent splitting of e-mail addresses at the wrong point by enclosing a username in '"'. The "To" e-mail address in the notification mail was malformed if a new user was added and included a ',' in it's name. Fixes #1569.