### PR TITLE
tests and fixes for set_doku_pref issues

### DIFF
--- a/_test/tests/inc/common_dokupref.test.php
+++ b/_test/tests/inc/common_dokupref.test.php
@@ -6,16 +6,49 @@ class common_dokupref_test extends DokuWikiTest {
         $this->assertEquals('nil', get_doku_pref('foo', 'nil'));
     }
 
-    function test_get_empty_string() {
-        set_doku_pref('foo', '');
-        $this->assertEquals('', get_doku_pref('foo', 'nil'));
-    }
-
     function test_set() {
         set_doku_pref('foo1', 'bar1');
         set_doku_pref('foo2', 'bar2');
-        $this->assertEquals('bar1', get_doku_pref('foo1', ''));
-        $this->assertEquals('bar2', get_doku_pref('foo2', ''));
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'));
+    }
+
+    function test_set_encode() {
+        set_doku_pref('foo#1', 'bar#1');
+        set_doku_pref('foo#2', 'bar2');
+        $this->assertEquals('bar#1', get_doku_pref('foo#1', 'nil'));
+        $this->assertEquals('bar2', get_doku_pref('foo#2', 'nil'));
+
+        set_doku_pref('foo#2', 'bar#2');
+        $this->assertEquals('bar#1', get_doku_pref('foo#1', 'nil'));
+        $this->assertEquals('bar#2', get_doku_pref('foo#2', 'nil'));
+    }
+
+    // mitigate bug in #2721
+    function test_duplicate_entries() {
+        $_COOKIE['DOKU_PREFS'] = 'foo1#bar1#foo2#bar1#foo2#bar2';
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'));
+
+        set_doku_pref('foo2', 'new2');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('new2', get_doku_pref('foo2', 'nil'));
+        $this->assertEquals('foo1#bar1#foo2#new2', $_COOKIE['DOKU_PREFS'],
+                            'cookie should not have duplicate entries');
+    }
+
+    // This is a definition from #1129
+    function test_empty() {
+        set_doku_pref('foo', '');
+        $this->assertSame('', get_doku_pref('foo', 'nil'));
+
+        set_doku_pref('foo', 0);
+        $this->assertSame('0', get_doku_pref('foo', 'nil'));
+
+        set_doku_pref('foo', null);
+        $this->assertSame('', get_doku_pref('foo', 'nil'));
+
+        set_doku_pref('foo', false);
+        $this->assertSame('nil', get_doku_pref('foo', 'nil'));
     }
 
     // #2721
@@ -30,6 +63,8 @@ class common_dokupref_test extends DokuWikiTest {
         set_doku_pref('foo2', 'bar2');
         $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'));
         $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'));
+        $this->assertEquals('foo1#bar1#foo2#bar2', $_COOKIE['DOKU_PREFS'],
+                            'cookie should not have duplicate entries');
     }
 
     // #2721

