### PR TITLE
Remove obsolete attributes at <script> tag

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -342,19 +342,19 @@ function tpl_metaheaders($alt = true) {
     }
     jsinfo();
     $script .= 'var JSINFO = ' . json_encode($JSINFO).';';
-    $head['script'][] = array('type'=> 'text/javascript', '_data'=> $script);
+    $head['script'][] = array('_data'=> $script);
 
     // load jquery
     $jquery = getCdnUrls();
     foreach($jquery as $src) {
         $head['script'][] = array(
-            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src
+            '_data' => '', 'src' => $src
         );
     }
 
     // load our javascript dispatcher
     $head['script'][] = array(
-        'type'=> 'text/javascript', 'charset'=> 'utf-8', '_data'=> '',
+        '_data'=> '',
         'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed
     );
 


### PR DESCRIPTION
Nowadays it is not necessary to specify `type `or `charset` attribute at `<script>` tag:

1. `type` attribute defaults to "application/javascript", so there is no need to specify that. The recent value "text/javascript" used in DokuWiki code is obsolete in favor of the default "application/javascript", as stated e.g. here: https://www.iana.org/assignments/media-types/media-types.xhtml#text
2. `charset` attribute of the `<script>` tag defaults to encoding be the same as the encoding of the script element's node document. As DokuWiki's default encoding is "utf-8", there is no need to specify this encoding in external resources. See: https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
3. both attributes cause unnecessary warning when passing the W3 validator.