### PR TITLE
Added some security HTTP headers

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -41,3 +41,13 @@
 ## rules if your server setup allows HTTPS.
 #RewriteCond %{HTTPS} !=on
 #RewriteRule ^lib/exe/xmlrpc.php$      https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
+
+<IfModule mod_headers.c>
+    # Header always set X-Frame-Options DENY
+    Header always set X-Content-Type-Options nosniff
+    Header always set Referrer-Policy strict-origin-when-cross-origin
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
+    Header always set Feature-Policy "camera 'none'; geolocation 'none'; microphone 'none'; payment 'none'"
+    Header always set Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'" 
+ </IfModule>  


### PR DESCRIPTION
These values can be applied by default to all dokuwiki installation. Unless there is a specific plugin that explicitly needs these security settings to be relaxed/tweaked these can help improve the security of a default installation. 'unsafe-inline' in csp of script-src is a reminder that it can be eventually fixed to improve security. I use these and more tweaked settings with reporting on my website. The CSP settings can be verified with csp-evaluator.withgoogle.com.