### PR TITLE
reset Doku_Renderer properties

### DIFF
--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -52,6 +52,9 @@ class Doku_Renderer extends DokuWiki_Plugin {
      * completely reset the state of the renderer to be reused for a new document
      */
     function reset() {
+        $this->doc           = '';
+        $this->info['cache'] = true;
+        $this->info['toc']   = true;
     }
 
     /**


### PR DESCRIPTION
Even though Doku_Renderer class and its child classes are NOT singleton, some meaningful reset() method is helpful for renderer plugin developers to use `parent:reset()` calls. 
 