### PR TITLE
define generic addInputElement() in Form\Form class 

### DIFF
--- a/inc/Form/ButtonElement.php
+++ b/inc/Form/ButtonElement.php
@@ -8,8 +8,8 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class ButtonElement extends Element {
-
+class ButtonElement extends Element
+{
     /** @var string HTML content */
     protected $content = '';
 
@@ -17,7 +17,8 @@ class ButtonElement extends Element {
      * @param string $name
      * @param string $content HTML content of the button. You have to escape it yourself.
      */
-    public function __construct($name, $content = '') {
+    public function __construct($name, $content = '')
+    {
         parent::__construct('button', array('name' => $name, 'value' => 1));
         $this->content = $content;
     }
@@ -27,7 +28,8 @@ class ButtonElement extends Element {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '<button ' . buildAttributes($this->attrs(), true) . '>'.$this->content.'</button>';
     }
 

--- a/inc/Form/CheckableElement.php
+++ b/inc/Form/CheckableElement.php
@@ -8,14 +8,15 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class CheckableElement extends InputElement {
-
+class CheckableElement extends InputElement
+{
     /**
      * @param string $type The type of this element
      * @param string $name The name of this form element
      * @param string $label The label text for this element
      */
-    public function __construct($type, $name, $label) {
+    public function __construct($type, $name, $label)
+    {
         parent::__construct($type, $name, $label);
         // default value is 1
         $this->attr('value', 1);
@@ -24,17 +25,18 @@ class CheckableElement extends InputElement {
     /**
      * Handles the useInput flag and sets the checked attribute accordingly
      */
-    protected function prefillInput() {
+    protected function prefillInput()
+    {
         global $INPUT;
         list($name, $key) = $this->getInputName();
         $myvalue = $this->val();
 
-        if(!$INPUT->has($name)) return;
+        if (!$INPUT->has($name)) return;
 
-        if($key === null) {
+        if ($key === null) {
             // no key - single value
             $value = $INPUT->str($name);
-            if($value == $myvalue) {
+            if ($value == $myvalue) {
                 $this->attr('checked', 'checked');
             } else {
                 $this->rmattr('checked');
@@ -42,16 +44,16 @@ class CheckableElement extends InputElement {
         } else {
             // we have an array, there might be several values in it
             $input = $INPUT->arr($name);
-            if(isset($input[$key])) {
+            if (isset($input[$key])) {
                 $this->rmattr('checked');
 
                 // values seem to be in another sub array
-                if(is_array($input[$key])) {
+                if (is_array($input[$key])) {
                     $input = $input[$key];
                 }
 
-                foreach($input as $value) {
-                    if($value == $myvalue) {
+                foreach ($input as $value) {
+                    if ($value == $myvalue) {
                         $this->attr('checked', 'checked');
                     }
                 }

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -8,8 +8,8 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class DropdownElement extends InputElement {
-
+class DropdownElement extends InputElement
+{
     /** @var array OptGroup[] */
     protected $optGroups = array();
 
@@ -18,7 +18,8 @@ class DropdownElement extends InputElement {
      * @param array  $options The available options
      * @param string $label The label text for this element (will be autoescaped)
      */
-    public function __construct($name, $options, $label = '') {
+    public function __construct($name, $options, $label = '')
+    {
         parent::__construct('dropdown', $name, $label);
         $this->rmattr('type');
         $this->optGroups[''] = new OptGroup(null, $options);
@@ -33,7 +34,8 @@ class DropdownElement extends InputElement {
      * @return OptGroup a reference to the added optgroup
      * @throws \Exception
      */
-    public function addOptGroup($label, $options) {
+    public function addOptGroup($label, $options)
+    {
         if (empty($label)) {
             throw new \InvalidArgumentException(hsc('<optgroup> must have a label!'));
         }
@@ -51,8 +53,9 @@ class DropdownElement extends InputElement {
      * @param null|array $optGroups
      * @return OptGroup[]|DropdownElement
      */
-    public function optGroups($optGroups = null) {
-        if($optGroups === null) {
+    public function optGroups($optGroups = null)
+    {
+        if ($optGroups === null) {
             return $this->optGroups;
         }
         if (!is_array($optGroups)) {
@@ -81,7 +84,8 @@ class DropdownElement extends InputElement {
      * @param null|array $options
      * @return $this|array
      */
-    public function options($options = null) {
+    public function options($options = null)
+    {
         if ($options === null) {
             return $this->optGroups['']->options();
         }
@@ -102,8 +106,9 @@ class DropdownElement extends InputElement {
      * @param null|string $value New value to set
      * @return string|$this
      */
-    public function attr($name, $value = null) {
-        if(strtolower($name) == 'multiple') {
+    public function attr($name, $value = null)
+    {
+        if (strtolower($name) == 'multiple') {
             throw new \InvalidArgumentException(
                 'Sorry, the dropdown element does not support the "multiple" attribute'
             );
@@ -120,12 +125,13 @@ class DropdownElement extends InputElement {
      * @param null|string $value The value to set
      * @return $this|string
      */
-    public function val($value = null) {
-        if($value === null) return $this->value;
+    public function val($value = null)
+    {
+        if ($value === null) return $this->value;
 
         $value_exists = $this->setValueInOptGroups($value);
 
-        if($value_exists) {
+        if ($value_exists) {
             $this->value = $value;
         } else {
             // unknown value set, select first option instead
@@ -141,7 +147,8 @@ class DropdownElement extends InputElement {
      *
      * @return string
      */
-    protected function getFirstOption() {
+    protected function getFirstOption()
+    {
         $options = $this->options();
         if (!empty($options)) {
             $keys = array_keys($options);
@@ -162,7 +169,8 @@ class DropdownElement extends InputElement {
      * @param string $value
      * @return bool
      */
-    protected function setValueInOptGroups($value) {
+    protected function setValueInOptGroups($value)
+    {
         $value_exists = false;
         /** @var OptGroup $optGroup */
         foreach ($this->optGroups as $optGroup) {
@@ -179,8 +187,9 @@ class DropdownElement extends InputElement {
      *
      * @return string
      */
-    protected function mainElementHTML() {
-        if($this->useInput) $this->prefillInput();
+    protected function mainElementHTML()
+    {
+        if ($this->useInput) $this->prefillInput();
 
         $html = '<select ' . buildAttributes($this->attrs()) . '>';
         $html = array_reduce(

--- a/inc/Form/Element.php
+++ b/inc/Form/Element.php
@@ -8,8 +8,8 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-abstract class Element {
-
+abstract class Element
+{
     /**
      * @var array the attributes of this element
      */
@@ -24,7 +24,8 @@ abstract class Element {
      * @param string $type The type of this element
      * @param array $attributes
      */
-    public function __construct($type, $attributes = array()) {
+    public function __construct($type, $attributes = array())
+    {
         $this->type = $type;
         $this->attributes = $attributes;
     }
@@ -34,7 +35,8 @@ abstract class Element {
      *
      * @return string
      */
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
@@ -51,15 +53,16 @@ abstract class Element {
      * @param null|string $value New value to set
      * @return string|$this
      */
-    public function attr($name, $value = null) {
+    public function attr($name, $value = null)
+    {
         // set
-        if($value !== null) {
+        if ($value !== null) {
             $this->attributes[$name] = $value;
             return $this;
         }
 
         // get
-        if(isset($this->attributes[$name])) {
+        if (isset($this->attributes[$name])) {
             return $this->attributes[$name];
         } else {
             return '';
@@ -72,8 +75,9 @@ abstract class Element {
      * @param string $name
      * @return $this
      */
-    public function rmattr($name) {
-        if(isset($this->attributes[$name])) {
+    public function rmattr($name)
+    {
+        if (isset($this->attributes[$name])) {
             unset($this->attributes[$name]);
         }
         return $this;
@@ -85,10 +89,11 @@ abstract class Element {
      * @param array|null $attributes
      * @return array|$this
      */
-    public function attrs($attributes = null) {
+    public function attrs($attributes = null)
+    {
         // set
-        if($attributes) {
-            foreach((array) $attributes as $key => $val) {
+        if ($attributes) {
+            foreach ((array) $attributes as $key => $val) {
                 $this->attr($key, $val);
             }
             return $this;
@@ -105,7 +110,8 @@ abstract class Element {
      * @param string $class the new class to add
      * @return $this
      */
-    public function addClass($class) {
+    public function addClass($class)
+    {
         $classes = explode(' ', $this->attr('class'));
         $classes[] = $class;
         $classes = array_unique($classes);
@@ -122,10 +128,11 @@ abstract class Element {
      * @param null|string $id
      * @return string|$this
      */
-    public function id($id = null) {
-        if(strpos($id, '__') === false) {
-            throw new \InvalidArgumentException('IDs in DokuWiki have to contain two subsequent underscores');
-        }
+    public function id($id = null)
+    {
+        if (strpos($id, '__') === false) throw new \InvalidArgumentException(
+            'IDs in DokuWiki have to contain two subsequent underscores'
+        );
 
         return $this->attr('id', $id);
     }
@@ -138,7 +145,8 @@ abstract class Element {
      * @param null|string $value
      * @return string|$this
      */
-    public function val($value = null) {
+    public function val($value = null)
+    {
         return $this->attr('value', $value);
     }
 

--- a/inc/Form/FieldsetCloseElement.php
+++ b/inc/Form/FieldsetCloseElement.php
@@ -8,12 +8,13 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class FieldsetCloseElement extends TagCloseElement {
-
+class FieldsetCloseElement extends TagCloseElement
+{
     /**
      * @param array $attributes
      */
-    public function __construct($attributes = array()) {
+    public function __construct($attributes = array())
+    {
         parent::__construct('', $attributes);
         $this->type = 'fieldsetclose';
     }
@@ -24,7 +25,8 @@ class FieldsetCloseElement extends TagCloseElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '</fieldset>';
     }
 }

--- a/inc/Form/FieldsetOpenElement.php
+++ b/inc/Form/FieldsetOpenElement.php
@@ -8,13 +8,14 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class FieldsetOpenElement extends TagOpenElement {
-
+class FieldsetOpenElement extends TagOpenElement
+{
     /**
      * @param string $legend
      * @param array $attributes
      */
-    public function __construct($legend='', $attributes = array()) {
+    public function __construct($legend='', $attributes = array())
+    {
         // this is a bit messy and we just do it for the nicer class hierarchy
         // the parent would expect the tag in $value but we're storing the
         // legend there, so we have to set the type manually
@@ -27,7 +28,8 @@ class FieldsetOpenElement extends TagOpenElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         $html = '<fieldset '.buildAttributes($this->attrs()).'>';
         $legend = $this->val();
         if($legend) $html .= DOKU_LF.'<legend>'.hsc($legend).'</legend>';

--- a/inc/Form/Form.php
+++ b/inc/Form/Form.php
@@ -206,6 +206,20 @@ class Form extends Element
     #region Element adding functions
 
     /**
+     * Adds a input field
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $label
+     * @param int $pos
+     * @return InputElement
+     */
+    public function addInput($type, $name, $label = '', $pos = -1)
+    {
+        return $this->addElement(new InputElement($type, $name, $label), $pos);
+    }
+
+    /**
      * Adds a text input field
      *
      * @param string $name
@@ -215,7 +229,7 @@ class Form extends Element
      */
     public function addTextInput($name, $label = '', $pos = -1)
     {
-        return $this->addElement(new InputElement('text', $name, $label), $pos);
+        return $this->addInput('text', $name, $label, $pos);
     }
 
     /**
@@ -228,7 +242,7 @@ class Form extends Element
      */
     public function addPasswordInput($name, $label = '', $pos = -1)
     {
-        return $this->addElement(new InputElement('password', $name, $label), $pos);
+        return $this->addInput('password', $name, $label, $pos);
     }
 
     /**

--- a/inc/Form/Form.php
+++ b/inc/Form/Form.php
@@ -8,8 +8,8 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class Form extends Element {
-
+class Form extends Element
+{
     /**
      * @var array name value pairs for hidden values
      */
@@ -26,26 +26,27 @@ class Form extends Element {
      * @param array $attributes
      * @param bool  $unsafe     if true, then the security token is ommited
      */
-    public function __construct($attributes = array(), $unsafe = false) {
+    public function __construct($attributes = array(), $unsafe = false)
+    {
         global $ID;
 
         parent::__construct('form', $attributes);
 
         // use the current URL as default action
-        if(!$this->attr('action')) {
+        if (!$this->attr('action')) {
             $get = $_GET;
-            if(isset($get['id'])) unset($get['id']);
+            if (isset($get['id'])) unset($get['id']);
             $self = wl($ID, $get, false, '&'); //attributes are escaped later
             $this->attr('action', $self);
         }
 
         // post is default
-        if(!$this->attr('method')) {
+        if (!$this->attr('method')) {
             $this->attr('method', 'post');
         }
 
         // we like UTF-8
-        if(!$this->attr('accept-charset')) {
+        if (!$this->attr('accept-charset')) {
             $this->attr('accept-charset', 'utf-8');
         }
 
@@ -65,7 +66,8 @@ class Form extends Element {
      * @param string $value
      * @return $this
      */
-    public function setHiddenField($name, $value) {
+    public function setHiddenField($name, $value)
+    {
         $this->hidden[$name] = $value;
         return $this;
     }
@@ -77,7 +79,8 @@ class Form extends Element {
      *
      * @return int
      */
-    public function elementCount() {
+    public function elementCount()
+    {
         return count($this->elements);
     }
 
@@ -105,10 +108,11 @@ class Form extends Element {
      * @param int $pos
      * @return Element
      */
-    public function getElementAt($pos) {
-        if($pos < 0) $pos = count($this->elements) + $pos;
-        if($pos < 0) $pos = 0;
-        if($pos >= count($this->elements)) $pos = count($this->elements) - 1;
+    public function getElementAt($pos)
+    {
+        if ($pos < 0) $pos = count($this->elements) + $pos;
+        if ($pos < 0) $pos = 0;
+        if ($pos >= count($this->elements)) $pos = count($this->elements) - 1;
         return $this->elements[$pos];
     }
 
@@ -119,10 +123,11 @@ class Form extends Element {
      * @param int $offset search from this position onward
      * @return false|int position of element if found, otherwise false
      */
-    public function findPositionByType($type, $offset = 0) {
+    public function findPositionByType($type, $offset = 0)
+    {
         $len = $this->elementCount();
-        for($pos = $offset; $pos < $len; $pos++) {
-            if($this->elements[$pos]->getType() == $type) {
+        for ($pos = $offset; $pos < $len; $pos++) {
+            if ($this->elements[$pos]->getType() == $type) {
                 return $pos;
             }
         }
@@ -137,10 +142,11 @@ class Form extends Element {
      * @param int $offset search from this position onward
      * @return false|int position of element if found, otherwise false
      */
-    public function findPositionByAttribute($name, $value, $offset = 0) {
+    public function findPositionByAttribute($name, $value, $offset = 0)
+    {
         $len = $this->elementCount();
-        for($pos = $offset; $pos < $len; $pos++) {
-            if($this->elements[$pos]->attr($name) == $value) {
+        for ($pos = $offset; $pos < $len; $pos++) {
+            if ($this->elements[$pos]->attr($name) == $value) {
                 return $pos;
             }
         }
@@ -158,11 +164,12 @@ class Form extends Element {
      * @param int $pos 0-based position in the form, -1 for at the end
      * @return Element
      */
-    public function addElement(Element $element, $pos = -1) {
-        if(is_a($element, '\dokuwiki\Form\Form')) throw new \InvalidArgumentException(
+    public function addElement(Element $element, $pos = -1)
+    {
+        if (is_a($element, '\dokuwiki\Form\Form')) throw new \InvalidArgumentException(
             'You can\'t add a form to a form'
         );
-        if($pos < 0) {
+        if ($pos < 0) {
             $this->elements[] = $element;
         } else {
             array_splice($this->elements, $pos, 0, array($element));
@@ -176,8 +183,9 @@ class Form extends Element {
      * @param Element $element the new element
      * @param int $pos 0-based position of the element to replace
      */
-    public function replaceElement(Element $element, $pos) {
-        if(is_a($element, '\dokuwiki\Form\Form')) throw new \InvalidArgumentException(
+    public function replaceElement(Element $element, $pos)
+    {
+        if (is_a($element, '\dokuwiki\Form\Form')) throw new \InvalidArgumentException(
             'You can\'t add a form to a form'
         );
         array_splice($this->elements, $pos, 1, array($element));
@@ -188,7 +196,8 @@ class Form extends Element {
      *
      * @param int $pos 0-based position of the element to remove
      */
-    public function removeElement($pos) {
+    public function removeElement($pos)
+    {
         array_splice($this->elements, $pos, 1);
     }
 
@@ -204,7 +213,8 @@ class Form extends Element {
      * @param int $pos
      * @return InputElement
      */
-    public function addTextInput($name, $label = '', $pos = -1) {
+    public function addTextInput($name, $label = '', $pos = -1)
+    {
         return $this->addElement(new InputElement('text', $name, $label), $pos);
     }
 
@@ -216,7 +226,8 @@ class Form extends Element {
      * @param int $pos
      * @return InputElement
      */
-    public function addPasswordInput($name, $label = '', $pos = -1) {
+    public function addPasswordInput($name, $label = '', $pos = -1)
+    {
         return $this->addElement(new InputElement('password', $name, $label), $pos);
     }
 
@@ -228,7 +239,8 @@ class Form extends Element {
      * @param int $pos
      * @return CheckableElement
      */
-    public function addRadioButton($name, $label = '', $pos = -1) {
+    public function addRadioButton($name, $label = '', $pos = -1)
+    {
         return $this->addElement(new CheckableElement('radio', $name, $label), $pos);
     }
 
@@ -240,7 +252,8 @@ class Form extends Element {
      * @param int $pos
      * @return CheckableElement
      */
-    public function addCheckbox($name, $label = '', $pos = -1) {
+    public function addCheckbox($name, $label = '', $pos = -1)
+    {
         return $this->addElement(new CheckableElement('checkbox', $name, $label), $pos);
     }
 
@@ -253,7 +266,8 @@ class Form extends Element {
      * @param int $pos
      * @return DropdownElement
      */
-    public function addDropdown($name, $options, $label = '', $pos = -1) {
+    public function addDropdown($name, $options, $label = '', $pos = -1)
+    {
         return $this->addElement(new DropdownElement($name, $options, $label), $pos);
     }
 
@@ -265,7 +279,8 @@ class Form extends Element {
      * @param int $pos
      * @return TextareaElement
      */
-    public function addTextarea($name, $label = '', $pos = -1) {
+    public function addTextarea($name, $label = '', $pos = -1)
+    {
         return $this->addElement(new TextareaElement($name, $label), $pos);
     }
 
@@ -277,7 +292,8 @@ class Form extends Element {
      * @param int $pos
      * @return Element
      */
-    public function addButton($name, $content, $pos = -1) {
+    public function addButton($name, $content, $pos = -1)
+    {
         return $this->addElement(new ButtonElement($name, hsc($content)), $pos);
     }
 
@@ -289,7 +305,8 @@ class Form extends Element {
      * @param int $pos
      * @return Element
      */
-    public function addButtonHTML($name, $html, $pos = -1) {
+    public function addButtonHTML($name, $html, $pos = -1)
+    {
         return $this->addElement(new ButtonElement($name, $html), $pos);
     }
 
@@ -301,7 +318,8 @@ class Form extends Element {
      * @param int $pos
      * @return Element
      */
-    public function addLabel($label, $for='', $pos = -1) {
+    public function addLabel($label, $for='', $pos = -1)
+    {
         return $this->addLabelHTML(hsc($label), $for, $pos);
     }
 
@@ -313,15 +331,16 @@ class Form extends Element {
      * @param int $pos
      * @return Element
      */
-    public function addLabelHTML($content, $for='', $pos = -1) {
+    public function addLabelHTML($content, $for='', $pos = -1)
+    {
         $element = new LabelElement(hsc($content));
 
-        if(is_a($for, '\dokuwiki\Form\Element')) {
+        if (is_a($for, '\dokuwiki\Form\Element')) {
             /** @var Element $for */
             $for = $for->id();
         }
         $for = (string) $for;
-        if($for !== '') {
+        if ($for !== '') {
             $element->attr('for', $for);
         }
 
@@ -335,7 +354,8 @@ class Form extends Element {
      * @param int $pos
      * @return HTMLElement
      */
-    public function addHTML($html, $pos = -1) {
+    public function addHTML($html, $pos = -1)
+    {
         return $this->addElement(new HTMLElement($html), $pos);
     }
 
@@ -346,7 +366,8 @@ class Form extends Element {
      * @param int $pos
      * @return TagElement
      */
-    public function addTag($tag, $pos = -1) {
+    public function addTag($tag, $pos = -1)
+    {
         return $this->addElement(new TagElement($tag), $pos);
     }
 
@@ -359,7 +380,8 @@ class Form extends Element {
      * @param int $pos
      * @return TagOpenElement
      */
-    public function addTagOpen($tag, $pos = -1) {
+    public function addTagOpen($tag, $pos = -1)
+    {
         return $this->addElement(new TagOpenElement($tag), $pos);
     }
 
@@ -372,7 +394,8 @@ class Form extends Element {
      * @param int $pos
      * @return TagCloseElement
      */
-    public function addTagClose($tag, $pos = -1) {
+    public function addTagClose($tag, $pos = -1)
+    {
         return $this->addElement(new TagCloseElement($tag), $pos);
     }
 
@@ -383,7 +406,8 @@ class Form extends Element {
      * @param int $pos
      * @return FieldsetOpenElement
      */
-    public function addFieldsetOpen($legend = '', $pos = -1) {
+    public function addFieldsetOpen($legend = '', $pos = -1)
+    {
         return $this->addElement(new FieldsetOpenElement($legend), $pos);
     }
 
@@ -393,7 +417,8 @@ class Form extends Element {
      * @param int $pos
      * @return TagCloseElement
      */
-    public function addFieldsetClose($pos = -1) {
+    public function addFieldsetClose($pos = -1)
+    {
         return $this->addElement(new FieldsetCloseElement(), $pos);
     }
 
@@ -402,15 +427,16 @@ class Form extends Element {
     /**
      * Adjust the elements so that fieldset open and closes are matching
      */
-    protected function balanceFieldsets() {
+    protected function balanceFieldsets()
+    {
         $lastclose = 0;
         $isopen = false;
         $len = count($this->elements);
 
-        for($pos = 0; $pos < $len; $pos++) {
+        for ($pos = 0; $pos < $len; $pos++) {
             $type = $this->elements[$pos]->getType();
-            if($type == 'fieldsetopen') {
-                if($isopen) {
+            if ($type == 'fieldsetopen') {
+                if ($isopen) {
                     //close previous fieldset
                     $this->addFieldsetClose($pos);
                     $lastclose = $pos + 1;
@@ -418,8 +444,8 @@ class Form extends Element {
                     $len++;
                 }
                 $isopen = true;
-            } else if($type == 'fieldsetclose') {
-                if(!$isopen) {
+            } elseif ($type == 'fieldsetclose') {
+                if (!$isopen) {
                     // make sure there was a fieldsetopen
                     // either right after the last close or at the begining
                     $this->addFieldsetOpen('', $lastclose);
@@ -432,7 +458,7 @@ class Form extends Element {
         }
 
         // close open fieldset at the end
-        if($isopen) {
+        if ($isopen) {
             $this->addFieldsetClose();
         }
     }
@@ -442,21 +468,21 @@ class Form extends Element {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         $this->balanceFieldsets();
 
         $html = '<form ' . buildAttributes($this->attrs()) . '>';
 
-        foreach($this->hidden as $name => $value) {
+        foreach ($this->hidden as $name => $value) {
             $html .= '<input type="hidden" name="' . $name . '" value="' . formText($value) . '" />';
         }
 
-        foreach($this->elements as $element) {
+        foreach ($this->elements as $element) {
             $html .= $element->toHTML();
         }
 
         $html .= '</form>';
-
         return $html;
     }
 }

--- a/inc/Form/InputElement.php
+++ b/inc/Form/InputElement.php
@@ -10,7 +10,8 @@ namespace dokuwiki\Form;
  * @todo figure out how to make wrapping or related label configurable
  * @package dokuwiki\Form
  */
-class InputElement extends Element {
+class InputElement extends Element
+{
     /**
      * @var LabelElement
      */
@@ -26,7 +27,8 @@ class InputElement extends Element {
      * @param string $name The name of this form element
      * @param string $label The label text for this element (will be autoescaped)
      */
-    public function __construct($type, $name, $label = '') {
+    public function __construct($type, $name, $label = '')
+    {
         parent::__construct($type, array('name' => $name));
         $this->attr('name', $name);
         $this->attr('type', $type);
@@ -51,7 +53,8 @@ class InputElement extends Element {
      * @param bool $useinput
      * @return $this
      */
-    public function useInput($useinput) {
+    public function useInput($useinput)
+    {
         $this->useInput = (bool) $useinput;
         return $this;
     }
@@ -62,8 +65,9 @@ class InputElement extends Element {
      * @param null|string $id
      * @return string|$this
      */
-    public function id($id = null) {
-        if($this->label) $this->label->attr('for', $id);
+    public function id($id = null)
+    {
+        if ($this->label) $this->label->attr('for', $id);
         return parent::id($id);
     }
 
@@ -75,8 +79,9 @@ class InputElement extends Element {
      * @param string $class the new class to add
      * @return $this
      */
-    public function addClass($class) {
-        if($this->label) $this->label->addClass($class);
+    public function addClass($class)
+    {
+        if ($this->label) $this->label->addClass($class);
         return parent::addClass($class);
     }
 
@@ -92,14 +97,15 @@ class InputElement extends Element {
      *
      * @return array name and array key (null if not an array)
      */
-    protected function getInputName() {
+    protected function getInputName()
+    {
         $name = $this->attr('name');
         parse_str("$name=1", $parsed);
 
         $name = array_keys($parsed);
         $name = array_shift($name);
 
-        if(is_array($parsed[$name])) {
+        if (is_array($parsed[$name])) {
             $key = array_keys($parsed[$name]);
             $key = array_shift($key);
         } else {
@@ -112,17 +118,18 @@ class InputElement extends Element {
     /**
      * Handles the useInput flag and set the value attribute accordingly
      */
-    protected function prefillInput() {
+    protected function prefillInput()
+    {
         global $INPUT;
 
         list($name, $key) = $this->getInputName();
-        if(!$INPUT->has($name)) return;
+        if (!$INPUT->has($name)) return;
 
-        if($key === null) {
+        if ($key === null) {
             $value = $INPUT->str($name);
         } else {
             $value = $INPUT->arr($name);
-            if(isset($value[$key])) {
+            if (isset($value[$key])) {
                 $value = $value[$key];
             } else {
                 $value = '';
@@ -136,8 +143,9 @@ class InputElement extends Element {
      *
      * @return string
      */
-    protected function mainElementHTML() {
-        if($this->useInput) $this->prefillInput();
+    protected function mainElementHTML()
+    {
+        if ($this->useInput) $this->prefillInput();
         return '<input ' . buildAttributes($this->attrs()) . ' />';
     }
 
@@ -146,12 +154,13 @@ class InputElement extends Element {
      *
      * @return string
      */
-    public function toHTML() {
-        if($this->label) {
+    public function toHTML()
+    {
+        if ($this->label) {
             return '<label ' . buildAttributes($this->label->attrs()) . '>' . DOKU_LF .
-            '<span>' . hsc($this->label->val()) . '</span>' . DOKU_LF .
-            $this->mainElementHTML() . DOKU_LF .
-            '</label>';
+                '<span>' . hsc($this->label->val()) . '</span>' . DOKU_LF .
+                $this->mainElementHTML() . DOKU_LF .
+                '</label>';
         } else {
             return $this->mainElementHTML();
         }

--- a/inc/Form/LabelElement.php
+++ b/inc/Form/LabelElement.php
@@ -5,14 +5,15 @@ namespace dokuwiki\Form;
  * Class Label
  * @package dokuwiki\Form
  */
-class LabelElement extends ValueElement {
-
+class LabelElement extends ValueElement
+{
     /**
      * Creates a new Label
      *
      * @param string $label This is is raw HTML and will not be escaped
      */
-    public function __construct($label) {
+    public function __construct($label)
+    {
         parent::__construct('label', $label);
     }
 
@@ -21,7 +22,8 @@ class LabelElement extends ValueElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '<label ' . buildAttributes($this->attrs()) . '>' . $this->val() . '</label>';
     }
 }

--- a/inc/Form/LegacyForm.php
+++ b/inc/Form/LegacyForm.php
@@ -11,23 +11,24 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class LegacyForm extends Form {
-
+class LegacyForm extends Form
+{
     /**
      * Creates a new modern form from an old legacy Doku_Form
      *
      * @param \Doku_Form $oldform
      */
-    public function __construct(\Doku_Form $oldform) {
+    public function __construct(\Doku_Form $oldform)
+    {
         parent::__construct($oldform->params);
 
         $this->hidden = $oldform->_hidden;
 
-        foreach($oldform->_content as $element) {
+        foreach ($oldform->_content as $element) {
             list($ctl, $attr) = $this->parseLegacyAttr($element);
 
-            if(is_array($element)) {
-                switch($ctl['elem']) {
+            if (is_array($element)) {
+                switch ($ctl['elem']) {
                     case 'wikitext':
                         $this->addTextarea('wikitext')
                              ->attrs($attr)
@@ -111,16 +112,17 @@ class LegacyForm extends Form {
      * @param array $legacy
      * @return array
      */
-    protected function parseLegacyAttr($legacy) {
+    protected function parseLegacyAttr($legacy)
+    {
         $attributes = array();
         $control = array();
 
-        foreach($legacy as $key => $val) {
-            if($key[0] == '_') {
+        foreach ($legacy as $key => $val) {
+            if ($key[0] == '_') {
                 $control[substr($key, 1)] = $val;
-            } elseif($key == 'name') {
+            } elseif ($key == 'name') {
                 $control[$key] = $val;
-            } elseif($key == 'id') {
+            } elseif ($key == 'id') {
                 $control[$key] = $val;
             } else {
                 $attributes[$key] = $val;
@@ -136,7 +138,8 @@ class LegacyForm extends Form {
      * @param string $type
      * @return string
      */
-    protected function legacyType($type) {
+    protected function legacyType($type)
+    {
         static $types = array(
             'text' => 'textfield',
             'password' => 'passwordfield',
@@ -147,7 +150,7 @@ class LegacyForm extends Form {
             'fieldsetopen' => 'openfieldset',
             'fieldsetclose' => 'closefieldset',
         );
-        if(isset($types[$type])) return $types[$type];
+        if (isset($types[$type])) return $types[$type];
         return $type;
     }
 
@@ -156,20 +159,21 @@ class LegacyForm extends Form {
      *
      * @return \Doku_Form
      */
-    public function toLegacy() {
+    public function toLegacy()
+    {
         $this->balanceFieldsets();
 
         $legacy = new \Doku_Form($this->attrs());
         $legacy->_hidden = $this->hidden;
-        foreach($this->elements as $element) {
-            if(is_a($element, 'dokuwiki\Form\HTMLElement')) {
+        foreach ($this->elements as $element) {
+            if (is_a($element, 'dokuwiki\Form\HTMLElement')) {
                 $legacy->_content[] = $element->toHTML();
-            } elseif(is_a($element, 'dokuwiki\Form\InputElement')) {
+            } elseif (is_a($element, 'dokuwiki\Form\InputElement')) {
                 /** @var InputElement $element */
                 $data = $element->attrs();
                 $data['_elem'] = $this->legacyType($element->getType());
                 $label = $element->getLabel();
-                if($label) {
+                if ($label) {
                     $data['_class'] = $label->attr('class');
                 }
                 $legacy->_content[] = $data;

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -3,7 +3,8 @@
 namespace dokuwiki\Form;
 
 
-class OptGroup extends Element {
+class OptGroup extends Element
+{
     protected $options = array();
     protected $value;
 
@@ -11,7 +12,8 @@ class OptGroup extends Element {
      * @param string $label The label text for this element (will be autoescaped)
      * @param array  $options The available options
      */
-    public function __construct($label, $options) {
+    public function __construct($label, $options)
+    {
         parent::__construct('optGroup', array('label' => $label));
         $this->options($options);
     }
@@ -24,7 +26,8 @@ class OptGroup extends Element {
      * @param string $value
      * @return bool true if an option with the given value exists, false otherwise
      */
-    public function storeValue($value) {
+    public function storeValue($value)
+    {
         $this->value = $value;
         return isset($this->options[$value]);
     }
@@ -45,22 +48,26 @@ class OptGroup extends Element {
      * @param null|array $options
      * @return $this|array
      */
-    public function options($options = null) {
-        if($options === null) return $this->options;
-        if(!is_array($options)) throw new \InvalidArgumentException('Options have to be an array');
+    public function options($options = null)
+    {
+        if ($options === null) return $this->options;
+        if (!is_array($options)) throw new \InvalidArgumentException('Options have to be an array');
         $this->options = array();
-        foreach($options as $key => $val) {
+        foreach ($options as $key => $val) {
             if (is_array($val)) {
                 if (!key_exists('label', $val)) throw new \InvalidArgumentException(
                     'If option is given as array, it has to have a "label"-key!'
                 );
-                if (key_exists('attrs', $val) && is_array($val['attrs']) && key_exists('selected', $val['attrs'])) {
+                if (key_exists('attrs', $val)
+                    && is_array($val['attrs'])
+                    && key_exists('selected', $val['attrs'])
+                ) {
                     throw new \InvalidArgumentException(
                         'Please use function "DropdownElement::val()" to set the selected option'
                     );
                 }
                 $this->options[$key] = $val;
-            } elseif(is_int($key)) {
+            } elseif (is_int($key)) {
                 $this->options[$val] = array('label' => (string) $val);
             } else {
                 $this->options[$key] = array('label' => (string) $val);
@@ -75,7 +82,8 @@ class OptGroup extends Element {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         if ($this->attributes['label'] === null) {
             return $this->renderOptions();
         }
@@ -89,9 +97,10 @@ class OptGroup extends Element {
     /**
      * @return string
      */
-    protected function renderOptions() {
+    protected function renderOptions()
+    {
         $html = '';
-        foreach($this->options as $key => $val) {
+        foreach ($this->options as $key => $val) {
             $selected = ((string)$key === (string)$this->value) ? ' selected="selected"' : '';
             $attrs = '';
             if (!empty($val['attrs']) && is_array($val['attrs'])) {

--- a/inc/Form/TagCloseElement.php
+++ b/inc/Form/TagCloseElement.php
@@ -9,13 +9,14 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class TagCloseElement extends ValueElement {
-
+class TagCloseElement extends ValueElement
+{
     /**
      * @param string $tag
      * @param array $attributes
      */
-    public function __construct($tag, $attributes = array()) {
+    public function __construct($tag, $attributes = array())
+    {
         parent::__construct('tagclose', $tag, $attributes);
     }
 
@@ -26,7 +27,8 @@ class TagCloseElement extends ValueElement {
      * @return void
      * @throws \BadMethodCallException
      */
-    public function addClass($class) {
+    public function addClass($class)
+    {
         throw new \BadMethodCallException('You can\t add classes to closing tag');
     }
 
@@ -37,7 +39,8 @@ class TagCloseElement extends ValueElement {
      * @return string
      * @throws \BadMethodCallException
      */
-    public function id($id = null) {
+    public function id($id = null)
+    {
         if ($id === null) {
             return '';
         } else {
@@ -53,7 +56,8 @@ class TagCloseElement extends ValueElement {
      * @return string
      * @throws \BadMethodCallException
      */
-    public function attr($name, $value = null) {
+    public function attr($name, $value = null)
+    {
         if ($value === null) {
             return '';
         } else {
@@ -68,7 +72,8 @@ class TagCloseElement extends ValueElement {
      * @return array
      * @throws \BadMethodCallException
      */
-    public function attrs($attributes = null) {
+    public function attrs($attributes = null)
+    {
         if ($attributes === null) {
             return array();
         } else {
@@ -81,7 +86,8 @@ class TagCloseElement extends ValueElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '</'.$this->val().'>';
     }
 

--- a/inc/Form/TagElement.php
+++ b/inc/Form/TagElement.php
@@ -8,13 +8,14 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class TagElement extends ValueElement {
-
+class TagElement extends ValueElement
+{
     /**
      * @param string $tag
      * @param array $attributes
      */
-    public function __construct($tag, $attributes = array()) {
+    public function __construct($tag, $attributes = array())
+    {
         parent::__construct('tag', $tag, $attributes);
     }
 
@@ -23,7 +24,8 @@ class TagElement extends ValueElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '<'.$this->val().' '.buildAttributes($this->attrs()).' />';
     }
 }

--- a/inc/Form/TagOpenElement.php
+++ b/inc/Form/TagOpenElement.php
@@ -9,13 +9,14 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-class TagOpenElement extends ValueElement {
-
+class TagOpenElement extends ValueElement
+{
     /**
      * @param string $tag
      * @param array $attributes
      */
-    public function __construct($tag, $attributes = array()) {
+    public function __construct($tag, $attributes = array())
+    {
         parent::__construct('tagopen', $tag, $attributes);
     }
 
@@ -24,7 +25,8 @@ class TagOpenElement extends ValueElement {
      *
      * @return string
      */
-    public function toHTML() {
+    public function toHTML()
+    {
         return '<'.$this->val().' '.buildAttributes($this->attrs()).'>';
     }
 }

--- a/inc/Form/TextareaElement.php
+++ b/inc/Form/TextareaElement.php
@@ -5,8 +5,8 @@ namespace dokuwiki\Form;
  * Class TextareaElement
  * @package dokuwiki\Form
  */
-class TextareaElement extends InputElement {
-
+class TextareaElement extends InputElement
+{
     /**
      * @var string the actual text within the area
      */
@@ -16,7 +16,8 @@ class TextareaElement extends InputElement {
      * @param string $name The name of this form element
      * @param string $label The label text for this element
      */
-    public function __construct($name, $label) {
+    public function __construct($name, $label)
+    {
         parent::__construct('textarea', $name, $label);
         $this->attr('dir', 'auto');
     }
@@ -29,8 +30,9 @@ class TextareaElement extends InputElement {
      * @param null|string $value
      * @return string|$this
      */
-    public function val($value = null) {
-        if($value !== null) {
+    public function val($value = null)
+    {
+        if ($value !== null) {
             $this->text = cleanText($value);
             return $this;
         }
@@ -42,10 +44,11 @@ class TextareaElement extends InputElement {
      *
      * @return string
      */
-    protected function mainElementHTML() {
-        if($this->useInput) $this->prefillInput();
+    protected function mainElementHTML()
+    {
+        if ($this->useInput) $this->prefillInput();
         return '<textarea ' . buildAttributes($this->attrs()) . '>' .
-        formText($this->val()) . '</textarea>';
+            formText($this->val()) . '</textarea>';
     }
 
 }

--- a/inc/Form/ValueElement.php
+++ b/inc/Form/ValueElement.php
@@ -11,8 +11,8 @@ namespace dokuwiki\Form;
  *
  * @package dokuwiki\Form
  */
-abstract class ValueElement extends Element {
-
+abstract class ValueElement extends Element
+{
     /**
      * @var string holds the element's value
      */
@@ -23,7 +23,8 @@ abstract class ValueElement extends Element {
      * @param string $value
      * @param array $attributes
      */
-    public function __construct($type, $value, $attributes = array()) {
+    public function __construct($type, $value, $attributes = array())
+    {
         parent::__construct($type, $attributes);
         $this->val($value);
     }
@@ -34,8 +35,9 @@ abstract class ValueElement extends Element {
      * @param null|string $value
      * @return string|$this
      */
-    public function val($value = null) {
-        if($value !== null) {
+    public function val($value = null)
+    {
+        if ($value !== null) {
             $this->value = $value;
             return $this;
         }


### PR DESCRIPTION
This PR enables using **Form\Form** class methods instead of **Doku_Form** class to render `<input type="file">` that is used in the Extension Manager (manual install tab). The generic input tag generator will also allow to use new values for type attributes available in HTML5.
