### PR TITLE
new wildcard %NAME% for ACL rules

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -147,6 +147,15 @@ function auth_loadACL() {
             $rest = str_replace('%USER%',auth_nameencode($INPUT->server->str('REMOTE_USER')),$rest);
         }
 
+        // substitute user NAME wildcard 
+        if(strstr($line, '%NAME%')){
+            // if user is not logged in, this ACL line is meaningless - skip it
+            if (!$INPUT->server->has('REMOTE_USER')) continue;
+
+            $id   = str_replace('%USER%',cleanID($USERINFO['name']),$id);
+        }
+
+        
         // substitute group wildcard (its 1:m)
         if(strstr($line, '%GROUP%')){
             // if user is not logged in, grps is empty, no output will be added (i.e. skipped)

--- a/lib/plugins/acl/admin.php
+++ b/lib/plugins/acl/admin.php
@@ -84,7 +84,7 @@ class admin_plugin_acl extends DokuWiki_Admin_Plugin {
             $this->who = '@'.ltrim($auth->cleanGroup($who),'@');
         }elseif($INPUT->str('acl_t') == '__u__' && $who){
             $this->who = ltrim($who,'@');
-            if($this->who != '%USER%' && $this->who != '%GROUP%'){ #keep wildcard as is
+            if($this->who != '%USER%' && $this->who != '%NAME%' && $this->who != '%GROUP%'){ #keep wildcard as is
                 $this->who = $auth->cleanUser($this->who);
             }
         }elseif($INPUT->str('acl_t') &&


### PR DESCRIPTION
Introduces a new wildcard %NAME%, to be replaced by user's full name (after applying ``cleanID``). This is needed in a context where the existing wildcard %USER% cannot be used for data protection reasons (%USER% = student matriculation number)