### PR TITLE
use absolute URL in index.php when redirecting to doku.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,8 +14,10 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 if(php_sapi_name() != 'cli-server') {
-    header("Location: doku.php");
-    exit;
+    if(!defined('DOKU_INC')) define('DOKU_INC', dirname(__FILE__).'/');
+    require_once(DOKU_INC.'inc/init.php');
+
+    send_redirect(DOKU_URL.'doku.php');
 }
 
 # ROUTER starts below


### PR DESCRIPTION
This fixes #2706.

Note that in order to get an absolute URL, the whole DokuWiki environment is now loaded in index.php. I am not sure whether this is efficient enough, but this makes it consistent across all DokuWiki entrypoints.

Also, AppVeyor is failing just because it doesn't like `styleutils_cssstyleini_test::test_mergedstyleini` in another PR.