### PR TITLE
calculate content min-height based on height of aside and pagetool

### DIFF
--- a/lib/tpl/dokuwiki/script.js
+++ b/lib/tpl/dokuwiki/script.js
@@ -71,10 +71,15 @@ jQuery(function(){
     );
 
     // increase sidebar length to match content (desktop mode only)
-    var $sidebar = jQuery('.desktop #dokuwiki__aside');
-    if($sidebar.length) {
+    var sidebar_height = jQuery('.desktop #dokuwiki__aside').height();
+    var pagetool_height = jQuery('.desktop #dokuwiki__pagetools ul:first').height();
+    // pagetools div has no height; ul has a height
+    var content_min = Math.max(sidebar_height || 0, pagetool_height || 0);
+
+    var content_height = jQuery('#dokuwiki__content div.page').height();
+    if(content_min && content_min > content_height) {
         var $content = jQuery('#dokuwiki__content div.page');
-        $content.css('min-height', $sidebar.height());
+        $content.css('min-height', content_min);
     }
 
     // blur when clicked


### PR DESCRIPTION
Fixes #1716. Before it will only set min-height based on aside height.

I added a current height check before applying min-height, because there might be a min-height CSS on .page in stylesheet, and I want to respect that and only apply if necessery.