### PR TITLE
fix Windows tests for #2702

### DIFF
--- a/_test/bootstrap.php
+++ b/_test/bootstrap.php
@@ -20,9 +20,9 @@ error_reporting(DOKU_E_LEVEL);
 set_time_limit(0);
 ini_set('memory_limit','2048M');
 
-// prepare temporary directories
-define('DOKU_INC', dirname(dirname(__FILE__)).'/');
-define('TMP_DIR', sys_get_temp_dir().'/dwtests-'.microtime(true));
+// prepare temporary directories; str_replace is for WIN
+define('DOKU_INC', str_replace('\\', '/', dirname(dirname(__FILE__))) . '/');
+define('TMP_DIR', str_replace('\\', '/', sys_get_temp_dir()) . '/dwtests-'.microtime(true));
 define('DOKU_CONF', TMP_DIR.'/conf/');
 define('DOKU_TMP_DATA', TMP_DIR.'/data/');
 


### PR DESCRIPTION
Currently `DOKU_INC`, `DOKU_CONF` in test bootstrap is not consistent with [our `fullpath()`](https://github.com/splitbrain/dokuwiki/blob/cbaf278c50e5baf946b3bd606c369735fe0953be/_test/tests/inc/init_fullpath.test.php#L59), causing the concatenated expected string in styleutils_cssstyleini_test not correct in Windows; this patch use `str_replace()` to turn Windows directory separators into Linux ones.