### PR TITLE
do not remove blank lines from code

### DIFF
--- a/inc/parser/code.php
+++ b/inc/parser/code.php
@@ -35,7 +35,13 @@ class Doku_Renderer_code extends Doku_Renderer {
             header("Content-Type: text/plain; charset=utf-8");
             header("Content-Disposition: attachment; filename=$filename");
             header("X-Robots-Tag: noindex");
-            echo trim($text, "\r\n");
+            if($text{0} == PHP_EOL) {
+                $text = substr($text, 1);
+            }
+            if(substr($text, -1) == PHP_EOL) {
+                $text = substr($text, 0, -1);
+            }
+            echo $text;
             exit;
         }
 

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -684,10 +684,10 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             $this->doc .= '</a></dt>'.DOKU_LF.'<dd>';
         }
 
-        if($text{0} == "\n") {
+        if($text{0} == PHP_EOL) {
             $text = substr($text, 1);
         }
-        if(substr($text, -1) == "\n") {
+        if(substr($text, -1) == PHP_EOL) {
             $text = substr($text, 0, -1);
         }
 

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -755,9 +755,6 @@ function p_xhtml_cached_geshi($code, $language, $wrapper='pre', array $options=n
     global $conf, $config_cascade, $INPUT;
     $language = strtolower($language);
 
-    // remove any leading or trailing blank lines
-    $code = preg_replace('/^\s*?\n|\s*?\n$/','',$code);
-
     $optionsmd5 = md5(serialize($options));
     $cache = getCacheName($language.$code.$optionsmd5,".code");
     $ctime = @filemtime($cache);
@@ -793,4 +790,3 @@ function p_xhtml_cached_geshi($code, $language, $wrapper='pre', array $options=n
         return $highlighted_code;
     }
 }
-


### PR DESCRIPTION
I wonder if there is any reason to always remove leading and trailing blank lines from snippets of code.
I think it's more reasonable to leave the decision to the user.

In the image below, on the left, the current behaviour, on the right, the desired result, of the code in the middle which tries to simulate all the possibile cases.
![blank_lines_code](https://user-images.githubusercontent.com/10964663/47659641-ad5d8f00-db95-11e8-9466-1bf16718266b.png)
