### PR TITLE
Force Travis CI PHPUnit version to 7 for PHP 7.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,27 +12,8 @@ env:
   - DISABLE_FUNCTIONS="gzopen"
 matrix:
   fast_finish: true
-  include:
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
-      services:
-        - mysql
-        - postgresql
-      env: DISABLE_FUNCTIONS=
   allow_failures:
-    - php: "hhvm"
     - php: "nightly"
-  exclude:
-    - php: "hhvm"
-      env: DISABLE_FUNCTIONS="gzopen"
 notifications:
   irc:
     channels:
@@ -40,15 +21,12 @@ notifications:
     on_success: change
     on_failure: change
 install:
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.6.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-  - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693; nightly will match $TRAVIS_PHP_VERSION > '7.1' rule
 before_script:
   # Disable the HHVM JIT for faster Unit Testing
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp _test/mysql.conf.php.dist _test/mysql.conf.php
   - cp _test/pgsql.conf.php.dist _test/pgsql.conf.php
   - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ notifications:
     on_success: change
     on_failure: change
 install:
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.6.phar; fi
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
   - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: hhvm-stable
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next update
@@ -28,10 +28,10 @@ matrix:
         - postgresql
       env: DISABLE_FUNCTIONS=
   allow_failures:
-    - php: "hhvm-stable"
+    - php: "hhvm"
     - php: "nightly"
   exclude:
-    - php: "hhvm-stable"
+    - php: "hhvm"
       env: DISABLE_FUNCTIONS="gzopen"
 notifications:
   irc:
@@ -42,9 +42,9 @@ notifications:
 install:
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-  - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-  # Force PHPUnit 7 #2693
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION != hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  # Force PHPUnit 7 #2693; nightly will match $TRAVIS_PHP_VERSION > '7.1' rule
 before_script:
   # Disable the HHVM JIT for faster Unit Testing
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 sudo: false
 php:
   - "nightly"
+  - "7.3"
   - "7.2"
   - "7.1"
   - "7.0"
@@ -39,12 +40,18 @@ notifications:
     on_success: change
     on_failure: change
 install:
-  - wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
-  - chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  # Force PHPUnit 7 #2693
 before_script:
   # Disable the HHVM JIT for faster Unit Testing
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - cp _test/mysql.conf.php.dist _test/mysql.conf.php
   - cp _test/pgsql.conf.php.dist _test/pgsql.conf.php
-script: cd _test && phpunit --verbose --stderr
+  - php -v
+  - phpunit --version
+script:
+  - cd _test && phpunit --verbose --stderr

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - if [[ $TRAVIS_PHP_VERSION > '7.1' ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693; nightly will match $TRAVIS_PHP_VERSION > '7.1' rule
 before_script:
-  # Disable the HHVM JIT for faster Unit Testing
   - test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - cp _test/mysql.conf.php.dist _test/mysql.conf.php
   - cp _test/pgsql.conf.php.dist _test/pgsql.conf.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: hhvm
+    - php: hhvm-stable
       sudo: true
       dist: trusty
       group: edge # until the next update
@@ -28,10 +28,10 @@ matrix:
         - postgresql
       env: DISABLE_FUNCTIONS=
   allow_failures:
-    - php: "hhvm"
+    - php: "hhvm-stable"
     - php: "nightly"
   exclude:
-    - php: "hhvm"
+    - php: "hhvm-stable"
       env: DISABLE_FUNCTIONS="gzopen"
 notifications:
   irc:
@@ -40,8 +40,8 @@ notifications:
     on_success: change
     on_failure: change
 install:
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
   - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693
@@ -51,7 +51,6 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - cp _test/mysql.conf.php.dist _test/mysql.conf.php
   - cp _test/pgsql.conf.php.dist _test/pgsql.conf.php
-  - php -v
   - phpunit --version
 script:
   - cd _test && phpunit --verbose --stderr

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "suggest": {
         "squizlabs/php_codesniffer": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-        "phpunit/phpunit": "Allows automated tests to be run without system-wide install."
+        "phpunit/phpunit": "Allows automated tests to be run without system-wide install (only version 4-7 are supported)."
     },
     "prefer-stable": true
 }


### PR DESCRIPTION
This patch does the following:

- Add PHP 7.3 (`nightly` before) to main version list
- Force PHPUnit version to 7 for PHP 7.2+ (and nightly)
- Remove HHVM test that will fail forever (see comment for more information)
- Display PHPUnit version before running the actual test
- Write notice about PHPUnit version in composer.json suggest field