### PR TITLE
Check for null JS object on form field.

### DIFF
--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -161,7 +161,7 @@ function currentHeadlineLevel(textboxId){
     var field = jQuery('#' + textboxId)[0],
         s = false,
         opts = [field.value.substr(0,DWgetSelection(field).start)];
-    if (field.form.prefix) {
+    if (field.form && field.form.prefix) {
         // we need to look in prefix context
         opts.push(field.form.prefix.value);
     }


### PR DESCRIPTION
Plugins which manipulate the page editor form textarea can cause the `field.form` object to be null.

This causes the heading buttons to stop working. And the JS console shows an error:

```
Uncaught TypeError: Cannot read property 'prefix' of null at currentHeadlineLevel.
```

For example, plugin https://www.dokuwiki.org/plugin:dokucrypt2 requires this patch for its access of the form field. This small patch, prevents this issue by simply adding an additional check for null on the object.

**Backward compatible. Does not change existing functionality in any way.**