### PR TITLE
Add random_bytes check in installer

### DIFF
--- a/inc/lang/en/lang.php
+++ b/inc/lang/en/lang.php
@@ -321,6 +321,7 @@ $lang['i_modified']            = 'For security reasons this script will only wor
 $lang['i_funcna']              = 'PHP function <code>%s</code> is not available. Maybe your hosting provider disabled it for some reason?';
 $lang['i_phpver']              = 'Your PHP version <code>%s</code> is lower than the needed <code>%s</code>. You need to upgrade your PHP install.';
 $lang['i_mbfuncoverload']      = 'mbstring.func_overload must be disabled in php.ini to run DokuWiki.';
+$lang['i_urandom']             = 'DokuWiki cannot create cryptographically secure numbers for cookies. You may want to check your open_basedir settings in php.ini for proper <code>/dev/urandom</code> access.';
 $lang['i_permfail']            = '<code>%s</code> is not writable by DokuWiki. You need to fix the permission settings of this directory!';
 $lang['i_confexists']          = '<code>%s</code> already exists';
 $lang['i_writeerr']            = 'Unable to create <code>%s</code>. You will need to check directory/file permissions and create the file manually.';

--- a/install.php
+++ b/install.php
@@ -565,6 +565,20 @@ function check_functions(){
         $ok = false;
     }
 
+    try {
+        random_bytes(1);
+    } catch (\Exception $th) {
+        // If an appropriate source of randomness cannot be found, an Exception will be thrown by PHP 7+
+        // this exception is also thrown by paragonie/random_compat for PHP 5.6 support
+        $error[] = $lang['i_urandom'];
+        $ok = false;
+    }
+
+    if(ini_get('mbstring.func_overload') != 0){
+        $error[] = $lang['i_mbfuncoverload'];
+        $ok = false;
+    }
+
     $funcs = explode(' ','addslashes call_user_func chmod copy fgets '.
                          'file file_exists fseek flush filesize ftell fopen '.
                          'glob header ignore_user_abort ini_get mail mkdir '.


### PR DESCRIPTION
Fixes #1892. This will be triggered by:

- PHP 7+: "If an appropriate source of randomness cannot be found, an Exception will be thrown"
- paragonie/random_compat: PHP 5.6 support will fail if urandom is not readable