### PR TITLE
Add nsfallback feature for browser request

### DIFF
--- a/_test/tests/inc/pageutils_getid.test.php
+++ b/_test/tests/inc/pageutils_getid.test.php
@@ -14,7 +14,7 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['REQUEST_URI'] = '/doku.php?id=0&do=edit';
         $_REQUEST['id'] = '0';
 
-        $this->assertSame('0', getID('id'));
+        $this->assertSame(getID('id'), '0');
     }
 
     /**
@@ -32,7 +32,7 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['SCRIPT_FILENAME'] = '/lib/exe/fetch.php';
         $_SERVER['REQUEST_URI'] = '/lib/exe/fetch.php/myhdl-0.5dev1.tar.gz?id=snapshots&cache=cache';
 
-        $this->assertEquals(getID('media'), 'myhdl-0.5dev1.tar.gz');
+        $this->assertEquals('myhdl-0.5dev1.tar.gz', getID('media'));
     }
 
 
@@ -54,8 +54,8 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['PATH_INFO'] = '/wiki/discussion/button-dw.png';
         $_SERVER['PATH_TRANSLATED'] = '/var/www/wiki/discussion/button-dw.png';
 
-        $this->assertEquals(getID('media',true), 'wiki:discussion:button-dw.png');
-        $this->assertEquals(getID('media',false), 'wiki/discussion/button-dw.png');
+        $this->assertEquals('wiki:discussion:button-dw.png', getID('media',true));
+        $this->assertEquals('wiki/discussion/button-dw.png', getID('media',false));
     }
 
     /**
@@ -74,7 +74,7 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['PATH_TRANSLATED'] = '/var/www/wiki:dokuwiki';
         $_SERVER['PHP_SELF'] = '/dokuwiki/doku.php/wiki:dokuwiki';
 
-        $this->assertEquals(getID(), 'wiki:dokuwiki');
+        $this->assertEquals('wiki:dokuwiki', getID());
     }
 
     /**
@@ -95,7 +95,7 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['PATH_TRANSLATED'] = '/var/www/vhosts/example.com/htdocs/doku.php';
         $_SERVER['PHP_SELF'] = '/doku.php/wiki/dokuwiki';
 
-        $this->assertEquals(getID(), 'wiki:dokuwiki');
+        $this->assertEquals('wiki:dokuwiki', getID());
     }
 
     /**
@@ -114,8 +114,109 @@ class init_getID_test extends DokuWikiTest {
         $_SERVER['PATH_TRANSLATED'] = '/var/www/index.html';
         $_SERVER['PHP_SELF'] = '/dokuwiki/doku.php/';
 
-        $this->assertEquals(getID(), cleanID($conf['start']));
+        $this->assertEquals(cleanID($conf['start']), getID());
     }
 
+    function _test_default_ns($path, $expected){
+        global $conf, $ACT;
+        $_SERVER['DOCUMENT_ROOT'] = '/var/www/vhosts/example.com/htdocs';
+        $_SERVER['SCRIPT_FILENAME'] = '/var/www/vhosts/example.com/htdocs/dw/doku.php';
+        $_SERVER['SCRIPT_NAME'] = '/dw/doku.php';
+        $_SERVER['REQUEST_URI'] = '/dw/doku.php'.$path;
+        $_SERVER['PATH_INFO'] = '/dw'.$path;
+        $_SERVER['PATH_TRANSLATED'] = '/var/www/vhosts/example.com/htdocs/dw/doku.php';
+        $_SERVER['PHP_SELF'] = '/dw/doku.php'.$path;
+        $this->assertEquals($expected, getID());
+    }
+
+    /**
+     * getID with given id in url and userewrite=2, basedir set, Apache and CGI.
+     */
+    function test_default_ns(){
+        global $conf;
+        $cleanStart = cleanID($conf['start']);
+        $conf['basedir'] = '/dw/';
+        $conf['userewrite'] = '2';
+        $conf['baseurl'] = '';
+        $conf['useslash'] = '1';
+        $conf['nsfallback'] = '0';
+        // root test
+        $this->_test_default_ns('/', $cleanStart);
+        $this->_test_default_ns('', $cleanStart);
+        // for "foo:bar:"
+        // order foo:bar:$conf['start'] -> foo:bar:bar -> foo:bar
+        saveWikiText('foo:bar', 'test1', '');
+        $this->_test_default_ns('/foo/bar/', 'foo:bar');
+        saveWikiText('foo:bar:bar', 'test2', '');
+        $this->_test_default_ns('/foo/bar/', 'foo:bar:bar');
+        saveWikiText('foo:bar:'.$cleanStart, 'test3', '');
+        $this->_test_default_ns('/foo/bar/', 'foo:bar:'.$cleanStart);
+    }
+
+    function test_ns_fallback(){
+        global $conf, $ACT;
+        $cleanStart = cleanID($conf['start']);
+        $conf['basedir'] = '/dw/';
+        $conf['userewrite'] = '2';
+        $conf['baseurl'] = '';
+        $conf['useslash'] = '1';
+        $conf['nsfallback'] = '1';
+        $ACT = 'show';
+        // root test
+        $this->_test_default_ns('/', $cleanStart);
+        $this->_test_default_ns('', $cleanStart);
+        // for "foo:bar"
+        // order foo:bar -> foo:bar:$conf['start'] -> foo:bar:bar
+        saveWikiText('foo_ns:bar:bar', 'test2', '');
+        $this->_test_default_ns('/foo_ns/bar', 'foo_ns:bar:bar');
+        saveWikiText('foo_ns:bar:'.$cleanStart, 'test1', '');
+        $this->_test_default_ns('/foo_ns/bar', 'foo_ns:bar:'.$cleanStart);
+        saveWikiText('foo_ns:bar', 'test3', '');
+        $this->_test_default_ns('/foo_ns/bar', 'foo_ns:bar');
+    }
+
+    function test_ns_fallback_edit(){
+        global $conf, $ACT;
+        $cleanStart = cleanID($conf['start']);
+        $conf['basedir'] = '/dw/';
+        $conf['userewrite'] = '2';
+        $conf['baseurl'] = '';
+        $conf['useslash'] = '1';
+        $conf['nsfallback'] = '1';
+        $ACT = 'edit';
+        // root test
+        $this->_test_default_ns('/', $cleanStart);
+        $this->_test_default_ns('', $cleanStart);
+        // for "foo:bar"
+        // order foo:bar -> foo:bar:$conf['start'] -> foo:bar:bar
+        saveWikiText('foo_ns_edit:bar:bar', 'test2', '');
+        $this->_test_default_ns('/foo_ns_edit/bar', 'foo_ns_edit:bar');
+        saveWikiText('foo_ns_edit:bar:'.$cleanStart, 'test1', '');
+        $this->_test_default_ns('/foo_ns_edit/bar', 'foo_ns_edit:bar');
+        saveWikiText('foo_ns_edit:bar', 'test3', '');
+        $this->_test_default_ns('/foo_ns_edit/bar', 'foo_ns_edit:bar');
+    }
+
+    function test_ns_fallback_off(){
+        global $conf, $ACT;
+        $cleanStart = cleanID($conf['start']);
+        $conf['basedir'] = '/dw/';
+        $conf['userewrite'] = '2';
+        $conf['baseurl'] = '';
+        $conf['useslash'] = '1';
+        $conf['nsfallback'] = '0';
+        $ACT = 'show';
+        // root test
+        $this->_test_default_ns('/', $cleanStart);
+        $this->_test_default_ns('', $cleanStart);
+        // for "foo:bar"
+        // order foo:bar -> foo:bar:$conf['start'] -> foo:bar:bar
+        saveWikiText('foo_ns_off:bar:bar', 'test2', '');
+        $this->_test_default_ns('/foo_ns_off/bar', 'foo_ns_off:bar');
+        saveWikiText('foo_ns_off:bar:'.$cleanStart, 'test1', '');
+        $this->_test_default_ns('/foo_ns_off/bar', 'foo_ns_off:bar');
+        saveWikiText('foo_ns_off:bar', 'test3', '');
+        $this->_test_default_ns('/foo_ns_off/bar', 'foo_ns_off:bar');
+    }
 }
 //Setup VIM: ex: et ts=4 :

