### PR TITLE
Cleanup styling cookie properly to exit preview

### DIFF
--- a/lib/plugins/styling/script.js
+++ b/lib/plugins/styling/script.js
@@ -78,8 +78,8 @@ jQuery(function () {
     // reload the main page on close
     window.onunload = function(e) {
         if(doreload) {
-            window.opener.DokuCookie.setValue('styling_plugin', 0);
-            window.opener.document.location.reload();
+            DokuCookie.setValue('styling_plugin', 0);
+            if(window.opener) window.opener.document.location.reload();
         }
         return null;
     };
@@ -90,8 +90,8 @@ jQuery(function () {
     });
 
     // on first load apply preview
-    applyPreview(window.opener);
+    if(window.opener) applyPreview(window.opener);
 
     // enable the preview cookie
-    window.opener.DokuCookie.setValue('styling_plugin', 1);
+    DokuCookie.setValue('styling_plugin', 1);
 });


### PR DESCRIPTION
This is inspired by https://forum.dokuwiki.org/thread/14395 and should fix the problem described there (I did a local test which seems to work).

Previously styling cookie depends on `window.opener`. Since the popup should be on the same domain as the opener, and the popup's cookie domain is the same as the opener (`DokuCookie` is used), there is no need to rely on the opener to set the preview cookie. This change will ensure the preview cookie is cleared before the popup is closed, regardless of whether opener exists or not.

Also checks on whether opener exists are added as well.