### PR TITLE
remove recursively empty direcories

### DIFF
--- a/inc/io.php
+++ b/inc/io.php
@@ -535,8 +535,6 @@ function io_rmdir($path, $removefiles = false) {
                 $dirs[] = "$path/$f";
             } else if($removefiles) {
                 $files[] = "$path/$f";
-            } else {
-                return false; // abort when non empty
             }
 
         }


### PR DESCRIPTION
Let's consider the following tree directory:
```
/foo/
    file
    bar/
```
From my point of view the function `io_rmdir()`, defined in  `/inc/io.php`, could be a little be wiser because it fails in deleting recursively empty directories when the parameter `$removefiles` is `false`. In fact the call:
```
io_rmdir('/foo')
```
doesn't remove the empty directory `/foo/bar/` because of `/foo/file`.