### PR TITLE
unify send_redirect(wl()) parameters

### DIFF
--- a/inc/Action/Logout.php
+++ b/inc/Action/Logout.php
@@ -41,7 +41,7 @@ class Logout extends AbstractUserAction {
 
         // do the logout stuff and redirect to login
         auth_logoff();
-        send_redirect(wl($ID, array('do' => 'login')));
+        send_redirect(wl($ID, 'do=login', true, '&'));
 
         // should never be reached
         throw new ActionException('login');

--- a/inc/Action/Redirect.php
+++ b/inc/Action/Redirect.php
@@ -55,7 +55,7 @@ class Redirect extends AbstractAliasAction {
      * @param array $opts id and fragment for the redirect and the preact
      */
     public function redirect($opts) {
-        $go = wl($opts['id'], '', true);
+        $go = wl($opts['id'], '', true, '&');
         if(isset($opts['fragment'])) $go .= '#' . $opts['fragment'];
 
         //show it

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -86,7 +86,7 @@ function getID($param='id',$clean=true){
             if (isset($urlParameters['id'])) {
                 unset($urlParameters['id']);
             }
-            send_redirect(wl($id,$urlParameters,true));
+            send_redirect(wl($id, $urlParameters, true, '&'));
         }
     }
 

--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -74,7 +74,7 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
             // save state & force a page reload to get the new settings to take effect
             $_SESSION['PLUGIN_CONFIG'] = array('state' => 'updated', 'time' => time());
             $this->_close_session();
-            send_redirect(wl($ID,array('do'=>'admin','page'=>'config'),true,'&'));
+            send_redirect(wl($ID, 'do=admin&page=config'), true, '&'));
             exit();
         } elseif(!$this->_error) {
             $this->_config->touch_settings(); // just touch to refresh cache


### PR DESCRIPTION
- always use absolute URL
- use static string instead of array if no concat is required
- use `&` instead of `&amp;`