### PR TITLE
obfuscate: use utf8_tohtml for hex mode encoding

### DIFF
--- a/_test/tests/inc/common_obfuscate.test.php
+++ b/_test/tests/inc/common_obfuscate.test.php
@@ -5,27 +5,27 @@ class common_obfuscate_test extends DokuWikiTest {
     function test_none(){
         global $conf;
         $conf['mailguard'] = 'none';
-        $this->assertEquals(obfuscate('jon-doe@example.com'), 'jon-doe@example.com');
+        $this->assertEquals('jon-doe@example.com', obfuscate('jon-doe@example.com'));
     }
 
     function test_hex(){
         global $conf;
         $conf['mailguard'] = 'hex';
-        $this->assertEquals(obfuscate('jon-doe@example.com'),
-        '&#x6a;&#x6f;&#x6e;&#x2d;&#x64;&#x6f;&#x65;&#x40;&#x65;&#x78;&#x61;&#x6d;&#x70;&#x6c;&#x65;&#x2e;&#x63;&#x6f;&#x6d;');
+        $this->assertEquals('&#106;&#111;&#110;&#45;&#100;&#111;&#101;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;',
+                            obfuscate('jon-doe@example.com'));
     }
 
     function test_hex_utf32(){
         global $conf;
         $conf['mailguard'] = 'hex';
-        $this->assertEquals(obfuscate('user@example.com?subject=Привет'),
-        '&#x75;&#x73;&#x65;&#x72;&#x40;&#x65;&#x78;&#x61;&#x6D;&#x70;&#x6C;&#x65;&#x2E;&#x63;&#x6F;&#x6D;&#x3F;&#x73;&#x75;&#x62;&#x6A;&#x65;&#x63;&#x74;&#x3D;&#x41F;&#x440;&#x438;&#x432;&#x435;&#x442;');
+        $this->assertEquals('&#117;&#115;&#101;&#114;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;&#63;&#115;&#117;&#98;&#106;&#101;&#99;&#116;&#61;&#x41f;&#x440;&#x438;&#x432;&#x435;&#x442;',
+                            obfuscate('user@example.com?subject=Привет'));
     }
 
     function test_visible(){
         global $conf;
         $conf['mailguard'] = 'visible';
-        $this->assertEquals(obfuscate('jon-doe@example.com'), 'jon [dash] doe [at] example [dot] com');
+        $this->assertEquals('jon [dash] doe [at] example [dot] com', obfuscate('jon-doe@example.com'));
     }
 
 

--- a/_test/tests/inc/common_obfuscate.test.php
+++ b/_test/tests/inc/common_obfuscate.test.php
@@ -15,6 +15,13 @@ class common_obfuscate_test extends DokuWikiTest {
         '&#x6a;&#x6f;&#x6e;&#x2d;&#x64;&#x6f;&#x65;&#x40;&#x65;&#x78;&#x61;&#x6d;&#x70;&#x6c;&#x65;&#x2e;&#x63;&#x6f;&#x6d;');
     }
 
+    function test_hex_utf32(){
+        global $conf;
+        $conf['mailguard'] = 'hex';
+        $this->assertEquals(obfuscate('user@example.com?subject=Привет'),
+        '&#x75;&#x73;&#x65;&#x72;&#x40;&#x65;&#x78;&#x61;&#x6D;&#x70;&#x6C;&#x65;&#x2E;&#x63;&#x6F;&#x6D;&#x3F;&#x73;&#x75;&#x62;&#x6A;&#x65;&#x63;&#x74;&#x3D;&#x41F;&#x440;&#x438;&#x432;&#x435;&#x442;');
+    }
+
     function test_visible(){
         global $conf;
         $conf['mailguard'] = 'visible';

--- a/_test/tests/inc/utf8_html.test.php
+++ b/_test/tests/inc/utf8_html.test.php
@@ -11,6 +11,12 @@ class utf8_html_test extends DokuWikiTest {
         $this->assertEquals(utf8_tohtml($in),$out);
     }
 
+    function test_from_1byte_all(){
+        $in  = 'a';
+        $out = '&#97;';
+        $this->assertEquals(utf8_tohtml($in, true),$out);
+    }
+
     function test_from_2byte(){
         $in  = "\xc3\xbc";
         $out = '&#252;';

--- a/inc/common.php
+++ b/inc/common.php
@@ -1611,12 +1611,7 @@ function obfuscate($email) {
             return strtr($email, $obfuscate);
 
         case 'hex' :
-            $encode = '';
-            $len    = strlen($email);
-            for($x = 0; $x < $len; $x++) {
-                $encode .= '&#x'.bin2hex($email{$x}).';';
-            }
-            return $encode;
+            return utf8_tohtml($email, true);
 
         case 'none' :
         default :

--- a/inc/utf8.php
+++ b/inc/utf8.php
@@ -569,12 +569,13 @@ if(!function_exists('utf8_tohtml')){
      * @link   http://php.net/manual/en/function.utf8-decode.php
      *
      * @param string $str
+     * @param bool $all Encode non-utf8 char to HTML as well
      * @return string
      */
-    function utf8_tohtml ($str) {
+    function utf8_tohtml($str, $all = false) {
         $ret = '';
         foreach (utf8_to_unicode($str) as $cp) {
-            if ($cp < 0x80)
+            if ($cp < 0x80 && !$all)
                 $ret .= chr($cp);
             elseif ($cp < 0x100)
                 $ret .= "&#$cp;";


### PR DESCRIPTION
This fixes #2665.

In order to implement this, `utf8_tohtml` adds a $all param to encode everything not utf8 (default false).

Note that obfuscate's output for "regular" char (codepoint < 2bytes) has also changed (before hex, now decimal), due to [the current behavior of `utf8_tohtml()`](https://github.com/splitbrain/dokuwiki/blob/debc52aabb80cdc05782261d7eee86b03b8e32f2/inc/utf8.php#L575-L586). In this case, the config value "hex" doesn't mean "hex" anymore, but it still obfuscates characters as numbers, as expected (see changed `common_obfuscate.test.php`). **It might need doc update to explain hex is no longer "hex" if this gets accepted.**