### PR TITLE
Add reverse_defaultns "reverse default namespace linking" option

### DIFF
--- a/_test/tests/inc/pageutils_getid.test.php
+++ b/_test/tests/inc/pageutils_getid.test.php
@@ -144,6 +144,34 @@ class init_getID_test extends DokuWikiTest {
         $this->_test_default_ns('/foo/bar/', 'foo:bar:'.$cleanStart);
     }
 
+    /**
+     * getID with given id in url and userewrite=2, basedir set, Apache and CGI.
+     */
+    function test_rev_default_ns(){
+        global $conf;
+        $conf['reverse_defaultns'] = '1';
+        $cleanStart = cleanID($conf['start']);
+        $conf['basedir'] = '/dw/';
+        $conf['userewrite'] = '2';
+        $conf['baseurl'] = '';
+        $conf['useslash'] = '1';
+
+        // root test
+        $this->_test_default_ns('/', $cleanStart);
+        $this->_test_default_ns('', $cleanStart);
+
+        // for "foo:bar:"
+        // order foo:bar -> foo:bar:$conf['start'] -> foo:bar:bar
+        saveWikiText('foo1:bar1:bar1', 'test1', '');
+        $this->_test_default_ns('/foo1/bar1/', 'foo1:bar1:bar1');
+
+        saveWikiText('foo1:bar1:'.$cleanStart, 'test2', '');
+        $this->_test_default_ns('/foo1/bar1/', 'foo1:bar1:'.$cleanStart);
+
+        saveWikiText('foo1:bar1', 'test3', '');
+        $this->_test_default_ns('/foo1/bar1/', 'foo1:bar1');
+    }
+
     function _test_default_ns($path, $expected){
         global $conf;
         $_SERVER['DOCUMENT_ROOT'] = '/var/www/vhosts/example.com/htdocs';

--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -141,6 +141,9 @@ $conf['rss_show_summary'] = 1;           //Add revision summary to title? 0|1
 $conf['updatecheck'] = 1;                //automatically check for new releases?
 $conf['userewrite']  = 0;                //this makes nice URLs: 0: off 1: .htaccess 2: internal
 $conf['useslash']    = 0;                //use slash instead of colon? only when rewrite is on
+$conf['reverse_defaultns'] = 0;          //use new reverse default namespace behaviour
+                                         //  0 is the previous foo:bar:start -> foo:bar:bar -> foo:bar
+                                         //  1 is the reverse foo:bar -> foo:bar:start -> foo:bar:bar
 $conf['sepchar']     = '_';              //word separator character in page names; may be a
                                          //  letter, a digit, '_', '-', or '.'.
 $conf['canonical']   = 0;                //Should all URLs use full canonical http://... style?

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -68,19 +68,36 @@ function getID($param='id',$clean=true){
 
     // Namespace autolinking from URL
     if(substr($id,-1) == ':' || ($conf['useslash'] && substr($id,-1) == '/')){
-        if(page_exists($id.$conf['start'])){
-            // start page inside namespace
-            $id = $id.$conf['start'];
-        }elseif(page_exists($id.noNS(cleanID($id)))){
-            // page named like the NS inside the NS
-            $id = $id.noNS(cleanID($id));
-        }elseif(page_exists($id)){
-            // page like namespace exists
-            $id = substr($id,0,-1);
+        if($conf['reverse_defaultns'] == '1'){
+            if(page_exists($id)){
+                // page like namespace exists
+                $id = substr($id,0,-1);
+            }elseif(page_exists($id.$conf['start'])){
+                // start page inside namespace
+                $id = $id.$conf['start'];
+            }elseif(page_exists($id.noNS(cleanID($id)))){
+                // page named like the NS inside the NS
+                $id = $id.noNS(cleanID($id));
+            }else{
+                // fall back to default
+                $id = $id.$conf['start'];
+            }
         }else{
-            // fall back to default
-            $id = $id.$conf['start'];
+            if(page_exists($id.$conf['start'])){
+                // start page inside namespace
+                $id = $id.$conf['start'];
+            }elseif(page_exists($id.noNS(cleanID($id)))){
+                // page named like the NS inside the NS
+                $id = $id.noNS(cleanID($id));
+            }elseif(page_exists($id)){
+                // page like namespace exists
+                $id = substr($id,0,-1);
+            }else{
+                // fall back to default
+                $id = $id.$conf['start'];
+            }
         }
+
         if (isset($ACT) && $ACT === 'show') {
             $urlParameters = $_GET;
             if (isset($urlParameters['id'])) {

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -164,6 +164,7 @@ $lang['rss_media_o_media'] = 'media';
 $lang['updatecheck'] = 'Check for updates and security warnings? DokuWiki needs to contact update.dokuwiki.org for this feature.';
 $lang['userewrite']  = 'Use nice URLs';
 $lang['useslash']    = 'Use slash as namespace separator in URLs';
+$lang['reverse_defaultns'] = 'Use new reverse default namespace behaviour. 0 is the old behaviour';
 $lang['sepchar']     = 'Page name word separator';
 $lang['canonical']   = 'Use fully canonical URLs';
 $lang['fnencode']    = 'Method for encoding non-ASCII filenames.';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -206,6 +206,7 @@ $meta['_advanced']   = array('fieldset');
 $meta['updatecheck'] = array('onoff');
 $meta['userewrite']  = array('multichoice','_choices' => array(0,1,2),'_caution' => 'danger');
 $meta['useslash']    = array('onoff');
+$meta['reverse_defaultns'] = array('onoff');
 $meta['sepchar']     = array('sepchar','_caution' => 'warning');
 $meta['canonical']   = array('onoff');
 $meta['fnencode']    = array('multichoice','_choices' => array('url','safe','utf-8'),'_caution' => 'warning');


### PR DESCRIPTION
This closes #2261. Thank you @fthommen for your great idea!

So if this gets merged, a new `$conf['reverse_defaultns']` config will be added. By default it will continue using the old behavior (0). For an example address `foo:bar:`

- 0 is the previous one, search route: `foo:bar:$conf['start']` -> `foo:bar:bar` -> `foo:bar`
- 1 is the reversed one, search route: `foo:bar` -> `foo:bar:$conf['start']` -> `foo:bar:bar`

Unit tests have been added (and adjusted to correct the argument order) as well.