### PR TITLE
install.php respect useacl=0 choice

### DIFF
--- a/install.php
+++ b/install.php
@@ -309,6 +309,9 @@ function check_data(&$d){
                 $error[] = sprintf($lang['i_badval'],$lang['email']);
                 $ok      = false;
             }
+        }else{
+            // Since default = 1, browser won't send acl=0 when user untick acl
+            $d['acl'] = '0';
         }
     }
     $d = array_merge($form_default, $d);


### PR DESCRIPTION
This fixes #2576.

> I tried to install the last stable release (Greebo) and unchecked "Use ACL".
>
> Then on pages I saw "Log In" form, and in local.php there was `$conf['useacl'] = 1;`
>
> It can cause confusion, because user has no way to actually login (except of hacking that auth files).