### PR TITLE
getRecents(): prevent non-exist changelog error

### DIFF
--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -217,12 +217,18 @@ function getRecents($first,$num,$ns='',$flags=0){
     } else {
         $lines = @file($conf['changelog']);
     }
+    if (!is_array($lines)) {
+        $lines = array();
+    }
     $lines_position = count($lines)-1;
     $media_lines_position = 0;
     $media_lines = array();
 
     if ($flags & RECENTS_MEDIA_PAGES_MIXED) {
         $media_lines = @file($conf['media_changelog']);
+        if (!is_array($media_lines)) {
+            $media_lines = array();
+        }
         $media_lines_position = count($media_lines)-1;
     }
 
@@ -743,7 +749,7 @@ abstract class ChangeLog {
 
         return array(array_reverse($revs1), array_reverse($revs2));
     }
-    
+
     /**
      * Checks if the ID has old revisons
      * @return boolean


### PR DESCRIPTION
This is based on #2506 but with a different approach to deal with unknown read error: If file function doesn't return an array, set it to an empty array. Somewhat pythonic?

Fixes #2440.