### PR TITLE
Fix source actionOK check in menu item

### DIFF
--- a/inc/Menu/Item/Edit.php
+++ b/inc/Menu/Item/Edit.php
@@ -32,7 +32,7 @@ class Edit extends AbstractItem {
                     }
                 }
             } else {
-                if(!actionOK($this->type)) throw new \RuntimeException("action disabled: source");
+                if(!actionOK('source')) throw new \RuntimeException("action disabled: source");
                 $params['rev'] = $REV;
                 $this->type = 'source';
                 $this->accesskey = 'v';


### PR DESCRIPTION
According to https://www.freelists.org/post/dokuwiki/page-tools-and-source-view-disabled, the source actionOK check doesn't work. This is because when checking against $this->type, it is "edit" in this case instead of "source." It should be fine to hard-code this.

This also fixes #2396.