### PR TITLE
Added an ID to config manager form

### DIFF
--- a/lib/plugins/config/admin.php
+++ b/lib/plugins/config/admin.php
@@ -108,7 +108,7 @@ class admin_plugin_config extends DokuWiki_Admin_Plugin {
         // POST to script() instead of wl($ID) so config manager still works if
         // rewrite config is broken. Add $ID as hidden field to remember
         // current ID in most cases.
-        ptln('<form action="'.script().'" method="post">');
+        ptln('<form id="dw__configform" action="'.script().'" method="post">');
         ptln('<div class="no"><input type="hidden" name="id" value="'.$ID.'" /></div>');
         formSecurityToken();
         $this->_print_h1('dokuwiki_settings', $this->getLang('_header_dokuwiki'));


### PR DESCRIPTION
Goal is to make it easy to create an alternate "save" button with a 'form' attribute pointing to that ID, be it in pagetools or anywhere else (related to https://github.com/splitbrain/dokuwiki/issues/764)