### PR TITLE
don't show empty optiongroup item in Mobilemenu

### DIFF
--- a/inc/Menu/MobileMenu.php
+++ b/inc/Menu/MobileMenu.php
@@ -70,14 +70,16 @@ class MobileMenu implements MenuInterface {
         $html .= '<option value="">' . $empty . '</option>';
 
         foreach($this->getGroupedItems() as $tools => $items) {
-            $html .= '<optgroup label="' . $lang[$tools . '_tools'] . '">';
-            foreach($items as $item) {
-                $params = $item->getParams();
-                $html .= '<option value="' . $params['do'] . '">';
-                $html .= hsc($item->getLabel());
-                $html .= '</option>';
+            if (count($items)) {
+                $html .= '<optgroup label="' . $lang[$tools . '_tools'] . '">';
+                foreach($items as $item) {
+                    $params = $item->getParams();
+                    $html .= '<option value="' . $params['do'] . '">';
+                    $html .= hsc($item->getLabel());
+                    $html .= '</option>';
+                }
+                $html .= '</optgroup>';
             }
-            $html .= '</optgroup>';
         }
 
         $html .= '</select>';


### PR DESCRIPTION
> If all the actions of a group (e.g. Page Edit) are disabled option group is still shown (empty).

Fixes #2647. Co-authored by @eiroca.