### PR TITLE
getGoogleQuery: ignore if query includes a full URL

### DIFF
--- a/_test/tests/inc/common_getGoogleQuery.test.php
+++ b/_test/tests/inc/common_getGoogleQuery.test.php
@@ -1,0 +1,38 @@
+<?php
+
+class common_getGoogleQuery_test extends DokuWikiTest {
+
+    /**
+     * https://github.com/splitbrain/dokuwiki/issues/2848
+     */
+    function test_google_form(){
+        global $INPUT;
+        $_SERVER['HTTP_REFERER'] = 'https://www.google.com/url?q=https://www.dokuwiki.org/&sa=D&ust=a&usg=b';
+        $INPUT = new Input();
+        $this->assertEquals('', getGoogleQuery());
+    }
+
+    function test_google_url(){
+        global $INPUT;
+        $_SERVER['HTTP_REFERER'] = 'https://www.google.com/url?sa=t&source=web&rct=j&url=https://www.dokuwiki.org/&ved=a';
+        $INPUT = new Input();
+        $this->assertEquals('', getGoogleQuery());
+    }
+
+    function test_uncommon_url(){
+        global $INPUT;
+        $_SERVER['HTTP_REFERER'] = 'http://search.example.com/search?q=DokuWiki';
+        $INPUT = new Input();
+        $this->assertEquals('', getGoogleQuery());
+    }
+
+    function test_old_google(){
+        global $INPUT;
+        $_SERVER['HTTP_REFERER'] = 'https://www.google.com/search?newwindow=1&q=what%27s+my+referer';
+        $INPUT = new Input();
+        $this->assertEquals(array('what', 's', 'my', 'referer'), getGoogleQuery());
+    }
+
+}
+
+//Setup VIM: ex: et ts=4 :

--- a/inc/common.php
+++ b/inc/common.php
@@ -1540,6 +1540,8 @@ function getGoogleQuery() {
     $q = trim($q);
 
     if(!$q) return '';
+    // ignore if query includes a full URL
+    if(strpos($q, '//') !== false) return '';
     $q = preg_split('/[\s\'"\\\\`()\]\[?:!\.{};,#+*<>\\/]+/', $q, -1, PREG_SPLIT_NO_EMPTY);
     return $q;
 }

--- a/inc/common.php
+++ b/inc/common.php
@@ -1523,11 +1523,7 @@ function getGoogleQuery() {
     if(!preg_match('/(google|bing|yahoo|ask|duckduckgo|babylon|aol|yandex)/',$url['host'])) return '';
 
     $query = array();
-    // temporary workaround against PHP bug #49733
-    // see http://bugs.php.net/bug.php?id=49733
-    if(UTF8_MBSTRING) $enc = mb_internal_encoding();
     parse_str($url['query'], $query);
-    if(UTF8_MBSTRING) mb_internal_encoding($enc);
 
     $q = '';
     if(isset($query['q'])){


### PR DESCRIPTION
We don't want to split the URL to highlight the "query", especially when q is the URL of the page itself - e.g. Google Form's redirect https://www.google.com/url

This will also ignore queries like `syntax site:https://www.dokuwiki.org` but it should be fine. Just don't want to use a full parser here.

This fixes #2848. I also added tests and removed a legacy workaround for PHP 5.3 in the function.