### PR TITLE
Fixed inconsistent handling of falsy values on fperm setting

### DIFF
--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -1000,7 +1000,7 @@ class Indexer {
         if (!empty($lines))
             fwrite($fh, "\n");
         fclose($fh);
-        if (isset($conf['fperm']))
+        if ($conf['fperm'])
             chmod($fn.'.tmp', $conf['fperm']);
         io_rename($fn.'.tmp', $fn.'.idx');
         return true;
@@ -1067,7 +1067,7 @@ class Indexer {
             fwrite($fh, $line);
         }
         fclose($fh);
-        if (isset($conf['fperm']))
+        if ($conf['fperm'])
             chmod($fn.'.tmp', $conf['fperm']);
         io_rename($fn.'.tmp', $fn.'.idx');
         return true;

--- a/inc/init.php
+++ b/inc/init.php
@@ -340,7 +340,7 @@ function init_files(){
             $fh = @fopen($file,'a');
             if($fh){
                 fclose($fh);
-                if(!empty($conf['fperm'])) chmod($file, $conf['fperm']);
+                if($conf['fperm']) chmod($file, $conf['fperm']);
             }else{
                 nice_die("$file is not writable. Check your permissions settings!");
             }

--- a/inc/init.php
+++ b/inc/init.php
@@ -405,7 +405,7 @@ function init_creationmodes(){
 
     // check what is set automatically by the system on file creation
     // and set the fperm param if it's not what we want
-    $auto_fmode = 0666 & ~$umask;
+    $auto_fmode = $conf['fmode'] & ~$umask;
     if($auto_fmode != $conf['fmode']) $conf['fperm'] = $conf['fmode'];
 
     // check what is set automatically by the system on file creation

--- a/inc/io.php
+++ b/inc/io.php
@@ -252,7 +252,7 @@ function _io_saveFile($file, $content, $append) {
         fclose($fh);
     }
 
-    if(!$fileexists and !empty($conf['fperm'])) chmod($file, $conf['fperm']);
+    if(!$fileexists and $conf['fperm']) chmod($file, $conf['fperm']);
     return true;
 }
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -2082,7 +2082,7 @@ function media_resize_image($file, $ext, $w, $h=0){
         media_resize_imageIM($ext, $file, $info[0], $info[1], $local, $w, $h) ||
         media_resize_imageGD($ext, $file, $info[0], $info[1], $local, $w, $h)
     ) {
-        if(!empty($conf['fperm'])) @chmod($local, $conf['fperm']);
+        if($conf['fperm']) @chmod($local, $conf['fperm']);
         return $local;
     }
     //still here? resizing failed
@@ -2149,7 +2149,7 @@ function media_crop_image($file, $ext, $w, $h=0){
     if( $mtime > @filemtime($file) ||
             media_crop_imageIM($ext,$file,$info[0],$info[1],$local,$cw,$ch,$cx,$cy) ||
             media_resize_imageGD($ext,$file,$cw,$ch,$local,$cw,$ch,$cx,$cy) ){
-        if(!empty($conf['fperm'])) @chmod($local, $conf['fperm']);
+        if($conf['fperm']) @chmod($local, $conf['fperm']);
         return media_resize_image($local,$ext, $w, $h);
     }
 

--- a/lib/plugins/extension/helper/extension.php
+++ b/lib/plugins/extension/helper/extension.php
@@ -1238,10 +1238,10 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
             closedir($dh);
             return $ok;
         } else {
-            $exists = file_exists($dst);
+            $existed = file_exists($dst);
 
             if (!@copy($src, $dst)) return false;
-            if (!$exists && !empty($conf['fperm'])) chmod($dst, $conf['fperm']);
+            if (!$existed && $conf['fperm']) chmod($dst, $conf['fperm']);
             @touch($dst, filemtime($src));
         }
 


### PR DESCRIPTION
The $conf['fperm'] value was checked in multiple files using different methods.
This can cause permission trouble with restricted environments, i.e. when chmod is forbidden and file permissions are non-default.
Now, all checks use implicit cast to boolean which leads to consistent behaviour.

Also, a misleading variable was renamed in context to better understand one of the checks.