### PR TITLE
Defer javascript and add feature Flag

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -162,6 +162,9 @@ $conf['trustedproxy'] = '^(::1|[fF][eE]80:|127\.|10\.|192\.168\.|172\.((1[6-9])|
                                          //Regexp of trusted proxy address when reading IP using HTTP header
                                          //  if blank, do not trust any proxy (including local IP)
 
+/* Feature Flags */
+$conf['defer_js'] = 1;                   // Defer javascript to be executed after the page's HTML has been parsed. Setting will be removed in the next release.
+
 /* Network Settings */
 $conf['dnslookups'] = 1;                 //disable to disallow IP to hostname lookups
 $conf['jquerycdn']  = 0;                 //use a CDN for delivering jQuery?

--- a/inc/template.php
+++ b/inc/template.php
@@ -355,7 +355,8 @@ function tpl_metaheaders($alt = true) {
     // load our javascript dispatcher
     $head['script'][] = array(
         'type'=> 'text/javascript', 'charset'=> 'utf-8', '_data'=> '',
-        'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed
+        'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed,
+		'defer'=> 'defer'
     );
 
     // trigger event here

--- a/inc/template.php
+++ b/inc/template.php
@@ -348,16 +348,18 @@ function tpl_metaheaders($alt = true) {
     $jquery = getCdnUrls();
     foreach($jquery as $src) {
         $head['script'][] = array(
-            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src, 'defer' => 'defer'
-        );
+            'type' => 'text/javascript',
+            'charset' => 'utf-8',
+            '_data' => '',
+            'src' => $src,
+        ) + ($conf['defer_js'] ? [ 'defer' => 'defer'] : []);
     }
 
     // load our javascript dispatcher
     $head['script'][] = array(
         'type'=> 'text/javascript', 'charset'=> 'utf-8', '_data'=> '',
         'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed,
-		'defer'=> 'defer'
-    );
+    ) + ($conf['defer_js'] ? [ 'defer' => 'defer'] : []);
 
     // trigger event here
     Event::createAndTrigger('TPL_METAHEADER_OUTPUT', $head, '_tpl_metaheaders_action', true);

--- a/inc/template.php
+++ b/inc/template.php
@@ -348,7 +348,7 @@ function tpl_metaheaders($alt = true) {
     $jquery = getCdnUrls();
     foreach($jquery as $src) {
         $head['script'][] = array(
-            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src
+            'type' => 'text/javascript', 'charset' => 'utf-8', '_data' => '', 'src' => $src, 'defer' => 'defer'
         );
     }
 

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -187,6 +187,9 @@ $lang['search_fragment_o_ends_with'] = 'ends with';
 $lang['search_fragment_o_contains'] = 'contains';
 $lang['trustedproxy'] = 'Trust forwarding proxies matching this regular expression about the true client IP they report. The default matches local networks. Leave empty to trust no proxy.';
 
+$lang['_feature_flags'] = 'Feature Flags';
+$lang['defer_js'] = 'Defer javascript to be execute after the page\'s HTML has been parsed. Improves perceived page speed but could break a small number of plugins.';
+
 /* Network Options */
 $lang['dnslookups'] = 'DokuWiki will lookup hostnames for remote IP addresses of users editing pages. If you have a slow or non working DNS server or don\'t want this feature, disable this option';
 $lang['jquerycdn'] = 'Should the jQuery and jQuery UI script files be loaded from a CDN? This adds additional HTTP requests, but files may load faster and users may have them cached already.';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -230,6 +230,9 @@ $meta['search_nslimit'] = array('numeric', '_min' => 0);
 $meta['search_fragment'] = array('multichoice','_choices' => array('exact', 'starts_with', 'ends_with', 'contains'),);
 $meta['trustedproxy'] = array('regex');
 
+$meta['_feature_flags'] = ['fieldset'];
+$meta['defer_js']       = ['onoff'];
+
 $meta['_network']    = array('fieldset');
 $meta['dnslookups']  = array('onoff');
 $meta['jquerycdn']   = array('multichoice', '_choices' => array(0,'jquery', 'cdnjs'));


### PR DESCRIPTION
This builds upon the pull requests #2786 and #2958 by @Dr-Yukon and adds a feature flag for the defer attribute added to the jQuery and main-js requests in these pull requests. It adds only a single feature flag since deferring jQuery without deferring the main javascript request is likely to cause errors and confusion.

The feature flag defaults to "on" as this should be unproblematic except for a few plugins. Also, with this flag being on by default, it should see more usage and is more likely to uncover existing issues.

This feature flag should be removed once this feature is deemed safe.

Closes #2786 
Closes #2958