### PR TITLE
Compare cleaned pageid case-insensitive in search

### DIFF
--- a/_test/tests/inc/Ui/Search_createPagenameFromQuery.test.php
+++ b/_test/tests/inc/Ui/Search_createPagenameFromQuery.test.php
@@ -111,6 +111,22 @@ class Search_createPagenameFromQuery extends DokuWikiTest
             ],
             [
                 [
+                    'query' => 'Бб:Гг:Rr',
+                    'parsed_str' => '((W+:бб)AND(W+:гг)AND(W+:rr))',
+                    'parsed_ary' => ['W+:бб', 'AND', 'W+:гг', 'AND', 'W+:rr', 'AND'],
+                    'words' => ["бб", "гг", "rr"],
+                    'highlight' => ["бб", "гг", "rr"],
+                    'and' => ["бб", "гг", "rr"],
+                    'phrases' => [],
+                    'ns' => [],
+                    'notns' => [],
+                    'not' => [],
+                ],
+                ':бб:гг:rr',
+                'uppercased utf-8 pageid with colons should result in clean pageid',
+            ],
+            [
+                [
                     'query' => '"wiki:foo"',
                     'parsed_str' => '((W_:wiki)AND(W_:foo)AND(P+:wiki:foo))',
                     'parsed_ary' => [0 => 'W_:wiki', 1 => 'W_:foo', 2 => 'AND', 3 => 'P+:wiki:foo', 4 => 'AND',],

--- a/_test/tests/inc/Ui/Search_createPagenameFromQuery.test.php
+++ b/_test/tests/inc/Ui/Search_createPagenameFromQuery.test.php
@@ -95,6 +95,22 @@ class Search_createPagenameFromQuery extends DokuWikiTest
             ],
             [
                 [
+                    'query' => 'WiKi:Foo',
+                    'parsed_str' => '((W+:wiki)AND(W+:foo))',
+                    'parsed_ary' => [0 => 'W+:wiki', 1 => 'W+:foo', 2 => 'AND',],
+                    'words' => [0 => 'wiki', 1 => 'foo',],
+                    'highlight' => [0 => 'wiki', 1 => 'foo',],
+                    'and' => [0 => 'wiki', 1 => 'foo',],
+                    'phrases' => [],
+                    'ns' => [],
+                    'notns' => [],
+                    'not' => [],
+                ],
+                ':wiki:foo',
+                'uppercased pageid with colons should result in clean pageid',
+            ],
+            [
+                [
                     'query' => '"wiki:foo"',
                     'parsed_str' => '((W_:wiki)AND(W_:foo)AND(P+:wiki:foo))',
                     'parsed_ary' => [0 => 'W_:wiki', 1 => 'W_:foo', 2 => 'AND', 3 => 'P+:wiki:foo', 4 => 'AND',],

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -498,8 +498,8 @@ class Search extends Ui
      */
     public function createPagenameFromQuery($parsedQuery)
     {
-        $cleanedQuery = cleanID($parsedQuery['query']);
-        if (strtolower($cleanedQuery) === strtolower($parsedQuery['query'])) {
+        $cleanedQuery = cleanID($parsedQuery['query']); // already strtolowered
+        if ($cleanedQuery === utf8_strtolower($parsedQuery['query'])) {
             return ':' . $cleanedQuery;
         }
         $pagename = '';

--- a/inc/Ui/Search.php
+++ b/inc/Ui/Search.php
@@ -499,7 +499,7 @@ class Search extends Ui
     public function createPagenameFromQuery($parsedQuery)
     {
         $cleanedQuery = cleanID($parsedQuery['query']);
-        if ($cleanedQuery === $parsedQuery['query']) {
+        if (strtolower($cleanedQuery) === strtolower($parsedQuery['query'])) {
             return ':' . $cleanedQuery;
         }
         $pagename = '';


### PR DESCRIPTION
This fixes #2613, with tests that fails with current code, and works with the patch.

> Tring to create the following pages from the search bar, the namespaces are converted in pages:
>
> Foo -> :foo
> Foo:bar -> :foo_bar
> foobar:Foo:bar -> :foobar_foo_bar
> FooBar:foo:bar -> :foobar_foo_bar