### PR TITLE
Only ob_flush if there is actually a buffer.

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1658,7 +1658,7 @@ function tpl_subscribe() {
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function tpl_flush() {
-    ob_flush();
+    if( ob_get_level() > 0 ) ob_flush();
     flush();
 }
 


### PR DESCRIPTION
If there is no buffer, application dies with no way to recover.