### PR TITLE
GitHub workflow adjustments

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -19,4 +19,4 @@ jobs:
               run: wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
 
             - name: run PHP codesniffer
-              run: php phpcs.phar -v --standard=_test/phpcs.xml
+              run: php phpcs.phar -v --standard=_test/phpcs_MigrationAdjustments.xml

--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -1,6 +1,6 @@
 name: PHP Code Style
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
     phpcs:

--- a/_test/phpcs.xml
+++ b/_test/phpcs.xml
@@ -34,88 +34,13 @@
     <exclude-pattern>*/inc/cli.php</exclude-pattern>
     <exclude-pattern>*/inc/parser/*</exclude-pattern>
 
-    <!-- rules on top of PSR-2 -->
+    <!-- rules on top of PSR-12 -->
     <rule ref="PSR12">
-        <!-- the following rule is not in PSR-2 and breaks the guardian pattern -->
+        <!-- This rule breaks the single line guard pattern that we prefer to keep using -->
         <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
 
         <!-- we have lots of legacy classes without name spaces -->
         <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
-
-        <!-- Rules with automatic fixes that we want to adhere to, but currently don't -->
-        <exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine"/>
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma"/>
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma"/>
-        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
-        <exclude name="Generic.PHP.LowerCaseKeyword.Found"/>
-        <exclude name="Generic.PHP.LowerCaseConstant.Found"/>
-        <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact"/>
-        <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect"/>
-        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterDecrement"/>
-        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement"/>
-
-        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis"/>
-        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
-        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-        <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
-        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceBeforeArrow"/>
-        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceAfterArrow"/>
-        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.SpacingBeforeAs"/>
-        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterSecond"/>
-        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterSecond"/>
-        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterFirst"/>
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg"/>
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals"/>
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference"/>
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose"/>
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals"/>
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>
-        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine"/>
-        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
-        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
-        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore"/>
-        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent"/>
-        <exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
-
-        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
-        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
-        <exclude name="PSR2.Classes.PropertyDeclaration.StaticBeforeVisibility"/>
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace"/>
-        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonDEFAULT"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE"/>
-        <exclude name="PSR2.Files.EndFileNewline.TooMany"/>
-        <exclude name="PSR2.Files.EndFileNewline.NoneFound"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.Indent"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.EmptyLine"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket"/>
-        <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments"/>
-        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
-        <exclude name="PSR2.Methods.MethodDeclaration.StaticBeforeVisibility"/>
-        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
-        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
-
-        <exclude name="PSR12.Classes.ClassInstantiation.MissingParentheses"/>
-        <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.LineIndent"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace"/>
-        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
-        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceBefore"/>
-        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceAfter"/>
-
-        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
     </rule>
 
     <!-- disable some rules for certain paths, for legacy support -->
@@ -152,25 +77,4 @@
         <exclude-pattern>*/inc/Extension/PluginInterface.php</exclude-pattern>
         <exclude-pattern>*/inc/Extension/PluginTrait.php</exclude-pattern>
     </rule>
