### PR TITLE
Update license links to HTTPS

### DIFF
--- a/conf/license.php
+++ b/conf/license.php
@@ -7,30 +7,30 @@
 
 $license['cc-zero'] = array(
     'name' => 'CC0 1.0 Universal',
-    'url'  => 'http://creativecommons.org/publicdomain/zero/1.0/',
+    'url'  => 'https://creativecommons.org/publicdomain/zero/1.0/',
 );
 $license['publicdomain'] = array(
     'name' => 'Public Domain',
-    'url'  => 'http://creativecommons.org/licenses/publicdomain/',
+    'url'  => 'https://creativecommons.org/licenses/publicdomain/',
 );
 $license['cc-by'] = array(
     'name' => 'CC Attribution 4.0 International',
-    'url'  => 'http://creativecommons.org/licenses/by/4.0/',
+    'url'  => 'https://creativecommons.org/licenses/by/4.0/',
 );
 $license['cc-by-sa'] = array(
     'name' => 'CC Attribution-Share Alike 4.0 International',
-    'url'  => 'http://creativecommons.org/licenses/by-sa/4.0/',
+    'url'  => 'https://creativecommons.org/licenses/by-sa/4.0/',
 );
 $license['gnufdl'] = array(
     'name' => 'GNU Free Documentation License 1.3',
-    'url'  => 'http://www.gnu.org/licenses/fdl-1.3.html',
+    'url'  => 'https://www.gnu.org/licenses/fdl-1.3.html',
 );
 $license['cc-by-nc'] = array(
     'name' => 'CC Attribution-Noncommercial 4.0 International',
-    'url'  => 'http://creativecommons.org/licenses/by-nc/4.0/',
+    'url'  => 'https://creativecommons.org/licenses/by-nc/4.0/',
 );
 $license['cc-by-nc-sa'] = array(
     'name' => 'CC Attribution-Noncommercial-Share Alike 4.0 International',
-    'url'  => 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+    'url'  => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
 );
 


### PR DESCRIPTION
This is a very small PR. But if the website provides a secure connection, it is better not to rely on correct permanent redirection (HTTP 301) from the insecure one, and provide a direct link to the secure web. Since these sites have been running their HTTPS versions in recent time, I am updating these links.