### PR TITLE
Fix zero width spaces in diffs

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -1560,7 +1560,7 @@ function html_softbreak_callback($match){
 
     // its a long string without a breaking character,
     // make certain characters into breaking characters by inserting a
-    // breaking character (zero length space, U+200B / #8203) in front them.
+    // word break opportunity (<wbr> tag) in front of them.
     $regex = <<< REGEX
 (?(?=                                 # start a conditional expression with a positive look ahead ...
 &\#?\\w{1,6};)                        # ... for html entities - we don't want to split them (ok to catch some invalid combinations)
@@ -1570,7 +1570,7 @@ function html_softbreak_callback($match){
 )+                                    # end conditional expression
 REGEX;
 
-    return preg_replace('<'.$regex.'>xu','\0&#8203;',$match[0]);
+    return preg_replace('<'.$regex.'>xu','\0<wbr>',$match[0]);
 }
 
 /**

--- a/lib/tpl/dokuwiki/css/basic.less
+++ b/lib/tpl/dokuwiki/css/basic.less
@@ -312,6 +312,10 @@ small {
     font-size: .8em;
 }
 
+wbr {
+    display: inline-block; /* for IE 11 */
+}
+
 /*____________ forms ____________*/
 
 /* for all of the form styles, style.ini colours are not used on purpose (except for fieldset border) */


### PR DESCRIPTION
see #165, #1208 and #2405 for reference
Copying from the diff view often leads to confusion, because zero-width chars are inserted to improve line-breaks. The same can now be achieved using the `<wbr>` tag which is **not** copied into the clipboard as it is not a control character.
Tested in recent Firefox, Chrome and Edge.

fixes #1208