### PR TITLE
remove any suffix from extension

### DIFF
--- a/inc/confutils.php
+++ b/inc/confutils.php
@@ -31,7 +31,8 @@ function mimetype($file, $knownonly=true){
     if ($ext === false) {
         return array(false, false, false);
     }
-    $ext = strtolower(substr($file, $ext + 1));
+    $re = '/(?=[^[:alnum:]]).+/';
+    $ext = preg_replace($re, '', strtolower(substr($file, $ext + 1)));
     if (!isset($mtypes[$ext])){
         if ($knownonly) {
             return array(false, false, false);


### PR DESCRIPTION
In DokuWiki I would like to include a downloadable code block using the syntax:
```
<code language https://host/user/repo/file.name.ext#L-N>
</code>
```
The path to the file is `https://host/user/repo/file.name.ext` and has extension `ext` but it also carries a suffix which could be anything that helps to better identify the snippet of code.

The issue is that  DokuWiki recognizes as extension `ext#L-N` which is, for him, an unknown mime type and so applies the icon for "general" document.