### PR TITLE
The php ISO8601 date format is not correct for XMLRPC dates

### DIFF
--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -5,8 +5,6 @@ use dokuwiki\Remote\XmlRpcServer;
 
 class XmlRpcServerTest extends DokuWikiTest
 {
-
-    protected $userinfo;
     protected $server;
 
 
@@ -14,31 +12,17 @@ class XmlRpcServerTest extends DokuWikiTest
     {
         parent::setUp();
         global $conf;
-        global $USERINFO;
-
-        parent::setUp();
-
-        // mock plugin controller to return our test plugins
-
 
         $conf['remote'] = 1;
         $conf['remoteuser'] = '';
         $conf['useacl'] = 0;
 
-        $this->userinfo = $USERINFO;
         $this->server = new XmlRpcServer(false,false,true);
-
     }
 
-    function tearDown()
-    {
-        global $USERINFO;
-        $USERINFO = $this->userinfo;
-    }
 
     function testDateFormat()
     {
-
         $pageName = ":wiki:dokuwiki";
         $file = wikiFN($pageName);
         $timestamp = filemtime($file);

--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -33,7 +33,7 @@ class XmlRpcServerTest extends DokuWikiTest
         $pageName = ":wiki:dokuwiki";
         $file = wikiFN($pageName);
         $timestamp = filemtime($file);
-        $ixrModifiedTime = (new DateTime('@' . $timestamp))->format(IXR_Date::XMLRPC_ISO8601);
+        $ixrModifiedTime = (new DateTime('@' . $timestamp))->format(DATE_ISO8601);
 
         $request = <<<EOD
 <?xml version="1.0"?>

--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -63,7 +63,7 @@ EOD;
 </methodResponse>
 EOD;
 
-        $this->server->serve($request, true);
+        $this->server->serve($request);
         $this->assertEquals(trim($expected), trim($this->server->output));
     }
 }

--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -1,0 +1,79 @@
+<?php
+
+use dokuwiki\Remote\XmlRpcServer;
+
+
+class XmlRpcServerTest extends DokuWikiTest
+{
+
+    protected $userinfo;
+    protected $server;
+
+
+    function setUp()
+    {
+        parent::setUp();
+        global $conf;
+        global $USERINFO;
+
+        parent::setUp();
+
+        // mock plugin controller to return our test plugins
+
+
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 0;
+
+        $this->userinfo = $USERINFO;
+        $this->server = new XmlRpcServer(false,false,true);
+
+    }
+
+    function tearDown()
+    {
+        global $USERINFO;
+        $USERINFO = $this->userinfo;
+    }
+
+    function testDateFormat()
+    {
+
+        $pageName = ":wiki:dokuwiki";
+        $file = wikiFN($pageName);
+        $timestamp = filemtime($file);
+        $ixrModifiedTime = (new DateTime('@' . $timestamp))->format(IXR_Date::XMLRPC_ISO8601);
+
+        $request = <<<EOD
+<?xml version="1.0"?>
+   <methodCall>
+     <methodName>wiki.getPageInfo</methodName>
+     		<param> 
+			<value>
+				<string>$pageName</string>
+			</value>
+		</param>
+   </methodCall>
+EOD;
+        $expected = <<<EOD
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <struct>
+  <member><name>name</name><value><string>wiki:dokuwiki</string></value></member>
+  <member><name>lastModified</name><value><dateTime.iso8601>$ixrModifiedTime</dateTime.iso8601></value></member>
+  <member><name>author</name><value><string></string></value></member>
+  <member><name>version</name><value><int>$timestamp</int></value></member>
+</struct>
+      </value>
+    </param>
+  </params>
+</methodResponse>
+EOD;
+
+        $response = $this->server->serve($request, true);
+        $this->assertEquals(trim($expected), trim($response));
+        print($ixrModifiedTime);
+    }
+}

--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -2,11 +2,18 @@
 
 use dokuwiki\Remote\XmlRpcServer;
 
