### PR TITLE
Include rev_id in new revision link in notification email

### DIFF
--- a/inc/Subscriptions/MediaSubscriptionSender.php
+++ b/inc/Subscriptions/MediaSubscriptionSender.php
@@ -16,8 +16,9 @@ class MediaSubscriptionSender extends SubscriptionSender
      * @param string   $template        Mail template ('uploadmail', ...)
      * @param string   $id              Media file for which the notification is
      * @param int|bool $rev             Old revision if any
+     * @param int|bool $current_rev     New revision if any
      */
-    public function sendMediaDiff($subscriber_mail, $template, $id, $rev = false)
+    public function sendMediaDiff($subscriber_mail, $template, $id, $rev = false, $current_rev = false)
     {
         global $conf;
 
@@ -26,7 +27,7 @@ class MediaSubscriptionSender extends SubscriptionSender
 
         $trep = [
             'MIME' => $mime,
-            'MEDIA' => ml($id, '', true, '&', true),
+            'MEDIA' => ml($id, $current_rev?('rev='.$current_rev):'', true, '&', true),
             'SIZE' => filesize_h(filesize($file)),
         ];
 

--- a/inc/Subscriptions/PageSubscriptionSender.php
+++ b/inc/Subscriptions/PageSubscriptionSender.php
@@ -19,17 +19,18 @@ class PageSubscriptionSender extends SubscriptionSender
      * @param string   $id              Page for which the notification is
      * @param int|null $rev             Old revision if any
      * @param string   $summary         Change summary if any
+     * @param int|null $current_rev     New revision if any
      *
      * @return bool                     true if successfully sent
      */
-    public function sendPageDiff($subscriber_mail, $template, $id, $rev = null, $summary = '')
+    public function sendPageDiff($subscriber_mail, $template, $id, $rev = null, $summary = '', $current_rev = null)
     {
         global $DIFF_INLINESTYLES;
 
         // prepare replacements (keys not set in hrep will be taken from trep)
         $trep = [
             'PAGE' => $id,
-            'NEWPAGE' => wl($id, '', true, '&'),
+            'NEWPAGE' => wl($id, $current_rev?('rev='.$current_rev):'', true, '&'),
             'SUMMARY' => $summary,
             'SUBSCRIBE' => wl($id, ['do' => 'subscribe'], true, '&'),
         ];

--- a/inc/common.php
+++ b/inc/common.php
@@ -1425,8 +1425,8 @@ function saveWikiText($id, $text, $summary, $minor = false) {
     );
 
     // send notify mails
-    notify($svdta['id'], 'admin', $svdta['oldRevision'], $svdta['summary'], $minor);
-    notify($svdta['id'], 'subscribers', $svdta['oldRevision'], $svdta['summary'], $minor);
+    notify($svdta['id'], 'admin', $svdta['oldRevision'], $svdta['summary'], $minor, $svdta['newRevision']);
+    notify($svdta['id'], 'subscribers', $svdta['oldRevision'], $svdta['summary'], $minor, $svdta['newRevision']);
 
     // update the purgefile (timestamp of the last time anything within the wiki was changed)
     io_saveFile($conf['cachedir'].'/purgefile', time());
@@ -1468,11 +1468,12 @@ function saveOldRevision($id) {
  * @param string     $summary  What changed
  * @param boolean    $minor    Is this a minor edit?
  * @param string[]   $replace  Additional string substitutions, @KEY@ to be replaced by value
+ * @param int|string $current_rev  New page revision
  * @return bool
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  */
-function notify($id, $who, $rev = '', $summary = '', $minor = false, $replace = array()) {
+function notify($id, $who, $rev = '', $summary = '', $minor = false, $replace = array(), $current_rev = false) {
     global $conf;
     /* @var Input $INPUT */
     global $INPUT;
@@ -1499,7 +1500,7 @@ function notify($id, $who, $rev = '', $summary = '', $minor = false, $replace = 
 
     // prepare content
     $subscription = new PageSubscriptionSender();
-    return $subscription->sendPageDiff($to, $tpl, $id, $rev, $summary);
+    return $subscription->sendPageDiff($to, $tpl, $id, $rev, $summary, $current_rev);
 }
 
 /**

--- a/inc/lang/en/mailtext.txt
+++ b/inc/lang/en/mailtext.txt
@@ -9,4 +9,7 @@ New Revision: @NEWPAGE@
 Edit Summary: @SUMMARY@
 User        : @USER@
 
+There may be newer changes after this revision. If this
+happens, a message will be shown on the top of the rev page.
+
 @DIFF@

--- a/inc/lang/en/subscr_single.txt
+++ b/inc/lang/en/subscr_single.txt
@@ -13,6 +13,9 @@ Edit Summary: @SUMMARY@
 Old Revision: @OLDPAGE@
 New Revision: @NEWPAGE@
 
+There may be newer changes after this revision. If this
+happens, a message will be shown on the top of the rev page.
+
 To cancel the page notifications, log into the wiki at
 @DOKUWIKIURL@ then visit
 @SUBSCRIBE@

--- a/inc/media.php
+++ b/inc/media.php
@@ -544,7 +544,7 @@ function media_upload_finish($fn_tmp, $fn, $id, $imime, $overwrite, $move = 'mov
         // (Should normally chmod to $conf['fperm'] only if $conf['fperm'] is set.)
         chmod($fn, $conf['fmode']);
         msg($lang['uploadsucc'],1);
-        media_notify($id,$fn,$imime,$old);
+        media_notify($id,$fn,$imime,$old,$new);
         // add a log entry to the media changelog
         $filesize_new = filesize($fn);
         $sizechange = $filesize_new - $filesize_old;
@@ -672,12 +672,12 @@ function media_contentcheck($file,$mime){
  * @param bool|int $old_rev revision timestamp or false
  * @return bool
  */
-function media_notify($id,$file,$mime,$old_rev=false){
+function media_notify($id,$file,$mime,$old_rev=false,$current_rev=false){
     global $conf;
     if(empty($conf['notify'])) return false; //notify enabled?
 
     $subscription = new MediaSubscriptionSender();
-    return $subscription->sendMediaDiff($conf['notify'], 'uploadmail', $id, $old_rev);
+    return $subscription->sendMediaDiff($conf['notify'], 'uploadmail', $id, $old_rev, $current_rev);
 }
 
 /**


### PR DESCRIPTION
Older page versions have a "This is an old revision of the document!" message on the top of the page. By including rev_id, user can always see the version the email is referring to, while knowing if it is the latest version by looking at the wiki page.

A hint about this is also added to email text.

This PR was tagged "Needs Discussion" last year, but as I mentioned, there are three thumb-ups in [my comment about this change in the original issue](https://github.com/splitbrain/dokuwiki/issues/2196#issuecomment-355545417).

This fixes #2196, and this is a replacement of #2201.