### PR TITLE
Fix tests on PHP 8.0 (nightly)

### DIFF
--- a/_test/tests/inc/common_basicinfo.test.php
+++ b/_test/tests/inc/common_basicinfo.test.php
@@ -1,11 +1,11 @@
 <?php
 
 class common_infofunctions_test extends DokuWikiTest {
- 
+
     function setup(){
         parent::setup();
 
-        global $USERINFO; 
+        global $USERINFO;
         $USERINFO = array(
            'pass' => '179ad45c6ce2cb97cf1029e212046e81',
            'name' => 'Arthur Dent',
@@ -15,7 +15,7 @@ class common_infofunctions_test extends DokuWikiTest {
         $_SERVER['REMOTE_USER'] = 'testuser';
         $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
     }
-    
+
     function _get_info() {
         global $USERINFO;
         $info = array (
@@ -27,7 +27,7 @@ class common_infofunctions_test extends DokuWikiTest {
           'ismobile' => false,
           'client' => 'testuser',
         );
-      
+
         return $info;
     }
 
@@ -36,14 +36,15 @@ class common_infofunctions_test extends DokuWikiTest {
      * Other functions provide the values
      */
     function test_basicinfo(){
+        global $ID;
         // test with REMOTE_USER set and the user an admin user
         $info = $this->_get_info();
         $this->assertEquals(basicinfo($ID,true),$info);
-        
-        // with $httpclient parameter set to false 
+
+        // with $httpclient parameter set to false
         unset($info['ismobile']);
         $this->assertEquals(basicinfo($ID,false),$info);
-        
+
         // with anonymous user
         unset($_SERVER['REMOTE_USER']);
         global $USERINFO; $USERINFO = array();
@@ -58,7 +59,7 @@ class common_infofunctions_test extends DokuWikiTest {
         );
         $this->assertEquals(basicinfo($ID,true),$info);
     }
-    
+
 }
 
 //Setup VIM: ex: et ts=4 :

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -276,7 +276,7 @@ class Ajax {
         if(isset($_FILES['qqfile']['error']) && $_FILES['qqfile']['error']) unset($_FILES['qqfile']);
 
         $res = false;
-        if($_FILES['qqfile']['tmp_name']) $res = media_upload($NS, $AUTH, $_FILES['qqfile']);
+        if(isset($_FILES['qqfile']['tmp_name'])) $res = media_upload($NS, $AUTH, $_FILES['qqfile']);
         if($INPUT->get->has('qqfile')) $res = media_upload_xhr($NS, $AUTH);
 
         if($res) {

--- a/inc/Ajax.php
+++ b/inc/Ajax.php
@@ -257,7 +257,7 @@ class Ajax {
         global $NS, $MSG, $INPUT;
 
         $id = '';
-        if($_FILES['qqfile']['tmp_name']) {
+        if(isset($_FILES['qqfile']['tmp_name'])) {
             $id = $INPUT->post->str('mediaid', $_FILES['qqfile']['name']);
         } elseif($INPUT->get->has('qqfile')) {
             $id = $INPUT->get->str('qqfile');
@@ -273,7 +273,7 @@ class Ajax {
             io_createNamespace("$ns:xxx", 'media');
         }
 
-        if($_FILES['qqfile']['error']) unset($_FILES['qqfile']);
+        if(isset($_FILES['qqfile']['error']) && $_FILES['qqfile']['error']) unset($_FILES['qqfile']);
 
         $res = false;
         if($_FILES['qqfile']['tmp_name']) $res = media_upload($NS, $AUTH, $_FILES['qqfile']);

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -644,8 +644,8 @@ class Mailer {
             'TITLE' => $conf['title'],
             'DOKUWIKIURL' => DOKU_URL,
             'USER' => $INPUT->server->str('REMOTE_USER'),
-            'NAME' => $INFO['userinfo'] ? $INFO['userinfo']['name'] : '',
-            'MAIL' => $INFO['userinfo'] ? $INFO['userinfo']['mail'] : ''
+            'NAME' => isset($INFO) ? $INFO['userinfo']['name'] : '',
+            'MAIL' => isset($INFO) ? $INFO['userinfo']['mail'] : ''
         );
         $signature = str_replace(
             '@DOKUWIKIURL@',

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -350,7 +350,7 @@ class Mailer {
      * addresses. Addresses must be separated by a comma. If the display
      * name includes a comma then it MUST be properly enclosed by '"' to
      * prevent spliting at the wrong point.
-     * 
+     *
      * Example:
      *   cc("föö <foo@bar.com>, me@somewhere.com","TBcc");
      *   to("foo, Dr." <foo@bar.com>, me@somewhere.com");
@@ -644,8 +644,8 @@ class Mailer {
             'TITLE' => $conf['title'],
             'DOKUWIKIURL' => DOKU_URL,
             'USER' => $INPUT->server->str('REMOTE_USER'),
-            'NAME' => $INFO['userinfo']['name'],
-            'MAIL' => $INFO['userinfo']['mail']
+            'NAME' => $INFO['userinfo'] ? $INFO['userinfo']['name'] : '',
+            'MAIL' => $INFO['userinfo'] ? $INFO['userinfo']['mail'] : ''
         );
         $signature = str_replace(
             '@DOKUWIKIURL@',

--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -635,6 +635,8 @@ class Mailer {
 
         $ip   = clientIP();
         $cip  = gethostsbyaddrs($ip);
+        $name = isset($INFO) ? $INFO['userinfo']['name'] : '';
+        $mail = isset($INFO) ? $INFO['userinfo']['mail'] : '';
 
         $this->replacements['text'] = array(
             'DATE' => dformat(),
@@ -644,8 +646,8 @@ class Mailer {
             'TITLE' => $conf['title'],
             'DOKUWIKIURL' => DOKU_URL,
             'USER' => $INPUT->server->str('REMOTE_USER'),
-            'NAME' => isset($INFO) ? $INFO['userinfo']['name'] : '',
-            'MAIL' => isset($INFO) ? $INFO['userinfo']['mail'] : ''
+            'NAME' => $name,
+            'MAIL' => $mail
         );
         $signature = str_replace(
             '@DOKUWIKIURL@',
@@ -662,9 +664,9 @@ class Mailer {
             'TITLE' => hsc($conf['title']),
             'DOKUWIKIURL' => '<a href="' . DOKU_URL . '">' . DOKU_URL . '</a>',
             'USER' => hsc($INPUT->server->str('REMOTE_USER')),
-            'NAME' => hsc($INFO['userinfo']['name']),
-            'MAIL' => '<a href="mailto:"' . hsc($INFO['userinfo']['mail']) . '">' .
-                hsc($INFO['userinfo']['mail']) . '</a>'
+            'NAME' => hsc($name),
+            'MAIL' => '<a href="mailto:"' . hsc($mail) . '">' .
+                hsc($mail) . '</a>'
         );
         $signature = $lang['email_signature_text'];
         if(!empty($lang['email_signature_html'])) {

--- a/inc/Menu/Item/AbstractItem.php
+++ b/inc/Menu/Item/AbstractItem.php
@@ -114,7 +114,7 @@ abstract class AbstractItem {
      * @return string
      */
     public function getLink() {
-        if($this->id[0] == '#') {
+        if($this->id && $this->id[0] == '#') {
             return $this->id;
         } else {
             return wl($this->id, $this->params, false, '&');

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -489,7 +489,7 @@ class ApiCore
         $data = array(
             'name' => $id,
             'lastModified' => $this->api->toDate($rev),
-            'author' => (($info['user']) ? $info['user'] : $info['ip']),
+            'author' => is_array($info) ? (($info['user']) ? $info['user'] : $info['ip']) : null,
             'version' => $rev
         );
 

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -154,10 +154,12 @@ function auth_loadACL() {
         // substitute group wildcard (its 1:m)
         if(strstr($line, '%GROUP%')){
             // if user is not logged in, grps is empty, no output will be added (i.e. skipped)
-            foreach((array) $USERINFO['grps'] as $grp){
-                $nid   = str_replace('%GROUP%',cleanID($grp),$id);
-                $nrest = str_replace('%GROUP%','@'.auth_nameencode($grp),$rest);
-                $out[] = "$nid\t$nrest";
+            if(isset($USERINFO['grps'])){
+                foreach((array) $USERINFO['grps'] as $grp){
+                    $nid   = str_replace('%GROUP%',cleanID($grp),$id);
+                    $nrest = str_replace('%GROUP%','@'.auth_nameencode($grp),$rest);
+                    $out[] = "$nid\t$nrest";
+                }
             }
         } else {
             $out[] = "$id\t$rest";

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -472,7 +472,7 @@ function auth_ismanager($user = null, $groups = null, $adminonly = false) {
         }
     }
     if(is_null($groups)) {
-        $groups = (array) $USERINFO['grps'];
+        $groups = $USERINFO ? (array) $USERINFO['grps'] : array();
     }
 
     // check superuser match
@@ -566,7 +566,7 @@ function auth_quickaclcheck($id) {
     global $INPUT;
     # if no ACL is used always return upload rights
     if(!$conf['useacl']) return AUTH_UPLOAD;
-    return auth_aclcheck($id, $INPUT->server->str('REMOTE_USER'), $USERINFO['grps']);
+    return auth_aclcheck($id, $INPUT->server->str('REMOTE_USER'), is_array($USERINFO) ? $USERINFO['grps'] : array());
 }
 
 /**

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -121,10 +121,10 @@ function addLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', $extr
             $meta['date']['created']  = $oldmeta['persistent']['date']['created'];
             $meta['date']['modified'] = $created; // use the files ctime here
             $meta['creator'] = $oldmeta['persistent']['creator'];
-            if ($user) $meta['contributor'][$user] = $INFO['userinfo']['name'];
+            if ($user) $meta['contributor'][$user] = $INFO['userinfo'] ? $INFO['userinfo']['name'] : null;
         } elseif (!$minor) {   // non-minor modification
             $meta['date']['modified'] = $date;
-            if ($user) $meta['contributor'][$user] = $INFO['userinfo']['name'];
+            if ($user) $meta['contributor'][$user] = $INFO['userinfo'] ? $INFO['userinfo']['name'] : null;
         }
         $meta['last_change'] = $logline;
         p_set_metadata($id, $meta);

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -113,7 +113,7 @@ function addLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', $extr
             // newly created
             $meta['date']['created'] = $created;
             if ($user){
-                $meta['creator'] = $INFO['userinfo']['name'];
+                $meta['creator'] = isset($INFO) ? $INFO['userinfo']['name'] : null;
                 $meta['user']    = $user;
             }
         } elseif (($wasCreated || $wasReverted) && !empty($oldmeta['persistent']['date']['created'])) {
@@ -121,10 +121,10 @@ function addLogEntry($date, $id, $type=DOKU_CHANGE_TYPE_EDIT, $summary='', $extr
             $meta['date']['created']  = $oldmeta['persistent']['date']['created'];
             $meta['date']['modified'] = $created; // use the files ctime here
             $meta['creator'] = $oldmeta['persistent']['creator'];
-            if ($user) $meta['contributor'][$user] = $INFO['userinfo'] ? $INFO['userinfo']['name'] : null;
+            if ($user) $meta['contributor'][$user] = isset($INFO) ? $INFO['userinfo']['name'] : null;
         } elseif (!$minor) {   // non-minor modification
             $meta['date']['modified'] = $date;
-            if ($user) $meta['contributor'][$user] = $INFO['userinfo'] ? $INFO['userinfo']['name'] : null;
+            if ($user) $meta['contributor'][$user] = isset($INFO) ? $INFO['userinfo']['name'] : null;
         }
         $meta['last_change'] = $logline;
         p_set_metadata($id, $meta);

--- a/inc/common.php
+++ b/inc/common.php
@@ -1189,8 +1189,8 @@ function parsePageTemplate(&$data) {
              \dokuwiki\Utf8\PhpString::ucwords($page),
              \dokuwiki\Utf8\PhpString::strtoupper($page),
              $INPUT->server->str('REMOTE_USER'),
-             $USERINFO['name'],
-             $USERINFO['mail'],
+             $USERINFO ? $USERINFO['name'] : '',
+             $USERINFO ? $USERINFO['mail'] : '',
              $conf['dformat'],
         ), $tpl
     );

--- a/inc/common.php
+++ b/inc/common.php
@@ -280,16 +280,23 @@ function pageinfo() {
         p_set_metadata($ID, array('last_change' => $revinfo));
     }
 
-    $info['ip']   = $revinfo['ip'];
-    $info['user'] = $revinfo['user'];
-    $info['sum']  = $revinfo['sum'];
-    // See also $INFO['meta']['last_change'] which is the most recent log line for page $ID.
-    // Use $INFO['meta']['last_change']['type']===DOKU_CHANGE_TYPE_MINOR_EDIT in place of $info['minor'].
+    if($revinfo !== false){
+        $info['ip']   = $revinfo['ip'];
+        $info['user'] = $revinfo['user'];
+        $info['sum']  = $revinfo['sum'];
+        // See also $INFO['meta']['last_change'] which is the most recent log line for page $ID.
+        // Use $INFO['meta']['last_change']['type']===DOKU_CHANGE_TYPE_MINOR_EDIT in place of $info['minor'].
 
-    if($revinfo['user']) {
-        $info['editor'] = $revinfo['user'];
-    } else {
-        $info['editor'] = $revinfo['ip'];
+        if($revinfo['user']) {
+            $info['editor'] = $revinfo['user'];
+        } else {
+            $info['editor'] = $revinfo['ip'];
+        }
+    }else{
+        $info['ip']     = null;
+        $info['user']   = null;
+        $info['sum']    = null;
+        $info['editor'] = null;
     }
 
     // draft

--- a/inc/common.php
+++ b/inc/common.php
@@ -319,7 +319,7 @@ function jsinfo() {
     }
     //export minimal info to JS, plugins can add more
     $JSINFO['id']                    = $ID;
-    $JSINFO['namespace']             = (string) $INFO['namespace'];
+    $JSINFO['namespace']             = isset($INFO) ? (string) $INFO['namespace'] : '';
     $JSINFO['ACT']                   = act_clean($ACT);
     $JSINFO['useHeadingNavigation']  = (int) useHeading('navigation');
     $JSINFO['useHeadingContent']     = (int) useHeading('content');

--- a/inc/html.php
+++ b/inc/html.php
@@ -108,7 +108,7 @@ function html_denied() {
 function html_secedit($text,$show=true){
     global $INFO;
 
-    if(!$INFO['writable'] || !$show || $INFO['rev']){
+    if((isset($INFO) && !$INFO['writable']) || !$show || (isset($INFO) && $INFO['rev'])){
         return preg_replace(SEC_EDIT_PATTERN,'',$text);
     }
 
@@ -964,7 +964,7 @@ function html_li_index($item){
 
     if($item['type'] == "f"){
         // scroll to the current item
-        if($item['id'] == $INFO['id'] && $ACT == 'index') {
+        if(isset($INFO) && $item['id'] == $INFO['id'] && $ACT == 'index') {
             $id = ' id="scroll__here"';
             $class = ' bounce';
         }

--- a/inc/parser/metadata.php
+++ b/inc/parser/metadata.php
@@ -64,7 +64,7 @@ class Doku_Renderer_metadata extends Doku_Renderer
         $this->headers = array();
 
         // external pages are missing create date
-        if (!$this->persistent['date']['created']) {
+        if (!isset($this->persistent['date']['created']) || !$this->persistent['date']['created']) {
             $this->persistent['date']['created'] = filectime(wikiFN($ID));
         }
         if (!isset($this->persistent['user'])) {

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -917,7 +917,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['pre']    = '';
         $link['suf']    = '';
         // highlight link to current page
-        if($id == $INFO['id']) {
+        if(isset($INFO) && $id == $INFO['id']) {
             $link['pre'] = '<span class="curid">';
             $link['suf'] = '</span>';
         }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1845,7 +1845,7 @@ function tpl_classes() {
         'mode_'.$ACT,
         'tpl_'.$conf['template'],
         $INPUT->server->bool('REMOTE_USER') ? 'loggedIn' : '',
-        $INFO['exists'] ? '' : 'notFound',
+        (isset($INFO) && $INFO['exists']) ? '' : 'notFound',
         ($ID == $conf['start']) ? 'home' : '',
     );
     return join(' ', $classes);

--- a/inc/template.php
+++ b/inc/template.php
@@ -263,7 +263,7 @@ function tpl_metaheaders($alt = true) {
             $head['link'][] = array(
                 'rel'  => 'alternate', 'type'=> 'application/rss+xml',
                 'title'=> $lang['currentns'],
-                'href' => DOKU_BASE.'feed.php?mode=list&ns='.$INFO['namespace']
+                'href' => DOKU_BASE.'feed.php?mode=list&ns='.(isset($INFO) ? $INFO['namespace'] : '')
             );
         }
         if(($ACT == 'show' || $ACT == 'search') && $INFO['writable']) {
@@ -336,7 +336,7 @@ function tpl_metaheaders($alt = true) {
         'href'=> DOKU_BASE.'lib/exe/css.php?t='.rawurlencode($conf['template']).'&tseed='.$tseed
     );
 
-    $script = "var NS='".$INFO['namespace']."';";
+    $script = "var NS='".(isset($INFO)?$INFO['namespace']:'')."';";
     if($conf['useacl'] && $INPUT->server->str('REMOTE_USER')) {
         $script .= "var SIG='".toolbar_signature()."';";
     }

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -418,7 +418,7 @@ function js_compress($s){
         // double quote strings
         if($ch == '"'){
             $j = 1;
-            while( $s[$i+$j] != '"' && ($i+$j < $slen)){
+            while( ($i+$j < $slen) && $s[$i+$j] != '"' ){
                 if( $s[$i+$j] == '\\' && ($s[$i+$j+1] == '"' || $s[$i+$j+1] == '\\') ){
                     $j += 2;
                 }else{
@@ -436,7 +436,7 @@ function js_compress($s){
         // single quote strings
         if($ch == "'"){
             $j = 1;
-            while( $s[$i+$j] != "'" && ($i+$j < $slen)){
+            while( ($i+$j < $slen) && $s[$i+$j] != "'" ){
                 if( $s[$i+$j] == '\\' && ($s[$i+$j+1] == "'" || $s[$i+$j+1] == '\\') ){
                     $j += 2;
                 }else{

--- a/lib/plugins/usermanager/_test/csv_import.test.php
+++ b/lib/plugins/usermanager/_test/csv_import.test.php
@@ -51,9 +51,12 @@ class plugin_usermanager_csv_import_test extends DokuWikiTest {
         $result = $this->usermanager->tryImport();
 
         $after_users = $auth->retrieveUsers();
+
+        $before_users = array_map('serialize', $before_users);
+        $after_users = array_map('serialize', $after_users);
         $import_count = count($after_users) - count($before_users);
-        $new_users = array_diff_key($after_users, $before_users);
-        $diff_users = array_diff_assoc($after_users, $before_users);
+        $new_users = array_map('unserialize', array_diff_key($after_users, $before_users));
+        $diff_users = array_map('unserialize', array_diff_assoc($after_users, $before_users));
 
         $expectedCount = count($expectedNewUsers);
 


### PR DESCRIPTION
Exceptions raised by PHP nightly are all "trying to access array offset on value of type bool/null". This patch adds checks in these situations.

Note: the only error in nightly now is supposed to be fixed in #2927:

> css_at_import_less_test::test_basic
> Array and string offset access syntax with curly braces is deprecated
> /home/travis/build/splitbrain/dokuwiki/vendor/marcusschwarz/lesserphp/lessc.inc.php:761