### PR TITLE
CDN antibrake

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -348,7 +348,7 @@ function tpl_metaheaders($alt = true) {
     $jquery = getCdnUrls();
     foreach($jquery as $src) {
         $head['script'][] = array(
-            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src
+            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src, 'defer' => 'defer'
         );
     }
 


### PR DESCRIPTION
GooglePage Speed Insights rank up 5-10 points
Otherwise, the browser render is waiting for loading and compiling big CDN script libraries

#2786 "async" bugged, so only "defer" in both places