### PR TITLE
prevent metadata rendering prior to DOKUWIKI_STARTED event

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -254,7 +254,7 @@ function pageinfo() {
     $info['lastmod']  = @filemtime($info['filepath']);
 
     //load page meta data
-    $info['meta'] = p_get_metadata($ID);
+    $info['meta'] = p_get_metadata($ID, '', METADATA_DONT_RENDER);
 
     //who's the editor
     $pagelog = new PageChangeLog($ID, 1024);


### PR DESCRIPTION
`pageinfo()` is called from doku.php file and will load page metadata into $INFO. If the page is really newer or the metadata doesn't exist, then metadata will rendered even before DOKUWIKI_STARTED event. The relevent event handlers implemented by any plugins will not not work as expected.