### PR TITLE
Fix issue with ID/NS "0"

### DIFF
--- a/_test/tests/inc/common_wl.test.php
+++ b/_test/tests/inc/common_wl.test.php
@@ -38,6 +38,15 @@ class common_wl_test extends DokuWikiTest {
         $this->assertEquals($expect, wl('some'));
     }
 
+    function test_wl_id_zero() {
+        global $conf;
+        $conf['useslash'] = 0;
+        $conf['userewrite'] = 0;
+
+        $expect = DOKU_BASE . DOKU_SCRIPT . '?id=0';
+        $this->assertEquals($expect, wl('0'));
+    }
+
     function test_wl_id_ns() {
         global $conf;
         $conf['useslash'] = 0;
@@ -142,7 +151,7 @@ class common_wl_test extends DokuWikiTest {
         $expect = DOKU_BASE . DOKU_SCRIPT . '/some/one?a=b&c=d';
         $this->assertEquals($expect, wl('some:one', 'a=b,c=d', false, '&'));
     }
-    
+
     function test_wl_empty_rev() {
         global $conf;
         $conf['useslash'] = 0;

--- a/_test/tests/inc/indexer_indexing.test.php
+++ b/_test/tests/inc/indexer_indexing.test.php
@@ -59,4 +59,21 @@ class indexer_indexing_test extends DokuWikiTest {
         $query = '1010';
         $this->assertEquals(array('notfound', 'testpage'), $indexer->lookupKey('onezero', $query));
     }
+
+    public function test_numeric_zerostring_meta() {
+        $indexer = idx_get_indexer();
+        $indexer->addMetaKeys('zero1', 'zerostring', array('0'));
+        $indexer->addMetaKeys('zero2', 'zerostring', array('0'));
+        $indexer->addMetaKeys('0', 'zerostring', array('zero'));
+
+        $query = '0';
+        $result = $indexer->lookupKey('zerostring', $query);
+        sort($result);
+        $this->assertEquals(array('zero1', 'zero2'), $result);
+
+        $query = 'zero';
+        $result = $indexer->lookupKey('zerostring', $query);
+        sort($result);
+        $this->assertEquals(array('0'), $result);
+    }
 }

--- a/_test/tests/inc/pageutils_findnearest.test.php
+++ b/_test/tests/inc/pageutils_findnearest.test.php
@@ -36,6 +36,25 @@ class pageutils_findnearest_test extends DokuWikiTest {
         $this->assertEquals(false, $sidebar);
     }
 
+    function testZeroID() {
+        global $ID;
+
+        saveWikiText('sidebar', 'topsidebar-test', '');
+        saveWikiText('0', 'zero-test', '');
+        saveWikiText('0:0:0', 'zero-test', '');
+
+        $ID = '0:0:0';
+        $sidebar = page_findnearest('sidebar');
+        $this->assertEquals('sidebar', $sidebar);
+
+        $sidebar = page_findnearest('0');
+        $this->assertEquals('0:0:0', $sidebar);
+
+        $ID = '0';
+        $sidebar = page_findnearest('0');
+        $this->assertEquals('0', $sidebar);
+    }
+
     function testExistingSidebars() {
         global $ID;
 

--- a/_test/tests/inc/pageutils_getid.test.php
+++ b/_test/tests/inc/pageutils_getid.test.php
@@ -3,6 +3,21 @@
 class init_getID_test extends DokuWikiTest {
 
     /**
+     * id=0 case
+     */
+    function test_zero_id(){
+        global $conf;
+        $conf['basedir'] = '/';
+        $conf['userewrite'] = 0;
+
+        $_SERVER['SCRIPT_FILENAME'] = '/doku.php';
+        $_SERVER['REQUEST_URI'] = '/doku.php?id=0&do=edit';
+        $_REQUEST['id'] = '0';
+
+        $this->assertSame('0', getID('id'));
+    }
+
+    /**
      * fetch media files with basedir and urlrewrite=2
      *
      * data provided by Jan Decaluwe <jan@jandecaluwe.com>

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -415,7 +415,7 @@ class Ajax {
         foreach($data as $item) {
             $even *= -1; //zebra
 
-            if(($item['type'] == 'd' || $item['type'] == 'u') && $item['id']) $item['id'] .= ':';
+            if(($item['type'] == 'd' || $item['type'] == 'u') && $item['id'] !== '') $item['id'] .= ':';
             $link = wl($item['id']);
 
             echo '<div class="' . (($even > 0) ? 'even' : 'odd') . ' type_' . $item['type'] . '">';

--- a/inc/TaskRunner.php
+++ b/inc/TaskRunner.php
@@ -188,7 +188,7 @@ class TaskRunner
         global $conf;
         print 'runIndexer(): started' . NL;
 
-        if (!$ID) {
+        if ((string) $ID === '') {
             return false;
         }
 

--- a/inc/common.php
+++ b/inc/common.php
@@ -506,7 +506,7 @@ function wl($id = '', $urlParameters = '', $absolute = false, $separator = '&amp
     } elseif($conf['userewrite']) {
         $xlink .= $id;
         if($urlParameters) $xlink .= '?'.$urlParameters;
-    } elseif($id) {
+    } elseif($id !== '') {
         $xlink .= DOKU_SCRIPT.'?id='.$id;
         if($urlParameters) $xlink .= $separator.$urlParameters;
     } else {

--- a/inc/indexer.php
+++ b/inc/indexer.php
@@ -295,7 +295,7 @@ class Doku_Indexer {
             if (!is_array($values)) $values = array($values);
 
             $val_idx = $this->getIndexKey($metaname.'_p', '', $pid);
-            if ($val_idx != '') {
+            if ($val_idx !== '') {
                 $val_idx = explode(':', $val_idx);
                 // -1 means remove, 0 keep, 1 add
                 $val_idx = array_combine($val_idx, array_fill(0, count($val_idx), -1));
@@ -1286,7 +1286,7 @@ class Doku_Indexer {
             list($key, $cnt) = explode('*', $tuple);
             if (!$cnt) continue;
             $key = $keys[$key];
-            if (!$key) continue;
+            if ($key === false || is_null($key)) continue;
             $result[$key] = $cnt;
         }
         return $result;

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -89,9 +89,8 @@ function getID($param='id',$clean=true){
             send_redirect(wl($id, $urlParameters, true, '&'));
         }
     }
-
     if($clean) $id = cleanID($id);
-    if(empty($id) && $param=='id') $id = $conf['start'];
+    if($id === '' && $param=='id') $id = $conf['start'];
 
     return $id;
 }

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -758,7 +758,7 @@ function utf8_decodeFN($file){
  * @return false|string the full page id of the found page, false if any
  */
 function page_findnearest($page, $useacl = true){
-    if (!$page) return false;
+    if ((string) $page === '') return false;
     global $ID;
 
     $ns = $ID;
@@ -768,7 +768,7 @@ function page_findnearest($page, $useacl = true){
         if(page_exists($pageid) && (!$useacl || auth_quickaclcheck($pageid) >= AUTH_READ)){
             return $pageid;
         }
-    } while($ns);
+    } while($ns !== false);
 
     return false;
 }


### PR DESCRIPTION
Inspired by #2610, I tested a bit with `:0` and `:0:start`, found some problems and tried to fix them. With this patch edit/show/search/backlink looks OK now.

- `wl()` removing id parameter when seeing `:0`
- `getID()` redirecting `:0` to `:start` when trying to show/edit `:0`
- "from any page, try to add a link to `0:start` using Link Wizard but you can't navigate into `:0` namespace"
- no `:0` page in index because when indexer sees `:0` it's being ignored
- backlink never shows `:0` page in the list because of indexer's `lookupKey()`
- sidebar routing finding nothing for `0` NS/ID because of `page_findnearest()`

This should fix #2610 finally.