--- a/_test/tests/inc/pageutils_resolve_pageid.test.php
+++ b/_test/tests/inc/pageutils_resolve_pageid.test.php
@@ -72,7 +72,35 @@ class init_resolve_pageid_test extends DokuWikiTest {
 
         resolve_pageid($ns, $page, $exist);
         $this->assertEquals($page, $conf['start']);
-   }
+    }
+
+    /**
+     * nsfallback should not affect link parsing due to need for page creation
+     */
+    function test_resolve_pageid_nsfallback() {
+        global $conf;
+        $conf['nsfallback'] = '1';
+        $cleanStart = cleanID($conf['start']);
+
+        saveWikiText('foo_resolve:bar:bar', 'test1', '');
+        $ns = 'foo_resolve';
+        $page = 'bar';
+        $exist = false;
+        resolve_pageid($ns, $page, $exist);
+        $this->assertEquals('foo_resolve:bar', $page);
+
+        saveWikiText('foo_resolve:bar:'.$cleanStart, 'test2', '');
+        $page = 'bar';
+        $exist = false;
+        resolve_pageid($ns, $page, $exist);
+        $this->assertEquals('foo_resolve:bar', $page);
+
+        saveWikiText('foo_resolve:bar', 'test3', '');
+        $page = 'bar';
+        $exist = false;
+        resolve_pageid($ns, $page, $exist);
+        $this->assertEquals('foo_resolve:bar', $page);
+    }
 
 }
 //Setup VIM: ex: et ts=4 :

