### PR TITLE
Better callable support in Event default actions

### DIFF
--- a/_test/tests/inc/Extension/Event.test.php
+++ b/_test/tests/inc/Extension/Event.test.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace tests\inc\Extension;
+
+use dokuwiki\Extension\Event;
+
+class EventTest extends \DokuWikiTest
+{
+    static public function staticFunc(&$data)
+    {
+        $data['test'] = strtoupper($data['test']);
+    }
+
+    public function dynamicFunc(&$data)
+    {
+        $data['test'] = strtoupper($data['test']);
+    }
+
+    public function testGlobal()
+    {
+        $data = 'test';
+        $result = Event::createAndTrigger('TESTTRIGGER', $data, 'strtoupper');
+        $this->assertEquals('TEST', $result);
+    }
+
+    public function testDynamic()
+    {
+        $data = ['test' => 'test'];
+        Event::createAndTrigger('TESTTRIGGER', $data, [$this, 'dynamicFunc']);
+        $this->assertEquals(['test' => 'TEST'], $data);
+    }
+
+    public function testStatic()
+    {
+        $data = ['test' => 'test'];
+        Event::createAndTrigger('TESTTRIGGER', $data, 'tests\inc\Extension\EventTest::staticFunc');
+        $this->assertEquals(['test' => 'TEST'], $data);
+
+        $data = ['test' => 'test'];
+        Event::createAndTrigger('TESTTRIGGER', $data, ['tests\inc\Extension\EventTest', 'staticFunc']);
+        $this->assertEquals(['test' => 'TEST'], $data);
+    }
+}

--- a/inc/Extension/Event.php
+++ b/inc/Extension/Event.php
@@ -126,12 +126,7 @@ class Event
         }
 
         if ($this->advise_before($enablePrevent) && is_callable($action)) {
-            if (is_array($action)) {
-                list($obj, $method) = $action;
-                $this->result = $obj->$method($this->data);
-            } else {
-                $this->result = $action($this->data);
-            }
+            $this->result = call_user_func_array($action, [&$this->data]);
         }
 
         $this->advise_after();


### PR DESCRIPTION
Instead of parsing the passed callback ourselves, this patch relies on `call_user_func_array()` instead to call an Event's default action. This ensures all possible ways to define a callback (including static methods) can be used.

This should fix a problem mentioned in #2943