### PR TITLE
Fix value of @PAGE@ in templates for startpages

### DIFF
--- a/_test/tests/inc/common_pagetemplate.test.php
+++ b/_test/tests/inc/common_pagetemplate.test.php
@@ -11,5 +11,25 @@ class common_pagetemplate_test extends DokuWikiTest {
         );
         $this->assertEquals(parsePageTemplate($data), '"page id long" "Page id long" "Page Id Long" "PAGE ID LONG"');
     }
+
+    function test_start_root(){
+        global $conf;
+        $conf['startpage'] = 'start';
+        $data = [
+            'id' => 'start',
+            'tpl' => '@PAGE@',
+        ];
+        $this->assertEquals(parsePageTemplate($data), 'start');
+    }
+
+    function test_start_namespace(){
+        global $conf;
+        $conf['startpage'] = 'start';
+        $data = [
+            'id' => 'wiki:topic:start',
+            'tpl' => '@PAGE@',
+        ];
+        $this->assertEquals(parsePageTemplate($data), 'topic');
+    }
 }
 //Setup VIM: ex: et ts=4 :

--- a/inc/common.php
+++ b/inc/common.php
@@ -1145,7 +1145,7 @@ function parsePageTemplate(&$data) {
 
     // replace placeholders
     $file = noNS($id);
-    $page = strtr($file, $conf['sepchar'], ' ');
+    $page = strtr(noNSorNS($id), $conf['sepchar'], ' ');
 
     $tpl = str_replace(
         array(


### PR DESCRIPTION
Use the name of the current namespace for template value @page@ instead of "start" when creating the namespaces' startpage.