### PR TITLE
Improve tpl_getMediaFile()

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1698,6 +1698,9 @@ function tpl_getMediaFile($search, $abs = false, &$imginfo = null) {
         if(file_exists($file)) break;
     }
 
+    // stop process if file doesn't exist
+    if(!file_exists($file)) { return false; }
+
     // fetch image data if requested
     if(!is_null($imginfo)) {
         $imginfo = getimagesize($file);

--- a/inc/template.php
+++ b/inc/template.php
@@ -1675,13 +1675,14 @@ function tpl_flush() {
  * file, otherwise it is assumed to be relative to the current template
  *
  * @param  string[] $search       locations to look at
- * @param  bool     $abs           if to use absolute URL
- * @param  array   &$imginfo   filled with getimagesize()
+ * @param  bool     $abs          if to use absolute URL
+ * @param  array    &$imginfo     filled with getimagesize()
+ * @param  string[] $fallback     image used as fallback if target isn't found (or false if potential false result is required)
  * @return string
  *
  * @author Andreas  Gohr <andi@splitbrain.org>
  */
-function tpl_getMediaFile($search, $abs = false, &$imginfo = null) {
+function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = 'lib/images/blank.gif') {
     $img     = '';
     $file    = '';
     $ismedia = false;
@@ -1698,8 +1699,16 @@ function tpl_getMediaFile($search, $abs = false, &$imginfo = null) {
         if(file_exists($file)) break;
     }
 
-    // stop process if file doesn't exist
-    if(!file_exists($file)) { return false; }
+	// manage non existing target
+	if(!file_exists($file)) {
+		// give result for fallback image
+		if ($fallback) {
+			$file = $fallback;
+		// stop process if false result is required (if $fallback is false)
+		} else {
+			return false;
+		}
+	}
 
     // fetch image data if requested
     if(!is_null($imginfo)) {

--- a/inc/template.php
+++ b/inc/template.php
@@ -1677,12 +1677,12 @@ function tpl_flush() {
  * @param  string[] $search       locations to look at
  * @param  bool     $abs          if to use absolute URL
  * @param  array    &$imginfo     filled with getimagesize()
- * @param  string[] $fallback     image used as fallback if target isn't found (or false if potential false result is required)
+ * @param  bool     $fallback     use fallback image if target isn't found or return 'false' if potential false result is required
  * @return string
  *
  * @author Andreas  Gohr <andi@splitbrain.org>
  */
-function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = 'lib/images/blank.gif') {
+function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = true) {
     $img     = '';
     $file    = '';
     $ismedia = false;
@@ -1702,8 +1702,8 @@ function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = '
 	// manage non existing target
 	if(!file_exists($file)) {
 		// give result for fallback image
-		if ($fallback) {
-			$file = $fallback;
+		if ($fallback === true) {
+			$file = DOKU_INC.'lib/images/blank.gif';
 		// stop process if false result is required (if $fallback is false)
 		} else {
 			return false;


### PR DESCRIPTION
Previously, if no candidate is found, the result would still always be last candidate url even if it doesn't exist (and function would trigger a Warning for trying to getimagesize() on a file that doesn't exist)