### PR TITLE
Fix value of @PAGE@ in templates for startpages

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1145,7 +1145,7 @@ function parsePageTemplate(&$data) {
 
     // replace placeholders
     $file = noNS($id);
-    $page = strtr($file, $conf['sepchar'], ' ');
+    $page = strtr(noNSorNS($id), $conf['sepchar'], ' ');
 
     $tpl = str_replace(
         array(


### PR DESCRIPTION
Use the name of the current namespace for template value @PAGE@ instead of "start" when creating the namespaces' startpage.