### PR TITLE
Hide Media Manager from not-logged in user

### DIFF
--- a/inc/Menu/SiteMenuGuest.php
+++ b/inc/Menu/SiteMenuGuest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace dokuwiki\Menu;
+
+/**
+ * Class SiteMenu
+ *
+ * Actions that are not bound to an individual page but provide toolsfor the whole wiki.
+ */
+class SiteMenuGuest extends AbstractMenu {
+
+    protected $view = 'site';
+
+    protected $types = array(
+        'Recent',
+        'Index'
+    );
+
+}

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -60,7 +60,11 @@ if (!defined('DOKU_INC')) die();
                 <?php echo (new \dokuwiki\Menu\MobileMenu())->getDropdown($lang['tools']); ?>
             </div>
             <ul>
-                <?php echo (new \dokuwiki\Menu\SiteMenu())->getListItems('action ', false); ?>
+                <?php if (!empty($_SERVER['REMOTE_USER'])): ?>
+                    <?php echo (new \dokuwiki\Menu\SiteMenu())->getListItems('action ', false); ?>
+                <?php else: ?>
+                    <?php echo (new \dokuwiki\Menu\SiteMenuGuest())->getListItems('action ', false); ?>
+                <?php endif ?>
             </ul>
         </div>
 


### PR DESCRIPTION
Presenting the Media Manager for non logged in users is a little confusing I guess. Found some questions for how to hide this item in the dokuwiki forum, but no up-to-date solution. So I created one.
It is non optional - would be more convenient I think - but may be an idea to follow.

