### PR TITLE
Update the checkbox text displayed when Media Revisions is enabled

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1864,8 +1864,8 @@ function media_uploadform($ns, $auth, $fullscreen = false){
     if($auth >= $auth_ow){
         $form->addElement(form_makeOpenTag('p'));
         $attrs = array();
-        if ($update) $attrs['checked'] = 'checked';
-        $form->addElement(form_makeCheckboxField('ow', 1, $lang['txt_overwrt'], 'dw__ow', 'check', $attrs));
+        if ($update || $conf['mediarevisions']) $attrs['checked'] = 'checked';
+        $form->addElement(form_makeCheckboxField('ow', 1, ($conf['mediarevisions'] ? $lang['media_update'] : $lang['txt_overwrt']), 'dw__ow', 'check', $attrs));
         $form->addElement(form_makeCloseTag('p'));
     }
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -1424,8 +1424,6 @@ function tpl_mediaFileDetails($image, $rev) {
     /** @var Input $INPUT */
     global $INPUT;
 
-
-
     $removed = (
         !file_exists(mediaFN($image)) &&
         file_exists(mediaMetaFN($image, '.changes')) &&

--- a/inc/template.php
+++ b/inc/template.php
@@ -341,6 +341,7 @@ function tpl_metaheaders($alt = true) {
         $script .= "var SIG='".toolbar_signature()."';";
     }
     jsinfo();
+    $JSINFO['conf']['mediarevisions'] = $conf['mediarevisions'];
     $script .= 'var JSINFO = ' . json_encode($JSINFO).';';
     $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
 
@@ -1422,6 +1423,8 @@ function tpl_mediaFileDetails($image, $rev) {
     global $conf, $DEL, $lang;
     /** @var Input $INPUT */
     global $INPUT;
+
+
 
     $removed = (
         !file_exists(mediaFN($image)) &&

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -115,6 +115,7 @@ function js_out(){
     if(!empty($templatestrings)) {
         $lang['js']['template'] = $templatestrings;
     }
+    $lang['js']['media_update'] = $lang['media_update'];
     echo 'LANG = '.json_encode($lang['js']).";\n";
 
     // load toolbar

--- a/lib/scripts/fileuploaderextended.js
+++ b/lib/scripts/fileuploaderextended.js
@@ -83,7 +83,7 @@ qq.FileUploaderExtended = function(o){
             '<ul class="qq-upload-list"></ul>' +
             '<div class="qq-action-container">' +
             '  <button class="qq-upload-action" type="submit" id="mediamanager__upload_button">' + LANG.media_upload_btn + '</button>' +
-            '  <label class="qq-overwrite-check"><input type="checkbox" value="1" name="ow" class="dw__ow"> <span>' + LANG.media_overwrt + '</span></label>' +
+            '  <label class="qq-overwrite-check"><input type="checkbox" value="1" name="ow" class="dw__ow"' + (JSINFO.conf.mediarevisions ? ' checked' : '') + '> <span>' + (JSINFO.conf.mediarevisions ? LANG.media_update : LANG.media_overwrt) + '</span></label>' +
             '</div>' +
             '</div>',
 


### PR DESCRIPTION
Updated the checkbox text from 'Overwrite existing files' to
'Upload new version' and set checkbox to checked by default when
Media Revisions is enabled.

Behavior is the same when using HTML or JavaScript.

For the JavaScript behavior to function $conf['mediarevisions']
has been made available as $JSINFO['conf']['mediarevisions']
however there may be a more suitable location.

$lang['js']['media_update'] is being populated in lib/exe/js.php
from $lang['media_update'] however it may be better going forward
to add this value to the various lang.php files.

Fixes #2669 