--- a/_test/tests/inc/common_dokupref.test.php
+++ b/_test/tests/inc/common_dokupref.test.php
@@ -1,0 +1,51 @@
+<?php
+
+class common_dokupref_test extends DokuWikiTest {
+
+    function test_get_default() {
+        $this->assertEquals('nil', get_doku_pref('foo', 'nil'));
+    }
+
+    function test_get_empty_string() {
+        set_doku_pref('foo', '');
+        $this->assertEquals('', get_doku_pref('foo', 'nil'));
+    }
+
+    function test_set() {
+        set_doku_pref('foo1', 'bar1');
+        set_doku_pref('foo2', 'bar2');
+        $this->assertEquals('bar1', get_doku_pref('foo1', ''));
+        $this->assertEquals('bar2', get_doku_pref('foo2', ''));
+    }
+
+    // #2721
+    function test_set_empty_string() {
+        set_doku_pref('foo1', 'bar1');
+        set_doku_pref('foo2', 'bar1');
+
+        set_doku_pref('foo2', '');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('', get_doku_pref('foo2', 'nil'));
+
+        set_doku_pref('foo2', 'bar2');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'));
+    }
+
+    // #2721
+    function test_set_delete() {
+        set_doku_pref('foo1', 'bar1');
+        set_doku_pref('foo2', 'bar2');
+
+        set_doku_pref('foo1', false);
+        $this->assertEquals('nil', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'));
+
+        set_doku_pref('foo2', false);
+        $this->assertEquals('nil', get_doku_pref('foo1', 'nil'));
+        $this->assertEquals('nil', get_doku_pref('foo2', 'nil'));
+    }
+
+}
+
+//Setup VIM: ex: et ts=4 :

--- a/inc/common.php
+++ b/inc/common.php
@@ -2038,7 +2038,11 @@ function set_doku_pref($pref, $val) {
 
     if (!empty($cookieVal)) {
         $cookieDir = empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'];
-        setcookie('DOKU_PREFS', $cookieVal, time()+365*24*3600, $cookieDir, '', ($conf['securecookie'] && is_ssl()));
+        if(defined('DOKU_UNITTEST')) {
+            $_COOKIE['DOKU_PREFS'] = $cookieVal;
+        }else{
+            setcookie('DOKU_PREFS', $cookieVal, time()+365*24*3600, $cookieDir, '', ($conf['securecookie'] && is_ssl()));
+        }
     }
 }
 

--- a/inc/common.php
+++ b/inc/common.php
@@ -1993,7 +1993,10 @@ function get_doku_pref($pref, $default) {
     if(isset($_COOKIE['DOKU_PREFS']) && strpos($_COOKIE['DOKU_PREFS'], $enc_pref) !== false) {
         $parts = explode('#', $_COOKIE['DOKU_PREFS']);
         $cnt   = count($parts);
-        for($i = 0; $i < $cnt; $i += 2) {
+
+        // due to #2721 there might be duplicate entries,
+        // so we read from the end
+        for($i = $cnt-2; $i >= 0; $i -= 2) {
             if($parts[$i] == $enc_pref) {
                 return urldecode($parts[$i + 1]);
             }
@@ -2015,34 +2018,39 @@ function set_doku_pref($pref, $val) {
     $orig = get_doku_pref($pref, false);
     $cookieVal = '';
 
-    if($orig && ($orig != $val)) {
+    if($orig !== false && ($orig !== $val)) {
         $parts = explode('#', $_COOKIE['DOKU_PREFS']);
         $cnt   = count($parts);
         // urlencode $pref for the comparison
         $enc_pref = rawurlencode($pref);
-        for($i = 0; $i < $cnt; $i += 2) {
-            if($parts[$i] == $enc_pref) {
-                if ($val !== false) {
-                    $parts[$i + 1] = rawurlencode($val);
+        $seen = false;
+        for ($i = 0; $i < $cnt; $i += 2) {
+            if ($parts[$i] == $enc_pref) {
+                if (!$seen){
+                    if ($val !== false) {
+                        $parts[$i + 1] = rawurlencode($val);
+                    } else {
+                        unset($parts[$i]);
+                        unset($parts[$i + 1]);
+                    }
+                    $seen = true;
                 } else {
+                    // no break because we want to remove duplicate entries
                     unset($parts[$i]);
                     unset($parts[$i + 1]);
                 }
-                break;
             }
         }
         $cookieVal = implode('#', $parts);
-    } else if (!$orig && $val !== false) {
+    } else if ($orig === false && $val !== false) {
         $cookieVal = ($_COOKIE['DOKU_PREFS'] ? $_COOKIE['DOKU_PREFS'].'#' : '').rawurlencode($pref).'#'.rawurlencode($val);
     }
 
-    if (!empty($cookieVal)) {
-        $cookieDir = empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'];
-        if(defined('DOKU_UNITTEST')) {
-            $_COOKIE['DOKU_PREFS'] = $cookieVal;
-        }else{
-            setcookie('DOKU_PREFS', $cookieVal, time()+365*24*3600, $cookieDir, '', ($conf['securecookie'] && is_ssl()));
-        }
+    $cookieDir = empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'];
+    if(defined('DOKU_UNITTEST')) {
+        $_COOKIE['DOKU_PREFS'] = $cookieVal;
+    }else{
+        setcookie('DOKU_PREFS', $cookieVal, time()+365*24*3600, $cookieDir, '', ($conf['securecookie'] && is_ssl()));
     }
 }
 

--- a/lib/scripts/cookie.js
+++ b/lib/scripts/cookie.js
@@ -22,6 +22,7 @@ var DokuCookie = {
         var text = [],
             _this = this;
         this.init();
+        val = val + "";
         this.data[key] = val;
 
         //save the whole data array

--- a/lib/scripts/cookie.js
+++ b/lib/scripts/cookie.js
@@ -22,8 +22,13 @@ var DokuCookie = {
         var text = [],
             _this = this;
         this.init();
-        val = val + "";
-        this.data[key] = val;
+        if (val === false){
+            delete this.data[key];
+        }else{
+            val = val + "";
+            this.data[key] = val;
+        }
+
 
         //save the whole data array
         jQuery.each(_this.data, function (key, val) {
@@ -42,7 +47,7 @@ var DokuCookie = {
      */
     getValue: function(key, def){
         this.init();
-        return key in this.data ? this.data[key] : def;
+        return this.data.hasOwnProperty(key) ? this.data[key] : def;
     },
 
     /**

--- a/lib/scripts/cookie.js
+++ b/lib/scripts/cookie.js
@@ -38,10 +38,11 @@ var DokuCookie = {
      * Get a Value from the Cookie
      *
      * @author Andreas Gohr <andi@splitbrain.org>
+     * @param def default value if key does not exist; if not set, returns undefined by default
      */
-    getValue: function(key){
+    getValue: function(key, def){
         this.init();
-        return this.data[key];
+        return key in this.data ? this.data[key] : def;
     },
 
     /**


### PR DESCRIPTION
A fix for #2721.

- PHP tests added
- Read last entries (if duplicate) when get
- Remove duplicate entries when set
- Type-aware compare to decide append or modify
- Remove $cookieVal empty check before setcookie, because there might be cases when we want to remove cookie

Also a JavaScript cookie patch: Convert `value` type to string to prevent different type being returned by `DokuCookie.getValue()`.

```javascript
DokuCookie.setValue('foo', false);
console.log(DokuCookie.getValue('foo')); // buggy false, should be 'false'
location.reload(); // pseudo code
console.log(DokuCookie.getValue('foo')); // 'false'
```

AppVeyor is failing just because it doesn't like `styleutils_cssstyleini_test::test_mergedstyleini` in another PR.