### PR TITLE
Implemented only_new option for RSS feed,

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -465,7 +465,7 @@ function rssRecentChanges($opt) {
     global $conf;
     $flags = RECENTS_SKIP_DELETED;
     if(!$opt['show_minor']) $flags += RECENTS_SKIP_MINORS;
-    if($opt['only_new']) $flags += RECENTS_ONLY_NEW_PAGES;
+    if($opt['only_new']) $flags += RECENTS_ONLY_CREATION;
     if($opt['content_type'] == 'media' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_CHANGES;
     if($opt['content_type'] == 'both' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_PAGES_MIXED;
 

--- a/feed.php
+++ b/feed.php
@@ -127,6 +127,8 @@ function rss_parseOptions() {
                 'items'        => array('int', 'num', $conf['recent']),
                 // Boolean, only used in rc mode
                 'show_minor'   => array('bool', 'minor', false),
+                // Boolean, only used in rc mode
+                'only_new'     => array('bool', 'onlynewpages', false),
                 // String, only used in list mode
                 'sort'         => array('str', 'sort', 'natural'),
                 // String, only used in search mode
@@ -140,6 +142,7 @@ function rss_parseOptions() {
 
     $opt['items']      = max(0, (int) $opt['items']);
     $opt['show_minor'] = (bool) $opt['show_minor'];
+    $opt['only_new']   = (bool) $opt['only_new'];
     $opt['sort'] = valid_input_set('sort', array('default' => 'natural', 'date'), $opt);
 
     $opt['guardmail'] = ($conf['mailguard'] != '' && $conf['mailguard'] != 'none');
@@ -462,6 +465,7 @@ function rssRecentChanges($opt) {
     global $conf;
     $flags = RECENTS_SKIP_DELETED;
     if(!$opt['show_minor']) $flags += RECENTS_SKIP_MINORS;
+    if($opt['only_new']) $flags += RECENTS_ONLY_NEW_PAGES;
     if($opt['content_type'] == 'media' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_CHANGES;
     if($opt['content_type'] == 'both' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_PAGES_MIXED;
 

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -190,6 +190,7 @@ function addMediaLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', 
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
+ * RECENTS_ONLY_NEW_PAGES - only include new created pages
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  * RECENTS_MEDIA_PAGES_MIXED  - return both media changes and page changes
@@ -273,6 +274,7 @@ function getRecents($first,$num,$ns='',$flags=0){
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
+ * RECENTS_ONLY_NEW_PAGES - only include new created pages
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  *
@@ -346,6 +348,9 @@ function _handleRecent($line,$ns,$flags,&$seen){
 
     // skip seen ones
     if(isset($seen[$recent['id']])) return false;
+
+    // skip changes, of only new pages are requested
+    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_NEW_PAGES)) return false;
 
     // skip minors
     if($recent['type']===DOKU_CHANGE_TYPE_MINOR_EDIT && ($flags & RECENTS_SKIP_MINORS)) return false;

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -190,7 +190,7 @@ function addMediaLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', 
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_NEW_PAGES - only include new created pages
+ * RECENTS_ONLY_CREATION - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  * RECENTS_MEDIA_PAGES_MIXED  - return both media changes and page changes
@@ -274,7 +274,7 @@ function getRecents($first,$num,$ns='',$flags=0){
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_NEW_PAGES - only include new created pages
+ * RECENTS_ONLY_CREATION - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  *
@@ -349,8 +349,8 @@ function _handleRecent($line,$ns,$flags,&$seen){
     // skip seen ones
     if(isset($seen[$recent['id']])) return false;
 
-    // skip changes, of only new pages are requested
-    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_NEW_PAGES)) return false;
+    // skip changes, of only new items are requested
+    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_CREATION)) return false;
 
     // skip minors
     if($recent['type']===DOKU_CHANGE_TYPE_MINOR_EDIT && ($flags & RECENTS_SKIP_MINORS)) return false;
@@ -748,7 +748,7 @@ abstract class ChangeLog {
 
         return array(array_reverse($revs1), array_reverse($revs2));
     }
-    
+
     /**
      * Checks if the ID has old revisons
      * @return boolean

--- a/inc/common.php
+++ b/inc/common.php
@@ -16,7 +16,7 @@ define('RECENTS_SKIP_MINORS', 4);
 define('RECENTS_SKIP_SUBSPACES', 8);
 define('RECENTS_MEDIA_CHANGES', 16);
 define('RECENTS_MEDIA_PAGES_MIXED', 32);
-define('RECENTS_ONLY_NEW_PAGES', 64);
+define('RECENTS_ONLY_CREATION', 64);
 
 /**
  * Wrapper around htmlspecialchars()

--- a/inc/common.php
+++ b/inc/common.php
@@ -16,6 +16,7 @@ define('RECENTS_SKIP_MINORS', 4);
 define('RECENTS_SKIP_SUBSPACES', 8);
 define('RECENTS_MEDIA_CHANGES', 16);
 define('RECENTS_MEDIA_PAGES_MIXED', 32);
+define('RECENTS_ONLY_NEW_PAGES', 64);
 
 /**
  * Wrapper around htmlspecialchars()


### PR DESCRIPTION
This option allows you to RSS feed that contains only new files. This is useful if there is lots of changes, but you are not interested on them, but you are interested in new files or pages created in the wiki.

I did submit this as a patch few years back, and as I said in my reply to email which asked for me to create pull request out of this patch, that it might take few years for me to be able to do that, and I was correct. It took me two years to find time to learn how to use github (and 2 days to get the stupid git/github to work) and to create this pull request. Hopefully this is now in correct format and can be included.