### PR TITLE
fix site tools current item not in highlight due to Greebo change

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -66,16 +66,16 @@
 ********************************************************************/
 
 /* highlight selected tool */
-.mode_admin a.action.admin,
-.mode_login a.action.login,
-.mode_register a.action.register,
-.mode_profile a.action.profile,
-.mode_recent a.action.recent,
-.mode_index a.action.index,
-.mode_media a.action.media,
-.mode_revisions a.action.revs,
-.mode_backlink a.action.backlink,
-.mode_subscribe a.action.subscribe {
+.mode_admin .action.admin a,
+.mode_login .action.login a,
+.mode_register .action.register a,
+.mode_profile .action.profile a,
+.mode_recent .action.recent a,
+.mode_index .action.index a,
+.mode_media .action.media a,
+.mode_revisions .action.revs a,
+.mode_backlink .action.backlink a,
+.mode_subscribe .action.subscribe a {
     font-weight: bold;
 }
 


### PR DESCRIPTION
This should fix #2768 of regression in DokuWiki core (template), introduced by 93b8c351fad5246a7a91c86418f15bec833dc99f.

Co-Authored-By: Gerrit Uitslag <klapinklapin@gmail.com>