### PR TITLE
css_compress: use placeholder to keep quoted strings

### DIFF
--- a/_test/tests/lib/exe/css_css_compress.test.php
+++ b/_test/tests/lib/exe/css_css_compress.test.php
@@ -71,7 +71,7 @@ class css_css_compress_test extends DokuWikiTest {
     function test_hack(){
         $text = '/* Mac IE will not see this and continue with inline-block */
                  /* \\*/
-                 display: inline; 
+                 display: inline;
                  /* */';
         $this->assertEquals('/* \\*/display:inline;/* */', css_compress($text));
     }
@@ -134,6 +134,13 @@ class css_css_compress_test extends DokuWikiTest {
     function test_data() {
         $input  = 'list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);';
         $expect = 'list-style-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);';
+
+        $this->assertEquals($expect, css_compress($input));
+    }
+
+    function test_quotes() {
+        $input  = '/* "1" */content: "/* 1 : 2 */ 1 : 2";';
+        $expect = 'content:"/* 1 : 2 */ 1 : 2";';
 
         $this->assertEquals($expect, css_compress($input));
     }

--- a/_test/tests/lib/exe/css_css_compress.test.php
+++ b/_test/tests/lib/exe/css_css_compress.test.php
@@ -145,6 +145,12 @@ class css_css_compress_test extends DokuWikiTest {
         $this->assertEquals($expect, css_compress($input));
     }
 
+    function test_escapedQuotes() {
+        $inputEscapedQuote = 'content:"one quote visible: \\" "; foo: bar;//"';
+        $expectedOutput = 'content:"one quote visible: \\" ";foo:bar;';
+
+        $this->assertEquals($expectedOutput, css_compress($inputEscapedQuote));
+    }
 }
 
 //Setup VIM: ex: et ts=4 :

--- a/_test/tests/lib/exe/css_css_compress.test.php
+++ b/_test/tests/lib/exe/css_css_compress.test.php
@@ -139,8 +139,8 @@ class css_css_compress_test extends DokuWikiTest {
     }
 
     function test_quotes() {
-        $input  = '/* "comment" */ content: "/* STR2 : STR1 */ this : inquote"; STR1: 10px; STR2:"STR1"; STR3:\'STR1\';';
-        $expect = 'content:"/* STR2 : STR1 */ this : inquote";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
+        $input  = '/* "blockcomment" */ content: "/* STR2 : STR1 */ thisis : inquote"; STR1: 10px; STR2:"STR1"; STR3:\'STR1\';';
+        $expect = 'content:"/* STR2 : STR1 */ thisis : inquote";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
 
         $this->assertEquals($expect, css_compress($input));
     }

--- a/_test/tests/lib/exe/css_css_compress.test.php
+++ b/_test/tests/lib/exe/css_css_compress.test.php
@@ -139,8 +139,8 @@ class css_css_compress_test extends DokuWikiTest {
     }
 
     function test_quotes() {
-        $input  = '/* "1" */content: "/* STR2 : STR1 */ 1 : 2";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
-        $expect = 'content:"/* STR2 : STR1 */ 1 : 2";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
+        $input  = '/* "comment" */ content: "/* STR2 : STR1 */ this : inquote"; STR1: 10px; STR2:"STR1"; STR3:\'STR1\';';
+        $expect = 'content:"/* STR2 : STR1 */ this : inquote";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
 
         $this->assertEquals($expect, css_compress($input));
     }

--- a/_test/tests/lib/exe/css_css_compress.test.php
+++ b/_test/tests/lib/exe/css_css_compress.test.php
@@ -139,8 +139,8 @@ class css_css_compress_test extends DokuWikiTest {
     }
 
     function test_quotes() {
-        $input  = '/* "1" */content: "/* 1 : 2 */ 1 : 2";';
-        $expect = 'content:"/* 1 : 2 */ 1 : 2";';
+        $input  = '/* "1" */content: "/* STR2 : STR1 */ 1 : 2";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
+        $expect = 'content:"/* STR2 : STR1 */ 1 : 2";STR1:10px;STR2:"STR1";STR3:\'STR1\';';
 
         $this->assertEquals($expect, css_compress($input));
     }

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -548,10 +548,10 @@ function css_compress($css){
 
     $quote_cb = function ($match) use (&$quote_storage) {
         $quote_storage[] = $match[0];
-        return 'STR'.(count($quote_storage)-1);
+        return '"STR'.(count($quote_storage)-1).'"';
     };
 
-    $css = preg_replace_callback('/(([\'"]).*?(?<!\\\\)\2)|(STR\d+)/', $quote_cb, $css);
+    $css = preg_replace_callback('/(([\'"]).*?(?<!\\\\)\2)/', $quote_cb, $css);
 
     // strip comments through a callback
     $css = preg_replace_callback('#(/\*)(.*?)(\*/)#s','css_comment_cb',$css);
@@ -615,7 +615,7 @@ function css_compress($css){
         return $quote_storage[$match[1]];
     };
 
-    $css = preg_replace_callback('/STR(\d+)/', $quote_back_cb, $css);
+    $css = preg_replace_callback('/"STR(\d+)"/', $quote_back_cb, $css);
 
     return $css;
 }

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -616,6 +616,7 @@ function css_compress($css){
     };
 
     $css = preg_replace_callback('/"STR(\d+)"/', $quote_back_cb, $css);
+    $css = trim($css);
 
     return $css;
 }


### PR DESCRIPTION
This fixes #2517.

The idea mainly comes from https://github.com/matthiasmullie/minify/blob/97f118c4c745c7c8e47207f2daf3bab13ca65404/src/Minify.php#L343; I also removed the quote detection code in `css_onelinecomment_cb()` because it's a duplicate of this.