--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -146,6 +146,7 @@ $conf['sepchar']     = '_';              //word separator character in page name
 $conf['canonical']   = 0;                //Should all URLs use full canonical http://... style?
 $conf['fnencode']    = 'url';            //encode filenames (url|safe|utf-8)
 $conf['autoplural']  = 0;                //try (non)plural form of nonexisting files?
+$conf['nsfallback']  = 0;                //try namespace page of nonexisting files?
 $conf['compression'] = 'gz';             //compress old revisions: (0: off) ('gz': gnuzip) ('bz2': bzip)
                                          //  bz2 generates smaller files, but needs more cpu-power
 $conf['gzip_output'] = 0;                //use gzip content encodeing for the output xhtml (if allowed by browser)

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -169,6 +169,7 @@ $lang['sepchar']     = 'Page name word separator';
 $lang['canonical']   = 'Use fully canonical URLs';
 $lang['fnencode']    = 'Method for encoding non-ASCII filenames.';
 $lang['autoplural']  = 'Check for plural forms in links';
+$lang['nsfallback']  = 'Check namespace existence when browser requested file does not exist';
 $lang['compression'] = 'Compression method for attic files';
 $lang['gzip_output'] = 'Use gzip Content-Encoding for xhtml';
 $lang['compress']    = 'Compact CSS and javascript output';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -216,6 +216,7 @@ $meta['sepchar']     = array('sepchar','_caution' => 'warning');
 $meta['canonical']   = array('onoff');
 $meta['fnencode']    = array('multichoice','_choices' => array('url','safe','utf-8'),'_caution' => 'warning');
 $meta['autoplural']  = array('onoff');
+$meta['nsfallback']  = array('onoff');
 $meta['compress']    = array('onoff');
 $meta['cssdatauri']  = array('numeric','_pattern' => '/^\d+$/');
 $meta['gzip_output'] = array('onoff');


### PR DESCRIPTION
nsfallback is a fallback ns search when requesting:
foo:bar -> foo:bar:$conf['start'] -> foo:bar:bar

nsfallback is similar to autoplural, but autoplural is only effective during internal link parsing (not effective during browser request i.e. getID()). Not sure why it works like that, but because it's not rewriting getID you can try creating page by visiting the ID directly - however it is not working by searching for the not existed page or linking it, which is the recommended way in https://www.dokuwiki.org/page#create_a_page.

I decided to implement nsfallback to apply only during browser request and $ACT=show, not during internal link parsing, because this is most useful when users visit /foo/bar looking for /foo/bar/(start) - this is less intended for people writing the link on the wiki. By not rewriting the internal link, user can still create pages by linking it or searching.

This option is off by default. Tests for getid and resolve_pageid have been added to define the behavior.

This closes #2261. *Tests will go on once #2850 is merged, and I can do a rebase after that.*