+class XmlRpcServerTestWrapper extends XmlRpcServer
+{
+    public $output;
+
+    public function output($xml) {
+        $this->output = $xml;
+    }
+}
 
 class XmlRpcServerTest extends DokuWikiTest
 {
     protected $server;
-
 
     function setUp()
     {
@@ -17,7 +24,7 @@ class XmlRpcServerTest extends DokuWikiTest
         $conf['remoteuser'] = '';
         $conf['useacl'] = 0;
 
-        $this->server = new XmlRpcServer(false,false,true);
+        $this->server = new XmlRpcServerTestWrapper(true);
     }
 
 
@@ -56,7 +63,7 @@ EOD;
 </methodResponse>
 EOD;
 
-        $response = $this->server->serve($request, true);
-        $this->assertEquals(trim($expected), trim($response));
+        $this->server->serve($request, true);
+        $this->assertEquals(trim($expected), trim($this->server->output));
     }
 }

--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -74,6 +74,5 @@ EOD;
 
         $response = $this->server->serve($request, true);
         $this->assertEquals(trim($expected), trim($response));
-        print($ixrModifiedTime);
     }
 }

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -867,7 +867,7 @@ class IXR_Date {
      * @return string
      */
     public function getIso() {
-        return $this->date->format(DateTime::ISO8601);
+        return $this->date->format(self::XMLRPC_ISO8601);
     }
 
     /**

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -406,7 +406,7 @@ class IXR_Server {
     /**
      * @param bool|string $data
      */
-    function serve($data = false) {
+    function serve($data = false, $test = false) {
         if(!$data) {
 
             $postData = trim(http_get_raw_post_data());
@@ -448,7 +448,11 @@ class IXR_Server {
 
 EOD;
         // Send it
-        $this->output($xml);
+        if ($test) {
+            return $xml;
+        } else {
+            $this->output($xml);
+        }
     }
 
     /**
@@ -821,6 +825,8 @@ EOD;
  * @since 1.5
  */
 class IXR_Date {
+
+    const XMLRPC_ISO8601 = 'Ymd\TH:i:s';
 
     /** @var DateTime */
     protected $date;

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -822,8 +822,6 @@ EOD;
  */
 class IXR_Date {
 
-    const XMLRPC_ISO8601 = 'Ymd\TH:i:s';
-
     /** @var DateTime */
     protected $date;
 
@@ -863,7 +861,7 @@ class IXR_Date {
      * @return string
      */
     public function getIso() {
-        return $this->date->format(self::XMLRPC_ISO8601);
+        return $this->date->format(DateTime::ISO8601);
     }
 
     /**

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -406,7 +406,7 @@ class IXR_Server {
     /**
      * @param bool|string $data
      */
-    function serve($data = false, $test = false) {
+    function serve($data = false) {
         if(!$data) {
 
             $postData = trim(http_get_raw_post_data());
@@ -448,11 +448,7 @@ class IXR_Server {
 
 EOD;
         // Send it
-        if ($test) {
-            return $xml;
-        } else {
-            $this->output($xml);
-        }
+        $this->output($xml);
     }
 
     /**

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -12,12 +12,12 @@ class XmlRpcServer extends \IXR_Server
     /**
      * Constructor. Register methods and run Server
      */
-    public function __construct($callbacks = false , $data=false, $wait=false)
+    public function __construct($wait=false)
     {
         $this->remote = new Api();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));
-        parent::__construct($callbacks, $data, $wait);
+        parent::__construct(false, false, $wait);
     }
 
     /**

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -12,12 +12,12 @@ class XmlRpcServer extends \IXR_Server
     /**
      * Constructor. Register methods and run Server
      */
-    public function __construct()
+    public function __construct($callbacks = false , $data=false, $wait=false)
     {
         $this->remote = new Api();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));
-        parent::__construct();
+        parent::__construct($callbacks, $data, $wait);
     }
 
     /**


### PR DESCRIPTION
Fix the issue that incorrect date format is used in XMLRPC responses (issue #2883).