### PR TITLE
fix ACL admin footnote JS error

### DIFF
--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -193,7 +193,7 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
 
         echo '<div class="footnotes"><div class="fn">'.NL;
         echo '<sup><a id="fn__1" class="fn_bot" href="#fnt__1">1)</a></sup>'.NL;
-        echo $this->getLang('p_include');
+        echo '<div class="content">'.$this->getLang('p_include').'</div>';
         echo '</div></div>';
 
         echo '</div>'.NL;

--- a/lib/scripts/page.js
+++ b/lib/scripts/page.js
@@ -89,7 +89,7 @@ dw_page = {
         var $content = jQuery(jQuery(this).attr('href')) // Footnote text anchor
                       .parent().siblings('.content').clone();
 
-        if (!$content) {
+        if (!$content.length) {
             return;
         }
 


### PR DESCRIPTION
- Use `div.content` to wrap the footnote content in ACL's hand-written template 
- jQuery object existence check should use `$obj.length`

This fixes #2540.