### PR TITLE
Respect case provided by user for internal links when using headers

### DIFF
--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1752,7 +1752,15 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             if(useHeading($linktype) && $id) {
                 $heading = p_get_first_heading($id);
                 if(!blank($heading)) {
-                    return $this->_xmlEntities($heading);
+                    $mHeading = $heading;
+                    if(mb_strtoupper(mb_substr($default, 0, 1)) != mb_substr($default, 0, 1)) {
+                        //first char used in reference was lowercase
+                        $mHeading = mb_strtolower(mb_substr($heading, 0, 1)) . mb_substr($heading, 1);
+                    } elseif (mb_strtolower(mb_substr($default, 0, 1)) != mb_substr($default, 0, 1)) {
+                        //first char used in reference was uppercase
+                        $mHeading = mb_strtoupper(mb_substr($heading, 0, 1)) . mb_substr($heading, 1);
+                    }
+                    return $this->_xmlEntities($mHeading);
                 }
             }
             return $this->_xmlEntities($default);


### PR DESCRIPTION
On a wiki with "useheading" activated, when an editor references an internal page, the link displayed reuses the casing of the heading. This change respects the first-letter case used by the editor and applies it to the heading used to replace the page name. This avoids having disgraceful uppercase letter in the middle of a sentence without having to repeat the page name in the explicit title component of the link just to change the case of the first letter. Hope this makes sense.