### PR TITLE
fix create page from search in NS with ACL

### DIFF
--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -477,7 +477,7 @@ class Search extends Ui
         $createQueryPageLink = html_wikilink($queryPagename . '?do=edit', $queryPagename);
 
         $pagecreateinfo = '';
-        if (auth_quickaclcheck($queryPagename) >= AUTH_CREATE) {
+        if (auth_quickaclcheck(ltrim($queryPagename, ':')) >= AUTH_CREATE) {
             $pagecreateinfo = sprintf($lang['searchcreatepage'], $createQueryPageLink);
         }
         $intro = str_replace(


### PR DESCRIPTION
as described in #2507 it is not possible for acl restricted users to create pages in namespaces from the search.
The pagename for `auth_quickaclcheck` has a left colon. After removing it, it works as expected. 
