### PR TITLE
Ensure dokuwiki tmpl's pagetool focus is properly displayed and set

### DIFF
--- a/lib/tpl/dokuwiki/css/pagetools.less
+++ b/lib/tpl/dokuwiki/css/pagetools.less
@@ -109,8 +109,8 @@
     }
 }
 
-// on hover show all items
-#dokuwiki__pagetools:hover {
+// on hover or focus show all items
+#dokuwiki__pagetools:hover, #dokuwiki__pagetools:focus-within {
     div.tools ul {
         background-color: @ini_background;
         border-color: @ini_border;

--- a/lib/tpl/dokuwiki/script.js
+++ b/lib/tpl/dokuwiki/script.js
@@ -76,4 +76,9 @@ jQuery(function(){
         var $content = jQuery('#dokuwiki__content div.page');
         $content.css('min-height', $sidebar.height());
     }
+
+    // blur when clicked
+    jQuery('#dokuwiki__pagetools div.tools>ul>li>a').on('click', function(){
+        this.blur();
+    });
 });


### PR DESCRIPTION
- make use of `:focus-within`, consistently showing all items with :focus and :hover
- blur the focus to visually "close the pagetool menu" after clicking

Related to #2366.