### PR TITLE
trigger login check when trustExternal failed

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -96,10 +96,8 @@ function auth_setup() {
         $INPUT->set('p', stripctl($INPUT->str('p')));
     }
 
-    if(!is_null($auth) && $auth->canDo('external')) {
-        // external trust mechanism in place
-        $auth->trustExternal($INPUT->str('u'), $INPUT->str('p'), $INPUT->bool('r'));
-    } else {
+    if(!(!is_null($auth) && $auth->canDo('external')
+         && $auth->trustExternal($INPUT->str('u'), $INPUT->str('p'), $INPUT->bool('r')))) {
         $evdata = array(
             'user'     => $INPUT->str('u'),
             'password' => $INPUT->str('p'),


### PR DESCRIPTION
This fix allows combining of auth plugins which support trustExternal with plugins which don't support it.
Exmaples: either a plugin can support both (authremoteuser, authclientcert) or authchained mixes two types of plugins.

In situation when auth plugin supports both, trustExternal and login check, value returned by the truestExternal was ignored and login check was never called. 

The detailed description of my use case can be found in: #2694
I have used https://www.dokuwiki.org/plugin:authclientcert for testing.
