### PR TITLE
clientIP: add trustedproxy, return first untrusted IP instead of the last one

### DIFF
--- a/_test/tests/inc/common_clientip.test.php
+++ b/_test/tests/inc/common_clientip.test.php
@@ -197,7 +197,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8,<?php set_time_limit(0);echo \'my_delim\';passthru(\',123.123.123.123,\');die;?>';
-        $out = '8.8.8.8,123.123.123.123';
+        $out = '127.0.0.1,8.8.8.8,123.123.123.123';
         $this->assertEquals($out, clientIP());
     }
 

--- a/_test/tests/inc/common_clientip.test.php
+++ b/_test/tests/inc/common_clientip.test.php
@@ -2,12 +2,19 @@
 
 class common_clientIP_test extends DokuWikiTest {
 
+    function setup(){
+        parent::setup();
+
+        global $conf;
+        $conf['trustedproxy'] = '^(::1|[fF][eE]80:|127\.|10\.|192\.168\.|172\.((1[6-9])|(2[0-9])|(3[0-1]))\.)';
+    }
+
     function test_simple_all(){
         $_SERVER['REMOTE_ADDR']          = '123.123.123.123';
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_proxy1_all(){
@@ -15,7 +22,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '77.77.77.77';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '';
         $out = '123.123.123.123,77.77.77.77';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_proxy2_all(){
@@ -23,7 +30,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77';
         $out = '123.123.123.123,77.77.77.77';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_proxyhops_all(){
@@ -31,7 +38,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77,66.66.66.66';
         $out = '123.123.123.123,77.77.77.77,66.66.66.66';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_simple_single(){
@@ -39,31 +46,63 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_proxy1_single(){
         $_SERVER['REMOTE_ADDR']          = '123.123.123.123';
         $_SERVER['HTTP_X_REAL_IP']       = '77.77.77.77';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '';
-        $out = '77.77.77.77';
-        $this->assertEquals(clientIP(true),$out);
+        $out = '123.123.123.123';
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_proxy2_single(){
         $_SERVER['REMOTE_ADDR']          = '123.123.123.123';
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77';
-        $out = '77.77.77.77';
-        $this->assertEquals(clientIP(true),$out);
+        $out = '123.123.123.123';
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_proxyhops_single(){
         $_SERVER['REMOTE_ADDR']          = '123.123.123.123';
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77,66.66.66.66';
+        $out = '123.123.123.123';
+        $this->assertEquals($out, clientIP(true));
+    }
+
+    function test_proxy1_local_single(){
+        $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+        $_SERVER['HTTP_X_REAL_IP']       = '77.77.77.77';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '';
+        $out = '77.77.77.77';
+        $this->assertEquals($out, clientIP(true));
+    }
+
+    function test_proxy2_local_single(){
+        $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+        $_SERVER['HTTP_X_REAL_IP']       = '';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77';
+        $out = '77.77.77.77';
+        $this->assertEquals($out, clientIP(true));
+    }
+
+    function test_proxyhops1_local_single(){
+        $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+        $_SERVER['HTTP_X_REAL_IP']       = '';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '77.77.77.77,66.66.66.66';
+        $out = '77.77.77.77';
+        $this->assertEquals($out, clientIP(true));
+    }
+
+    function test_proxyhops2_local_single(){
+        $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+        $_SERVER['HTTP_X_REAL_IP']       = '';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1,66.66.66.66';
         $out = '66.66.66.66';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_local_all(){
@@ -71,7 +110,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1';
         $out = '123.123.123.123,127.0.0.1';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_local1_single(){
@@ -79,7 +118,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_local2_single(){
@@ -87,7 +126,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '123.123.123.123';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_local3_single(){
@@ -95,7 +134,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1,10.0.0.1,192.168.0.2,172.17.1.1,172.21.1.1,172.31.1.1';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_local4_single(){
@@ -103,7 +142,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.0.5';
         $out = '192.168.0.5';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_garbage_all(){
@@ -111,7 +150,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = 'some garbage, or something, 222';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_garbage_single(){
@@ -119,7 +158,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = 'some garbage, or something, 222';
         $out = '123.123.123.123';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_garbageonly_all(){
@@ -127,7 +166,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = 'some garbage, or something, 222';
         $out = '0.0.0.0';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
     }
 
     function test_garbageonly_single(){
@@ -135,7 +174,7 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = 'some garbage, or something, 222';
         $out = '0.0.0.0';
-        $this->assertEquals(clientIP(true),$out);
+        $this->assertEquals($out, clientIP(true));
     }
 
     function test_malicious(){
@@ -143,7 +182,23 @@ class common_clientIP_test extends DokuWikiTest {
         $_SERVER['HTTP_X_REAL_IP']       = '';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '<?php set_time_limit(0);echo \'my_delim\';passthru(123.123.123.123);die;?>';
         $out = '0.0.0.0';
-        $this->assertEquals(clientIP(),$out);
+        $this->assertEquals($out, clientIP());
+    }
+
+    function test_malicious_with_remote_addr(){
+        $_SERVER['REMOTE_ADDR']          = '8.8.8.8';
+        $_SERVER['HTTP_X_REAL_IP']       = '';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '<?php set_time_limit(0);echo \'my_delim\';passthru(\',123.123.123.123,\');die;?>';
+        $out = '8.8.8.8';
+        $this->assertEquals($out, clientIP(true));
+    }
+
+    function test_proxied_malicious_with_remote_addr(){
+        $_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+        $_SERVER['HTTP_X_REAL_IP']       = '';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8,<?php set_time_limit(0);echo \'my_delim\';passthru(\',123.123.123.123,\');die;?>';
+        $out = '8.8.8.8,123.123.123.123';
+        $this->assertEquals($out, clientIP());
     }
 
 }

--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -158,6 +158,9 @@ $conf['renderer_xhtml'] = 'xhtml';       //renderer to use for main page generat
 $conf['readdircache'] = 0;               //time cache in second for the readdir operation, 0 to deactivate.
 $conf['search_nslimit'] = 0;             //limit the search to the current X namespaces
 $conf['search_fragment'] = 'exact';      //specify the default fragment search behavior
+$conf['trustedproxy'] = '^(::1|[fF][eE]80:|127\.|10\.|192\.168\.|172\.((1[6-9])|(2[0-9])|(3[0-1]))\.)';
+                                         //Regexp of trusted proxy address when reading IP using HTTP header
+                                         //  if blank, do not trust any proxy (including local IP)
 
 /* Network Settings */
 $conf['dnslookups'] = 1;                 //disable to disallow IP to hostname lookups

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -185,6 +185,7 @@ $lang['search_fragment_o_exact'] = 'exact';
 $lang['search_fragment_o_starts_with'] = 'starts with';
 $lang['search_fragment_o_ends_with'] = 'ends with';
 $lang['search_fragment_o_contains'] = 'contains';
+$lang['trustedproxy'] = 'Regexp of trusted proxy address when reading IP using HTTP header';
 
 /* Network Options */
 $lang['dnslookups'] = 'DokuWiki will lookup hostnames for remote IP addresses of users editing pages. If you have a slow or non working DNS server or don\'t want this feature, disable this option';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -227,6 +227,7 @@ $meta['renderer_xhtml'] = array('renderer','_format' => 'xhtml','_choices' => ar
 $meta['readdircache'] = array('numeric');
 $meta['search_nslimit'] = array('numeric', '_min' => 0);
 $meta['search_fragment'] = array('multichoice','_choices' => array('exact', 'starts_with', 'ends_with', 'contains'),);
+$meta['trustedproxy'] = array('regex');
 
 $meta['_network']    = array('fieldset');
 $meta['dnslookups']  = array('onoff');
@@ -237,4 +238,3 @@ $meta['proxy____user'] = array('string');
 $meta['proxy____pass'] = array('password','_code' => 'base64');
 $meta['proxy____ssl']  = array('onoff');
 $meta['proxy____except'] = array('string');
-


### PR DESCRIPTION
This fixes #2828, where malicious clients passed in customized HTTP header to keep its IP address off records.

This is inspired by Sympony's Request::setTrustedProxies, but I don't want to implement everything including IP CIDR matching (IPv4 + IPv6), so I decided to reuse the local IP checker in place powered by regexp. Now admins can customize this "local" (trusted) proxy list using $conf['trustedproxy'], and by default it will allow any local IPs.

If in the future there is a need to implement array-based CIDR matching, $conf['trustedproxies'] can be used for the new config name.