-
-    <!-- for now we mix declarations and execution here (mostly for defines) -->
-    <rule ref="PSR1.Files.SideEffects">
-        <exclude-pattern>*/index.php</exclude-pattern>
-        <exclude-pattern>*/inc/parserutils.php</exclude-pattern>
-        <exclude-pattern>*/inc/mail.php</exclude-pattern>
-        <exclude-pattern>*/inc/init.php</exclude-pattern>
-        <exclude-pattern>*/inc/farm.php</exclude-pattern>
-        <exclude-pattern>*/inc/fulltext.php</exclude-pattern>
-        <exclude-pattern>*/inc/pluginutils.php</exclude-pattern>
-        <exclude-pattern>*/inc/indexer.php</exclude-pattern>
-        <exclude-pattern>*/inc/Mailer.class.php</exclude-pattern>
-        <exclude-pattern>*/doku.php</exclude-pattern>
-        <exclude-pattern>*/install.php</exclude-pattern>
-        <exclude-pattern>*/inc/utf8.php</exclude-pattern>
-        <exclude-pattern>*/feed.php</exclude-pattern>
-        <exclude-pattern>*/inc/load.php</exclude-pattern>
-        <exclude-pattern>*/bin/*.php</exclude-pattern>
-        <exclude-pattern>*/lib/exe/*.php</exclude-pattern>
-    </rule>
-
 </ruleset>

--- a/_test/phpcs_MigrationAdjustments.xml
+++ b/_test/phpcs_MigrationAdjustments.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<ruleset name="Migration Adjustments for the DokuWiki Coding Standard Standard" namespace="DokuWiki\CS\Standard">
+    <description>These are exceptions to the Coding Standard used for DokuWiki that are intended to be removed over time.</description>
+
+    <!-- rules on top of PSR-12 -->
+    <rule ref="./phpcs.xml">
+        <!-- Rules with automatic fixes that we want to adhere to, but currently don't -->
+        <exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine"/>
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma"/>
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma"/>
+        <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
+        <exclude name="Generic.PHP.LowerCaseKeyword.Found"/>
+        <exclude name="Generic.PHP.LowerCaseConstant.Found"/>
+        <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact"/>
+        <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect"/>
+        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterDecrement"/>
+        <exclude name="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement"/>
+
+        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis"/>
+        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
+        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+        <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
+        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceBeforeArrow"/>
+        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceAfterArrow"/>
+        <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.SpacingBeforeAs"/>
+        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterSecond"/>
+        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterSecond"/>
+        <exclude name="Squiz.ControlStructures.ForLoopDeclaration.NoSpaceAfterFirst"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose"/>
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore"/>
+        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace.Indent"/>
+        <exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
+
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
+        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
+        <exclude name="PSR2.Classes.PropertyDeclaration.StaticBeforeVisibility"/>
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace"/>
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonDEFAULT"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE"/>
+        <exclude name="PSR2.Files.EndFileNewline.TooMany"/>
+        <exclude name="PSR2.Files.EndFileNewline.NoneFound"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.Indent"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.EmptyLine"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments"/>
+        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.StaticBeforeVisibility"/>
+        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
+        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
+
+        <exclude name="PSR12.Classes.ClassInstantiation.MissingParentheses"/>
+        <exclude name="PSR12.ControlStructures.BooleanOperatorPlacement.FoundMixed"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.LineIndent"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace"/>
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceBefore"/>
+        <exclude name="PSR12.Operators.OperatorSpacing.NoSpaceAfter"/>
+
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
+    </rule>
+
+    <!-- for now we mix declarations and execution here (mostly for defines) -->
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>*/index.php</exclude-pattern>
+        <exclude-pattern>*/inc/parserutils.php</exclude-pattern>
+        <exclude-pattern>*/inc/mail.php</exclude-pattern>
+        <exclude-pattern>*/inc/init.php</exclude-pattern>
+        <exclude-pattern>*/inc/farm.php</exclude-pattern>
+        <exclude-pattern>*/inc/fulltext.php</exclude-pattern>
+        <exclude-pattern>*/inc/pluginutils.php</exclude-pattern>
+        <exclude-pattern>*/inc/indexer.php</exclude-pattern>
+        <exclude-pattern>*/inc/Mailer.class.php</exclude-pattern>
+        <exclude-pattern>*/doku.php</exclude-pattern>
+        <exclude-pattern>*/install.php</exclude-pattern>
+        <exclude-pattern>*/inc/utf8.php</exclude-pattern>
+        <exclude-pattern>*/feed.php</exclude-pattern>
+        <exclude-pattern>*/inc/load.php</exclude-pattern>
+        <exclude-pattern>*/bin/*.php</exclude-pattern>
+        <exclude-pattern>*/lib/exe/*.php</exclude-pattern>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
This should enable plugins to natively run PHP Code Sniffer checks against the actual DokuWiki standard and not against a version that has been watered down until we have gotten around to fixing all the violations.

An example for such a workflow can be found with the struct section plugin: [.github/workflows/phpCS.yml](https://github.com/micgro42/dokuwiki-plugin-structsection/blob/a16d28194e0f787a62a5b56cae5abbbc8c464e04/.github/workflows/phpCS.yml).

(Notice that this file is suitable to be included in the plugin-wizard)

----
PS: It is currently not reasonably possible to add namespaces to the classes like `action_plugin_structsection`. I wonder if we could at some point refactor the plugin system to support this?