### PR TITLE
Better deprecation annotation for DOKU_TPL*

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -114,13 +114,21 @@ if (!defined('DOKU_COOKIE')) define('DOKU_COOKIE', 'DW'.md5(DOKU_REL.(($conf['se
 // define main script
 if(!defined('DOKU_SCRIPT')) define('DOKU_SCRIPT','doku.php');
 
-// DEPRECATED, use tpl_basedir() instead
-if(!defined('DOKU_TPL')) define('DOKU_TPL',
-        DOKU_BASE.'lib/tpl/'.$conf['template'].'/');
+if(!defined('DOKU_TPL')) {
+    /**
+     * @deprecated 2012-10-13 replaced by more dynamic method
+     * @see tpl_basedir()
+     */
+    define('DOKU_TPL', DOKU_BASE.'lib/tpl/'.$conf['template'].'/');
+}
 
-// DEPRECATED, use tpl_incdir() instead
-if(!defined('DOKU_TPLINC')) define('DOKU_TPLINC',
-        DOKU_INC.'lib/tpl/'.$conf['template'].'/');
+if(!defined('DOKU_TPLINC')) {
+    /**
+     * @deprecated 2012-10-13 replaced by more dynamic method
+     * @see tpl_incdir()
+     */
+    define('DOKU_TPLINC', DOKU_INC.'lib/tpl/'.$conf['template'].'/');
+}
 
 // make session rewrites XHTML compliant
 @ini_set('arg_separator.output', '&amp;');


### PR DESCRIPTION
This syntax can be used by IDEA and other IDEs to mark the constants as deprecated in the editor.

Maybe checking for deprecated functions and constants in plugins could become part of the post-#2358 linting?