### PR TITLE
Remove X-UA-Compatible header in DokuWiki template

### DIFF
--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -9,7 +9,6 @@
  */
 
 if (!defined('DOKU_INC')) die(); /* must be run from within DokuWiki */
-header('X-UA-Compatible: IE=edge,chrome=1');
 
 $hasSidebar = page_findnearest($conf['sidebar']);
 $showSidebar = $hasSidebar && ($ACT=='show');


### PR DESCRIPTION
Nowadays there is no need to specify such `X-UA-Compatible` header for these reasons:

1. `chrome=1` refers to the Chrome Frame, which has been retired in 2014 and is not used nor supported any more. See https://blog.chromium.org/2013/06/retiring-chrome-frame.html. Specifying "chrome=1" causes _the only error_ when validating a fresh DokuWiki instance through W3 validator (although this is a HTTP header).
2. `IE=edge` is the default document mode starting with IE 11 (and in Edge, of course). Therefore specifying document mode to EdgeHTML is obsolete. Moreover, starting with Windows 10 (2015/2016), document modes are deprecated. See https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/dn384051(v=vs.85).