### PR TITLE
Show pencil symbol on preview

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -960,6 +960,7 @@ function tpl_pagetitle($id = null, $ret = false) {
 
         // page functions
         case 'edit' :
+        case 'preview' :
             $page_title = "✎ ".$name;
             break;
 


### PR DESCRIPTION
The pencil symbol shown in the page title when editing a page disappears once the preview button is clicked since the action changes. This adds the pencil symbol to the preview page (where you are still editing) as well.