### PR TITLE
Remove Google Lucky for non-existing interwiki links

### DIFF
--- a/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
+++ b/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
@@ -43,6 +43,7 @@ class Test_resolveInterwiki extends DokuWikiTest {
     function testNonexisting() {
         $Renderer = new Doku_Renderer();
         $Renderer->interwiki = getInterwiki();
+        unset($Renderer->interwiki['default']);
 
         $shortcut = 'nonexisting';
         $reference = 'foo @+%/';
@@ -50,6 +51,19 @@ class Test_resolveInterwiki extends DokuWikiTest {
 
         $this->assertEquals('', $url);
         $this->assertEquals('', $shortcut);
+    }
+
+    function testNonexistingWithDefault() {
+        $Renderer = new Doku_Renderer();
+        $Renderer->interwiki = getInterwiki();
+        $Renderer->interwiki['default'] = 'https://en.wikipedia.org/wiki/{NAME}';
+
+        $shortcut = 'nonexisting';
+        $reference = 'foo';
+        $url = $Renderer->_resolveInterWiki($shortcut, $reference);
+
+        $this->assertEquals('https://en.wikipedia.org/wiki/foo', $url);
+        $this->assertEquals('default', $shortcut);
     }
 
 }

--- a/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
+++ b/_test/tests/inc/parser/renderer_resolveinterwiki.test.php
@@ -47,9 +47,9 @@ class Test_resolveInterwiki extends DokuWikiTest {
         $shortcut = 'nonexisting';
         $reference = 'foo @+%/';
         $url = $Renderer->_resolveInterWiki($shortcut, $reference);
-        $expected = 'https://www.google.com/search?q=foo%20%40%2B%25%2F&amp;btnI=lucky';
 
-        $this->assertEquals($expected, $url);
+        $this->assertEquals('', $url);
+        $this->assertEquals('', $shortcut);
     }
 
 }

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -845,7 +845,10 @@ abstract class Doku_Renderer extends Plugin {
         //get interwiki URL
         if(isset($this->interwiki[$shortcut])) {
             $url = $this->interwiki[$shortcut];
-        } else {
+        }elseif(isset($this->interwiki['default'])) {
+            $shortcut = 'default';
+            $url = $this->interwiki[$shortcut];
+        }else{
             // not parsable interwiki outputs '' to make sure string manipluation works
             $shortcut = '';
             $url      = '';

--- a/inc/parser/renderer.php
+++ b/inc/parser/renderer.php
@@ -846,9 +846,9 @@ abstract class Doku_Renderer extends Plugin {
         if(isset($this->interwiki[$shortcut])) {
             $url = $this->interwiki[$shortcut];
         } else {
-            // Default to Google I'm feeling lucky
-            $url      = 'https://www.google.com/search?q={URL}&amp;btnI=lucky';
-            $shortcut = 'go';
+            // not parsable interwiki outputs '' to make sure string manipluation works
+            $shortcut = '';
+            $url      = '';
         }
 
         //split into hash and url part
@@ -880,8 +880,9 @@ abstract class Doku_Renderer extends Plugin {
                 '{PATH}' => $parsed['path'],
                 '{QUERY}' => $parsed['query'] ,
             ]);
-        } else {
-            //default
+        } else if($url != '') {
+            // make sure when no url is defined, we keep it null
+            // default
             $url = $url.rawurlencode($reference);
         }
         //handle as wiki links

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1062,11 +1062,13 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['url']   = $url;
         $link['title'] = htmlspecialchars($link['url']);
 
-        //output formatted
+        // output formatted
         if($returnonly) {
+            if($url == '') return $link['name'];
             return $this->_formatLink($link);
         } else {
-            $this->doc .= $this->_formatLink($link);
+            if($url == '') $this->doc .= $link['name'];
+            else $this->doc .= $this->_formatLink($link);
         }
     }
 
@@ -1248,9 +1250,17 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             list($shortcut, $reference) = explode('>', $src, 2);
             $exists = null;
             $src = $this->_resolveInterWiki($shortcut, $reference, $exists);
+            if($src == '' && empty($title)){
+                // make sure at least something will be shown in this case
+                $title = $reference;
+            }
         }
         list($src, $hash) = explode('#', $src, 2);
         $noLink = false;
+        if($src == '') {
+            // only output plaintext without link if there is no src
+            $noLink = true;
+        }
         $render = ($linking == 'linkonly') ? false : true;
         $link   = $this->_getMediaLinkConf($src, $title, $align, $width, $height, $cache, $render);
 

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1647,7 +1647,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
             if(!$render) {
                 // if the picture is not supposed to be rendered
                 // return the title of the picture
-                if(!$title) {
+                if($title === null || $title === "") {
                     // just show the sourcename
                     $title = $this->_xmlEntities(\dokuwiki\Utf8\PhpString::basename(noNS($src)));
                 }


### PR DESCRIPTION
For compatibility renderer will return string '' of $shortcut and $url instead of NULL when seeing a non-existing interwiki link. In the meantime, media and link output in xhtml renderer is adjusted, to show title text instead when src/href is null (doesn't limit to interwiki situation). In interwiki case, the title text will be the "reference" part of the interwiki link.

This makes it possible to also support no URL cases in `interwiki.conf`. Before it will output a URL as `rawurlencode($reference)`, which doesn't make sense since it's encoded. However, I am not sure if it's useful under the current behavior (no URL, but text as `$reference`).

Docs needs to be added to warn renderer plugin developers of this situation.

This fixes #2588.