### PR TITLE
jquery-migrate: replace on()/trigger() shorthand and use prop() for disabled attr

### DIFF
--- a/lib/plugins/acl/script.js
+++ b/lib/plugins/acl/script.js
@@ -15,8 +15,8 @@ var dw_acl = {
             return;
         }
 
-        jQuery('#acl__user select').change(dw_acl.userselhandler);
-        jQuery('#acl__user button').click(dw_acl.loadinfo);
+        jQuery('#acl__user select').on('change', dw_acl.userselhandler);
+        jQuery('#acl__user button').on('click', dw_acl.loadinfo);
 
         $tree = jQuery('#acl__tree');
         $tree.dw_tree({toggle_selector: 'img',

--- a/lib/plugins/extension/script.js
+++ b/lib/plugins/extension/script.js
@@ -5,7 +5,7 @@ jQuery(function(){
     /**
      * Confirm uninstalling
      */
-    $extmgr.find('button.uninstall').click(function(e){
+    $extmgr.find('button.uninstall').on('click', function(e){
         if(!window.confirm(LANG.plugins.extension.reallydel)){
             e.preventDefault();
             return false;
@@ -17,7 +17,7 @@ jQuery(function(){
      * very simple lightbox
      * @link http://webdesign.tutsplus.com/tutorials/htmlcss-tutorials/super-simple-lightbox-with-css-and-jquery/
      */
-    $extmgr.find('a.extension_screenshot').click(function(e) {
+    $extmgr.find('a.extension_screenshot').on('click', function(e) {
         e.preventDefault();
 
         //Get clicked link href
@@ -29,7 +29,7 @@ jQuery(function(){
             $lightbox = jQuery('<div id="plugin__extensionlightbox"><p>Click to close</p><div></div></div>')
                 .appendTo(jQuery('body'))
                 .hide()
-                .click(function(){
+                .on('click', function(){
                     $lightbox.hide();
                 });
         }
@@ -46,7 +46,7 @@ jQuery(function(){
     /**
      * Enable/Disable extension via AJAX
      */
-    $extmgr.find('button.disable, button.enable').click(function (e) {
+    $extmgr.find('button.disable, button.enable').on('click', function (e) {
         e.preventDefault();
         var $btn = jQuery(this);
 
@@ -85,7 +85,7 @@ jQuery(function(){
     /**
      * AJAX detail infos
      */
-    $extmgr.find('a.info').click(function(e){
+    $extmgr.find('a.info').on('click', function(e){
         e.preventDefault();
 
         var $link = jQuery(this);
@@ -129,12 +129,12 @@ jQuery(function(){
             var $label = jQuery( '<label></label>' )
                 .appendTo($displayOpts);
             var $input = jQuery( '<input />', { type: 'checkbox', name: chkName })
-                .change(displayOptionsHandler)
+                .on('change', displayOptionsHandler)
                 .appendTo($label);
 
             var previous = DokuCookie.getValue('ext_'+chkName);
             if(typeof previous === "undefined" || previous == '1') {
-                $input.click();
+                $input.trigger('click');
             }
 
             jQuery( '<span/>' )

--- a/lib/plugins/styling/script.js
+++ b/lib/plugins/styling/script.js
@@ -64,7 +64,7 @@ jQuery(function () {
         var $btn = jQuery('<button>' + LANG.plugins.styling.popup + '</button>');
         $form.prepend($btn);
 
-        $btn.click(function (e) {
+        $btn.on('click', function (e) {
             var windowFeatures = "menubar=no,location=no,resizable=yes,scrollbars=yes,status=false,width=500,height=500";
             window.open(DOKU_BASE + 'lib/plugins/styling/popup.php', 'styling_popup', windowFeatures);
             e.preventDefault();

--- a/lib/plugins/usermanager/script.js
+++ b/lib/plugins/usermanager/script.js
@@ -2,7 +2,7 @@
  * Add JavaScript confirmation to the User Delete button
  */
 jQuery(function(){
-    jQuery('#usrmgr__del').click(function(){
+    jQuery('#usrmgr__del').on('click', function(){
         return confirm(LANG.del_confirm);
     });
 });

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -85,14 +85,14 @@ var dw_behaviour = {
      * Looks for an element with the ID focus__this at sets focus to it
      */
     focusMarker: function(){
-        jQuery('#focus__this').focus();
+        jQuery('#focus__this').trigger('focus');
     },
 
     /**
      * Remove all search highlighting when clicking on a highlighted term
      */
     removeHighlightOnClick: function(){
-        jQuery('span.search_hit').click(
+        jQuery('span.search_hit').on('click',
             function(e){
                 jQuery(e.target).removeClass('search_hit', 1000);
             }
@@ -110,7 +110,7 @@ var dw_behaviour = {
      */
     quickSelect: function(){
         jQuery('select.quickselect')
-            .change(function(e){ e.target.form.submit(); })
+            .on('change', function(e){ e.target.form.submit(); })
             .closest('form').find(':button').not('.show').hide();
     },
 
@@ -146,7 +146,7 @@ var dw_behaviour = {
         $digest = $form.find("input[name='sub_style'][value='digest']");
 
         $form.find("input[name='sub_target']")
-            .click(
+            .on('click',
                 function () {
                     var $this = jQuery(this), show_list;
                     if (!$this.prop('checked')) {
@@ -161,7 +161,7 @@ var dw_behaviour = {
                 }
             )
             .filter(':checked')
-            .click();
+            .trigger('click');
     },
 
     /**
@@ -177,15 +177,15 @@ var dw_behaviour = {
         var $button    = jQuery('button', $revisions);
 
         if($checked.length < 2) {
-            $all.removeAttr('disabled');
-            $button.attr('disabled', true);
+            $all.prop('disabled', false);
+            $button.prop('disabled', true);
         } else {
-            $all.attr('disabled', true);
-            $button.removeAttr('disabled');
+            $all.prop('disabled', true);
+            $button.prop('disabled', false);
             $checked.each(function(i) {
-                jQuery(this).removeAttr('disabled');
+                jQuery(this).prop('disabled', false);
                 if(i>1) {
-                    jQuery(this).attr('checked', false);
+                    jQuery(this).prop('checked', false);
                 }
             });
         }

--- a/lib/scripts/edit.js
+++ b/lib/scripts/edit.js
@@ -238,7 +238,7 @@ jQuery(function () {
         sel.start = 0;
         sel.end   = 0;
         DWsetSelection(sel);
-        $edit_text.focus();
+        $edit_text.trigger('focus');
 
         doku_edit_text_content = $edit_text.val();
     }
@@ -260,13 +260,13 @@ jQuery(function () {
     window.onunload = deleteDraft;
 
     // reset change memory var on submit
-    jQuery('#edbtn__save').click(
+    jQuery('#edbtn__save').on('click',
         function() {
             window.onbeforeunload = '';
             textChanged = false;
         }
     );
-    jQuery('#edbtn__preview').click(
+    jQuery('#edbtn__preview').on('click',
         function() {
             window.onbeforeunload = '';
             textChanged = false;
@@ -275,8 +275,7 @@ jQuery(function () {
     );
 
     var $summary = jQuery('#edit__summary');
-    $summary.change(doku_summaryCheck);
-    $summary.keyup(doku_summaryCheck);
+    $summary.on('change keyup', doku_summaryCheck);
 
     if (textChanged) doku_summaryCheck();
 });

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -60,7 +60,7 @@ var dw_editor = {
             jQuery(document.createElement('img'))
                 .attr('src', DOKU_BASE+'lib/images/' + img[0] + '.gif')
                 .attr('alt', '')
-                .click(img[1])
+                .on('click', img[1])
                 .appendTo($ctl);
         });
     },
@@ -140,7 +140,7 @@ var dw_editor = {
 
         if((e.keyCode == 13 || e.keyCode == 10) && e.ctrlKey) { // Ctrl-Enter (With Chrome workaround)
             // Submit current edit
-            jQuery('#edbtn__save').click();
+            jQuery('#edbtn__save').trigger('click');
             e.preventDefault(); // prevent enter key
             return false;
         }else if(e.keyCode == 13){ // Enter

--- a/lib/scripts/fileuploaderextended.js
+++ b/lib/scripts/fileuploaderextended.js
@@ -149,7 +149,7 @@ qq.extend(qq.FileUploaderExtended.prototype, {
             self._handler._options.onUpload();
 
             jQuery(".qq-upload-name-input").each(function (i) {
-                jQuery(this).attr('disabled', 'disabled');
+                jQuery(this).prop('disabled', true);
             });
         });
     },

--- a/lib/scripts/linkwiz.js
+++ b/lib/scripts/linkwiz.js
@@ -57,7 +57,7 @@ var dw_linkwiz = {
         }
 
         // attach event handlers
-        jQuery('#link__wiz .ui-dialog-titlebar-close').click(dw_linkwiz.hide);
+        jQuery('#link__wiz .ui-dialog-titlebar-close').on('click', dw_linkwiz.hide);
         dw_linkwiz.$entry.keyup(dw_linkwiz.onEntry);
         jQuery(dw_linkwiz.result).on('click', 'a', dw_linkwiz.onResultClick);
     },

--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -107,7 +107,7 @@ var dw_mediamanager = {
 
         dw_mediamanager.update_resizable();
         dw_mediamanager.layout_width = $page.width();
-        jQuery(window).resize(dw_mediamanager.window_resize);
+        jQuery(window).on('resize', dw_mediamanager.window_resize);
     },
 
     init_options: function () {
@@ -194,7 +194,7 @@ var dw_mediamanager = {
                     .addClass('button')
                     .attr('id', "media__" + opt.id + "btn" + (i + 1))
                     .attr('title', LANG['media' + text])
-                    .click(bind(dw_mediamanager.setOpt, opt.id));
+                    .on('click', bind(dw_mediamanager.setOpt, opt.id));
 
                 $img = jQuery(document.createElement('img'))
                     .attr('src', DOKU_BASE + 'lib/images/media_' + opt.id + '_' + text + '.png');
@@ -735,7 +735,7 @@ var dw_mediamanager = {
 
         // remove old callback from the insert button and set the new one.
         var $sendbtn = jQuery('#media__sendbtn');
-        $sendbtn.off().click(bind(dw_mediamanager.insert, id));
+        $sendbtn.off().on('click', bind(dw_mediamanager.insert, id));
 
         dw_mediamanager.unforbid('ext');
         if (ext === '.swf') {
@@ -801,7 +801,7 @@ var dw_mediamanager = {
                 $box = jQuery(document.createElement('input'))
                     .attr('type', 'checkbox')
                     .attr('id', 'media__' + opt[0])
-                    .click(bind(dw_mediamanager.toggleOption, opt[0]));
+                    .on('click', bind(dw_mediamanager.toggleOption, opt[0]));
 
                 if (DokuCookie.getValue(opt[0])) {
                     $box.prop('checked', true);

--- a/lib/scripts/page.js
+++ b/lib/scripts/page.js
@@ -9,7 +9,7 @@ dw_page = {
      */
     init: function(){
         dw_page.sectionHighlight();
-        jQuery('a.fn_top').mouseover(dw_page.footnoteDisplay);
+        jQuery('a.fn_top').on('mouseover', dw_page.footnoteDisplay);
         dw_page.makeToggle('#dw__toc h3','#dw__toc > div');
     },
 
@@ -20,7 +20,7 @@ dw_page = {
      */
     sectionHighlight: function() {
         jQuery('form.btn_secedit')
-            .mouseover(function(){
+            .on('mouseover', function(){
                 var $tgt = jQuery(this).parent(),
                     nr = $tgt.attr('class').match(/(\s+|^)editbutton_(\d+)(\s+|$)/)[2],
                     $highlight = jQuery(),                                             // holder for elements in the section to be highlighted
@@ -36,7 +36,7 @@ dw_page = {
               // and move the elements to be highlighted inside the section highlight wrapper
               $highlight.detach().appendTo($highlightWrap);
             })
-            .mouseout(function(){
+            .on('mouseout', function(){
                 // find the section highlight wrapper...
                 var $highlightWrap = jQuery('.section_highlight');
                 // ...move its children in front of it (as siblings)...
@@ -63,7 +63,7 @@ dw_page = {
                 .attr('id', popup_id)
                 .addClass('insitu-footnote JSpopup')
                 .attr('aria-hidden', 'true')
-                .mouseleave(function () {jQuery(this).hide().attr('aria-hidden', 'true');})
+                .on('mouseleave', function () {jQuery(this).hide().attr('aria-hidden', 'true');})
                 .attr('role', 'tooltip');
             jQuery('.dokuwiki:first').append($fndiv);
         }
@@ -179,7 +179,7 @@ dw_page = {
 
         // click function
         $handle.css('cursor','pointer')
-               .click($handle[0].setState)
+               .on('click', $handle[0].setState)
                .prepend($clicky);
 
         // initial state

--- a/lib/scripts/qsearch.js
+++ b/lib/scripts/qsearch.js
@@ -57,7 +57,7 @@ jQuery.fn.dw_qsearch = function (overrides) {
                 );
             };
 
-            dw_qsearch.$inObj.keyup(
+            dw_qsearch.$inObj.on('keyup',
                 function () {
                     if (dw_qsearch.timer) {
                         window.clearTimeout(dw_qsearch.timer);
@@ -68,7 +68,7 @@ jQuery.fn.dw_qsearch = function (overrides) {
             );
 
             // attach eventhandler to output field
-            dw_qsearch.$outObj.click(dw_qsearch.clear_results);
+            dw_qsearch.$outObj.on('click', dw_qsearch.clear_results);
         },
 
         /**

--- a/lib/scripts/script.js
+++ b/lib/scripts/script.js
@@ -26,5 +26,5 @@ function closePopups(){
 }
 
 jQuery(function () {
-    jQuery(document).click(closePopups);
+    jQuery(document).on('click', closePopups);
 });

--- a/lib/scripts/search.js
+++ b/lib/scripts/search.js
@@ -30,7 +30,7 @@ jQuery(function () {
     });
 
     if (DokuCookie.getValue('sa') === 'on') {
-        $toggleAssistanceButton.click();
+        $toggleAssistanceButton.trigger('click');
     }
 
     $searchForm.find('.advancedOptions .toggle div.current').on('click', function () {


### PR DESCRIPTION
Related to #1546, on the way to remove jQuery migrate before its warnings got fixed.