### PR TITLE
Fix AuthLDAP user to case-insensitive

### DIFF
--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -150,6 +150,7 @@ class auth_plugin_authldap extends DokuWiki_Auth_Plugin
      */
     public function getUserData($user, $requireGroups = true)
     {
+        $user = strtolower($user);
         return $this->fetchUserData($user);
     }
 


### PR DESCRIPTION
This fixes #2398.
LDAP is in general case-insensitive, so the complete handling of the username-string should also be. The string now gets converted to lowercase directly after getting it.