### PR TITLE
Fix issue #2883

### DIFF
--- a/_test/tests/inc/XmlRpcServer.test.php
+++ b/_test/tests/inc/XmlRpcServer.test.php
@@ -1,0 +1,69 @@
+<?php
+
+use dokuwiki\Remote\XmlRpcServer;
+
+class XmlRpcServerTestWrapper extends XmlRpcServer
+{
+    public $output;
+
+    public function output($xml) {
+        $this->output = $xml;
+    }
+}
+
+class XmlRpcServerTest extends DokuWikiTest
+{
+    protected $server;
+
+    function setUp()
+    {
+        parent::setUp();
+        global $conf;
+
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $conf['useacl'] = 0;
+
+        $this->server = new XmlRpcServerTestWrapper(true);
+    }
+
+
+    function testDateFormat()
+    {
+        $pageName = ":wiki:dokuwiki";
+        $file = wikiFN($pageName);
+        $timestamp = filemtime($file);
+        $ixrModifiedTime = (new DateTime('@' . $timestamp))->format(IXR_Date::XMLRPC_ISO8601);
+
+        $request = <<<EOD
+<?xml version="1.0"?>
+   <methodCall>
+     <methodName>wiki.getPageInfo</methodName>
+     		<param> 
+			<value>
+				<string>$pageName</string>
+			</value>
+		</param>
+   </methodCall>
+EOD;
+        $expected = <<<EOD
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <struct>
+  <member><name>name</name><value><string>wiki:dokuwiki</string></value></member>
+  <member><name>lastModified</name><value><dateTime.iso8601>$ixrModifiedTime</dateTime.iso8601></value></member>
+  <member><name>author</name><value><string></string></value></member>
+  <member><name>version</name><value><int>$timestamp</int></value></member>
+</struct>
+      </value>
+    </param>
+  </params>
+</methodResponse>
+EOD;
+
+        $this->server->serve($request);
+        $this->assertEquals(trim($expected), trim($this->server->output));
+    }
+}

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -862,7 +862,7 @@ class IXR_Date {
      * @return string
      */
     public function getIso() {
-	      return $this->date->format(DateTime::ISO8601);
+	      return $this->date->format(self::XMLRPC_ISO8601);
     }
 
     /**

--- a/inc/IXR_Library.php
+++ b/inc/IXR_Library.php
@@ -822,6 +822,7 @@ EOD;
  */
 class IXR_Date {
 
+    const XMLRPC_ISO8601 = "Ymd\TH:i:sO" ;
     /** @var DateTime */
     protected $date;
 
@@ -861,7 +862,7 @@ class IXR_Date {
      * @return string
      */
     public function getIso() {
-        return $this->date->format(DateTime::ISO8601);
+	      return $this->date->format(DateTime::ISO8601);
     }
 
     /**

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -12,12 +12,12 @@ class XmlRpcServer extends \IXR_Server
     /**
      * Constructor. Register methods and run Server
      */
-    public function __construct()
+    public function __construct($wait=false)
     {
         $this->remote = new Api();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));
-        parent::__construct();
+        parent::__construct(false, false, $wait);
     }
 
     /**


### PR DESCRIPTION
Fix the issue that incorrect date format is used in XMLRPC responses (issue #2883).
This is the cleaned up result of the discussion at PR #2885. 