### PR TITLE
Use ob_end_clean to close the extra level of output buffer

### DIFF
--- a/inc/Action/Export.php
+++ b/inc/Action/Export.php
@@ -63,7 +63,8 @@ class Export extends AbstractAction {
                 // get metaheaders
                 ob_start();
                 tpl_metaheaders();
-                $pre .= ob_get_clean();
+                $pre .= ob_get_contents();
+                ob_end_clean();
 
                 $pre .= '</head>' . DOKU_LF;
                 $pre .= '<body>' . DOKU_LF;

--- a/inc/template.php
+++ b/inc/template.php
@@ -81,7 +81,8 @@ function tpl_content($prependTOC = true) {
 
     ob_start();
     trigger_event('TPL_ACT_RENDER', $ACT, 'tpl_content_core');
-    $html_output = ob_get_clean();
+    $html_output = ob_get_contents();
+    ob_end_clean();
     trigger_event('TPL_CONTENT_DISPLAY', $html_output, 'ptln');
 
     return !empty($html_output);


### PR DESCRIPTION
This is inspired by #2743 - No more extra level of output buffer, at least in core.