### PR TITLE
added method clearMetaKey() to indexer.php

### DIFF
--- a/inc/indexer.php
+++ b/inc/indexer.php
@@ -567,6 +567,28 @@ class Doku_Indexer {
     }
 
     /**
+     * Clear the given key from the index.
+     *
+     * @param string $key The metadata key
+     * @return bool If the key has been cleared successfully
+     */
+    public function clearMetaKey($key) {
+        global $conf;
+
+        $keyidx = array_diff($this->getIndex('metadata', ''), array($key));
+        $this->saveIndex('metadata', '', $keyidx);
+
+        if (!$this->lock()) return false;
+
+        @unlink($conf['indexdir'].'/'.$key.'_i.idx');
+        @unlink($conf['indexdir'].'/'.$key.'_p.idx');
+        @unlink($conf['indexdir'].'/'.$key.'_w.idx');
+
+        $this->unlock();
+        return true;
+    }
+
+    /**
      * Split the text into words for fulltext search
      *
      * TODO: does this also need &$stopwords ?


### PR DESCRIPTION
When a plugin creates a [metadata](https://www.dokuwiki.org/devel:metadata#metadata_index) entry associate to a given page, calling the method `addMetaKeys()`, then there is no way to remove it from the index. 

This means that all tag-ish plugins or plugins that make use of the `indexer`, after have been removed, leave their metadata keys with the potential risk to create conflicts with other homonymous keys, created by other plugins.

Another scenario could be when a plugin makes use of the `indexer` to check if its tokens are still in use in any page. In this case, the values of the key should be always up-to-date and the method `renameMetaValue()` in some circumstances doesn't offer a good alternative.

In any case, I think the availability of a method that allows to clear previously keys could come in handy. 