### PR TITLE
Restore Doku_Parser backward compatibility

### DIFF
--- a/inc/Debug/DebugHelper.php
+++ b/inc/Debug/DebugHelper.php
@@ -84,6 +84,48 @@ class DebugHelper
     }
 
     /**
+     * Trigger a custom deprecation event
+     *
+     * Usually dbgDeprecatedFunction() or dbgDeprecatedProperty() should be used instead.
+     * This method is intended only for those situation where they are not applicable.
+     *
+     * @param string $alternative
+     * @param string $deprecatedThing
+     * @param string $caller
+     * @param string $file
+     * @param int    $line
+     * @param int    $callerOffset How many lines should be removed from the beginning of the backtrace
+     */
+    public static function dbgCustomDeprecationEvent(
+        $alternative,
+        $deprecatedThing,
+        $caller,
+        $file,
+        $line,
+        $callerOffset = 1
+    ) {
+        global $conf;
+        /** @var EventHandler $EVENT_HANDLER */
+        global $EVENT_HANDLER;
+        if (!$conf['allowdebug'] && !$EVENT_HANDLER->hasHandlerForEvent(self::INFO_DEPRECATION_LOG_EVENT)) {
+            // avoid any work if no one cares
+            return;
+        }
+
+        $backtrace = array_slice(debug_backtrace(), $callerOffset);
+
+        self::triggerDeprecationEvent(
+            $backtrace,
+            $alternative,
+            $deprecatedThing,
+            $caller,
+            $file,
+            $line
+        );
+
+    }
+
+    /**
      * @param array  $backtrace
      * @param string $alternative
      * @param string $deprecatedThing

--- a/inc/Parsing/Parser.php
+++ b/inc/Parsing/Parser.php
@@ -107,7 +107,21 @@ class Parser {
         // Normalize CRs and pad doc
         $doc = "\n" . str_replace("\r\n", "\n", $doc) . "\n";
         $this->lexer->parse($doc);
-        $this->handler->finalize();
+
+        if (!method_exists($this->handler, 'finalize')) {
+            /** @deprecated 2019-10 we have a legacy handler from a plugin, assume legacy _finalize exists */
+
+            \dokuwiki\Debug\DebugHelper::dbgCustomDeprecationEvent(
+                'finalize()',
+                get_class($this->handler) . '::_finalize()',
+                __METHOD__,
+                __FILE__,
+                __LINE__
+            );
+            $this->handler->_finalize();
+        } else {
+            $this->handler->finalize();
+        }
         return $this->handler->calls;
     }
 

--- a/inc/parser/parser.php
+++ b/inc/parser/parser.php
@@ -1,5 +1,7 @@
 <?php
 
+use dokuwiki\Debug\PropertyDeprecationHelper;
+
 /**
  * Define various types of modes used by the parser - they are used to
  * populate the list of modes another mode accepts
@@ -48,10 +50,50 @@ $PARSER_MODES = array(
  * @deprecated 2018-05-04
  */
 class Doku_Parser extends \dokuwiki\Parsing\Parser {
+    use PropertyDeprecationHelper {
+        __set as protected deprecationHelperMagicSet;
+        __get as protected deprecationHelperMagicGet;
+    }
 
     /** @inheritdoc */
-    public function __construct(Doku_Handler $handler) {
+    public function __construct(Doku_Handler $handler = null) {
         dbg_deprecated(\dokuwiki\Parsing\Parser::class);
+        $this->deprecatePublicProperty('modes', __CLASS__);
+        $this->deprecatePublicProperty('connected', __CLASS__);
+
+        if ($handler === null) {
+            $handler = new Doku_Handler();
+        }
+
         parent::__construct($handler);
+    }
+
+    public function __set($name, $value)
+    {
+
+        if ($name === 'Handler') {
+            $this->handler = $value;
+            return;
+        }
+
+        if ($name === 'Lexer') {
+            $this->lexer = $value;
+            return;
+        }
+
+        $this->deprecationHelperMagicSet($name, $value);
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'Handler') {
+            return $this->handler;
+        }
+
+        if ($name === 'Lexer') {
+            return $this->lexer;
+        }
+
+        return $this->deprecationHelperMagicGet($name);
     }
 }


### PR DESCRIPTION
#2358 brought many improvements to the DokuWiki code base, but unfortunately, we also broke backward compatibility in some places where we didn't intend it.

This PR should restore that backward compatibility for `Doku_Parser` and a bit how `Doku_Handler` is used by the parser. In particular, I hope that this PR makes the move plugin work again, see michitux/dokuwiki-plugin-move#176

It also adds another method to the Debug class. I'm not sure if that is the best way to do it and would appreciate feedback or thoughts (poke @splitbrain, @phy25  and others 🙂 )

Future remark: we are going to want to extract the `Doku_Handler` class into a new one that follows PSR-12. That was overlooked in the original PR.