### PR TITLE
Feature: limit media displayed in media manager

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -100,6 +100,7 @@ $conf['gdlib']       = 2;                //the GDlib version (0, 1 or 2) 2 tries
 $conf['im_convert']  = '';               //path to ImageMagicks convert (will be used instead of GD)
 $conf['jpg_quality'] = '70';             //quality of compression when scaling jpg images (0-100)
 $conf['fetchsize']   = 0;                //maximum size (bytes) fetch.php may download from extern, disabled by default
+$conf['displayed_media_limit'] = 30;	 //maximum count of media displayed in media manager
 
 /* Notification Settings */
 $conf['subscribers'] = 0;                //enable change notice subscription support

--- a/inc/media.php
+++ b/inc/media.php
@@ -684,7 +684,7 @@ function media_filelist($ns,$auth=null,$jump='',$fullscreenview=false,$sort=fals
         $dir = utf8_encodeFN(str_replace(':','/',$ns));
         $data = array();
         search($data,$conf['mediadir'],'search_media',
-                array('showmsg'=>true,'depth'=>1),$dir,1,$sort);
+                array('showmsg'=>true,'depth'=>1),$dir,1,$sort,$conf['displayed_media_limit']);
 
         if(!count($data)){
             echo '<div class="nothing">'.$lang['nothingfound'].'</div>'.NL;
@@ -1504,7 +1504,8 @@ function media_searchlist($query,$ns,$auth=null,$fullscreen=false,$sort='natural
                     array('showmsg'=>false,'pattern'=>$pattern),
                     $dir,
                     1,
-                    $sort);
+		    $sort,
+		    $conf['displayed_media_limit']);
         }
         $evt->advise_after();
         unset($evt);

--- a/inc/search.php
+++ b/inc/search.php
@@ -21,9 +21,10 @@ if(!defined('DOKU_INC')) die('meh.');
  * @param   string    $dir  Current directory beyond $base
  * @param   int       $lvl  Recursion Level
  * @param   mixed     $sort 'natural' to use natural order sorting (default); 'date' to sort by filemtime; leave empty to skip sorting.
+ * @param   int	      $limit limit the result size of the results $data array
  * @author  Andreas Gohr <andi@splitbrain.org>
  */
-function search(&$data,$base,$func,$opts,$dir='',$lvl=1,$sort='natural'){
+function search(&$data,$base,$func,$opts,$dir='',$lvl=1,$sort='natural',$limit=-1){
     $dirs   = array();
     $files  = array();
     $filepaths = array();
@@ -57,13 +58,19 @@ function search(&$data,$base,$func,$opts,$dir='',$lvl=1,$sort='natural'){
 
     //give directories to userfunction then recurse
     foreach($dirs as $dir){
+	if ($limit > -1 && sizeOf($data) >= $limit) {
+	    break;
+	}
         if (call_user_func_array($func, array(&$data,$base,$dir,'d',$lvl,$opts))){
             search($data,$base,$func,$opts,$dir,$lvl+1,$sort);
         }
     }
     //now handle the files
     foreach($files as $file){
-        call_user_func_array($func, array(&$data,$base,$file,'f',$lvl,$opts));
+	if ($limit > -1 && sizeOf($data) >= $limit) {
+	    break;
+	}
+	call_user_func_array($func, array(&$data,$base,$file,'f',$lvl,$opts));
     }
 }
 


### PR DESCRIPTION
Fix #2758 
Add a limit parameter to file search function.
Add a configurable limit to number of media displayed in media manager.

By default, limit is set to -1 in search function to not change the current behavior.
By default, in media manager, limit media count displayed is set to 30 in conf/dokuwiki.php