### PR TITLE
 Add simple HTML template processing to menus

### DIFF
--- a/inc/Menu/AbstractMenu.php
+++ b/inc/Menu/AbstractMenu.php
@@ -73,9 +73,9 @@ abstract class AbstractMenu implements MenuInterface {
      * output, use getItems() and build the HTML yourself
      * 
      * Instead of a classprefix, you can also supply a template to use. The template may contain
-     * the substitution strings %type%, %svg% and %label% where you want the respective parts
+     * the substitution strings %TYPE%, %SVG% and %LABEL% where you want the respective parts
      * to appear. The string must begin with a '<' character. Example for the "writr" template:
-     * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
+     * <span class="icon">%SVG%</span> <span class="a11y">%LABEL%</span>
      *
      * @param string|false $classprefix create a class from type with this prefix, or html, false for no class
      * @param bool $svg add the SVG link

--- a/inc/Menu/AbstractMenu.php
+++ b/inc/Menu/AbstractMenu.php
@@ -73,9 +73,9 @@ abstract class AbstractMenu implements MenuInterface {
      * This is a convenience method for template authors. If you need more fine control over the
      * output, use getItems() and build the HTML yourself
      * 
-     * Instead of a classprefix, you can also supply a tgemplate to use. The template may contain
-     * the substitution strings %type%, %scv% and %label% where you want the respecrtive parts
-     * to appear. The string must begin with a '<' character. Example for the writr template:
+     * Instead of a classprefix, you can also supply a template to use. The template may contain
+     * the substitution strings %type%, %scv% and %label% where you want the respective parts
+     * to appear. The string must begin with a '<' character. Example for the "writr" template:
      * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      *
      * @param string|false $classprefix create a class from type with this prefix, or html, false for no class

--- a/inc/Menu/AbstractMenu.php
+++ b/inc/Menu/AbstractMenu.php
@@ -34,7 +34,6 @@ abstract class AbstractMenu implements MenuInterface {
     /**
      * Get the list of action items in this menu
      *
-     * @param array $template template array
      * @return AbstractItem[]
      * @triggers MENU_ITEMS_ASSEMBLY
      */
@@ -74,7 +73,7 @@ abstract class AbstractMenu implements MenuInterface {
      * output, use getItems() and build the HTML yourself
      * 
      * Instead of a classprefix, you can also supply a template to use. The template may contain
-     * the substitution strings %type%, %scv% and %label% where you want the respective parts
+     * the substitution strings %type%, %svg% and %label% where you want the respective parts
      * to appear. The string must begin with a '<' character. Example for the "writr" template:
      * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      *

--- a/inc/Menu/AbstractMenu.php
+++ b/inc/Menu/AbstractMenu.php
@@ -34,6 +34,7 @@ abstract class AbstractMenu implements MenuInterface {
     /**
      * Get the list of action items in this menu
      *
+     * @param array $template template array
      * @return AbstractItem[]
      * @triggers MENU_ITEMS_ASSEMBLY
      */
@@ -71,23 +72,33 @@ abstract class AbstractMenu implements MenuInterface {
      *
      * This is a convenience method for template authors. If you need more fine control over the
      * output, use getItems() and build the HTML yourself
+     * 
+     * Instead of a classprefix, you can also supply a tgemplate to use. The template may contain
+     * the substitution strings %type%, %scv% and %label% where you want the respecrtive parts
+     * to appear. The string must begin with a '<' character. Example for the writr template:
+     * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      *
-     * @param string|false $classprefix create a class from type with this prefix, false for no class
+     * @param string|false $classprefix create a class from type with this prefix, or html, false for no class
      * @param bool $svg add the SVG link
      * @return string
      */
     public function getListItems($classprefix = '', $svg = true) {
         $html = '';
         foreach($this->getItems() as $item) {
-            if($classprefix !== false) {
-                $class = ' class="' . $classprefix . $item->getType() . '"';
-            } else {
-                $class = '';
+            if (strlen($classprefix) && $classprefix[0] === '<') {
+                $html .= '<li>'.$item->asHtmlLink($classprefix, $svg).'</li>';
             }
+            else {
+                if($classprefix !== false) {
+                    $class = ' class="' . $classprefix . $item->getType() . '"';
+                } else {
+                    $class = '';
+                }
 
-            $html .= "<li$class>";
-            $html .= $item->asHtmlLink(false, $svg);
-            $html .= '</li>';
+                $html .= "<li$class>";
+                $html .= $item->asHtmlLink(false, $svg);
+                $html .= '</li>';
+            }
         }
         return $html;
     }

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -149,9 +149,9 @@ abstract class AbstractItem {
      * Wraps around the label and SVG image
      *
      * Instead of a classprefix, you can also supply a template to use. The template may contain
-     * the substitution strings %type%, %svg% and %label% where you want the respective parts
+     * the substitution strings %TYPE%, %SVG% and %LABEL% where you want the respective parts
      * to appear. The string must begin with a '<' character. Example for the "writr" template:
-     * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
+     * <span class="icon">%SVG%</span> <span class="a11y">%LABEL%</span>
      *
      * @param string|false $classprefix create a class from type with this prefix, or html, false for no class
      * @param bool $svg add SVG icon to the link
@@ -165,7 +165,7 @@ abstract class AbstractItem {
         $label = hsc($this->getLabel());
         if ($isHtml) {
             $html .= str_replace(
-                ['%type%', '%svg%', '%label%'],
+                ['%TYPE%', '%SVG%', '%LABEL%'],
                 [$this->getType(), $svg ? inlineSVG($this->getSvg()) : '', $label],
                 $classprefix);
         }

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -149,7 +149,7 @@ abstract class AbstractItem {
      * Wraps around the label and SVG image
      *
      * Instead of a classprefix, you can also supply a template to use. The template may contain
-     * the substitution strings %type%, %scv% and %label% where you want the respective parts
+     * the substitution strings %type%, %svg% and %label% where you want the respective parts
      * to appear. The string must begin with a '<' character. Example for the "writr" template:
      * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      *

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -148,18 +148,32 @@ abstract class AbstractItem {
      *
      * Wraps around the label and SVG image
      *
-     * @param string|false $classprefix create a class from type with this prefix, false for no class
+     * Instead of a classprefix, you can also supply a tgemplate to use. The template may contain
+     * the substitution strings %type%, %scv% and %label% where you want the respecrtive parts
+     * to appear. The string must begin with a '<' character. Example for the writr template:
+     * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
+     *
+     * @param string|false $classprefix create a class from type with this prefix, or html, false for no class
      * @param bool $svg add SVG icon to the link
      * @return string
+     * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      */
     public function asHtmlLink($classprefix = 'menuitem ', $svg = true) {
-        $attr = buildAttributes($this->getLinkAttributes($classprefix));
+        $isHtml = (strlen($classprefix) && $classprefix[0] === '<');
+        $attr = buildAttributes($this->getLinkAttributes($isHtml ? "menuitem " : $classprefix));
         $html = "<a $attr>";
-        if($svg) {
-            $html .= '<span>' . hsc($this->getLabel()) . '</span>';
+        $label = hsc($this->getLabel());
+        if ($isHtml) {
+            $html .= str_replace(
+                ['%type%', '%svg%', '%label%'],
+                [$this->getType(), $svg ? inlineSVG($this->getSvg()) : '', $label],
+                $classprefix);
+        }
+        else if($svg) {
+            $html .= '<span>' . $label . '</span>';
             $html .= inlineSVG($this->getSvg());
         } else {
-            $html .= hsc($this->getLabel());
+            $html .= $label;
         }
         $html .= "</a>";
 

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -148,9 +148,9 @@ abstract class AbstractItem {
      *
      * Wraps around the label and SVG image
      *
-     * Instead of a classprefix, you can also supply a tgemplate to use. The template may contain
-     * the substitution strings %type%, %scv% and %label% where you want the respecrtive parts
-     * to appear. The string must begin with a '<' character. Example for the writr template:
+     * Instead of a classprefix, you can also supply a template to use. The template may contain
+     * the substitution strings %type%, %scv% and %label% where you want the respective parts
+     * to appear. The string must begin with a '<' character. Example for the "writr" template:
      * <span class="icon">%svg%</span> <span class="a11y">%label%</span>
      *
      * @param string|false $classprefix create a class from type with this prefix, or html, false for no class


### PR DESCRIPTION
This pull request makes Menu::getListItems() to accept a templatized HTML string instead of a classprefix. The template may contain the substitution strings %type%, %svg% and %label% where you want the respective parts to appear. The string must begin with a '<' character. Example for the "writr" template (along with some CSS magic):

`<span class="icon">%svg</span><span class="a11y">%label<span>`
