### PR TITLE
Hide login form on denied page if login is disabled

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -82,7 +82,7 @@ function html_login($svg = false){
 function html_denied() {
     print p_locale_xhtml('denied');
 
-    if(empty($_SERVER['REMOTE_USER'])){
+    if(empty($_SERVER['REMOTE_USER']) && actionOK('login')){
         html_login();
     }
 }


### PR DESCRIPTION
The "Access denied" page showed a login form even if the action "login" is disabled in the configuration.