### PR TITLE
Fix ACL check in search_allpages

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -333,7 +333,7 @@ function search_allpages(&$data,$base,$file,$type,$lvl,$opts){
 
     $item = array();
     $item['id']   = pathID($file);
-    if(isset($opts['skipacl']) && !$opts['skipacl'] && auth_quickaclcheck($item['id']) < AUTH_READ){
+    if(empty($opts['skipacl']) && auth_quickaclcheck($item['id']) < AUTH_READ){
         return false;
     }
 


### PR DESCRIPTION
Due to the changes in 8f34cf3d32c9c091caa658472bd4e3a8270969a8 (first included in the Greebo release), the ACL check in search_allpages was only executed when 'skipacl' has been explicitly set to false. Otherwise, only ACLs for namespaces were checked (unless the sneakyacl option was passed). The documentation states that the default for 'skipacl' is false, so setting it to false shouldn't be necessary.

From all I can see, this does not concern DokuWiki itself as search_allpages is never used without the 'skipacl' option explicitly set to true or false. However, this causes serious security issues in plugins that rely on this ACL check in search_allpages like the include plugin (see dokufreaks/plugin-include#229).