### PR TITLE
Prevent double encoding audio/video titles

### DIFF
--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -133,6 +133,17 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $this->assertEquals($rest, substr($url, $substr_start));
     }
 
+    function testVideoInternalTitle() {
+        $file = 'wiki:kind_zu_katze.ogv';
+        $title = 'Single quote: \' Ampersand: &';
+        
+        $Renderer = new Doku_Renderer_xhtml();
+        $url = $Renderer->externalmedia($file, $title, null, null, null, 'cache', 'details', true);
+        
+        // make sure the title is escaped just once
+        $this->assertEquals(htmlspecialchars($title), substr($url, 28, 32));
+    }
+
     function testSimpleLinkText() {
         $file = 'wiki:dokuwiki-128.png';
         $parser_response = p_get_instructions('{{' . $file . '|This is a simple text.}}');

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1671,11 +1671,11 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
 
         } elseif(media_supportedav($mime, 'video') || media_supportedav($mime, 'audio')) {
             // first get the $title
-            $title = !is_null($title) ? $this->_xmlEntities($title) : false;
+            $title = !is_null($title) ? $title : false;
             if(!$render) {
                 // if the file is not supposed to be rendered
                 // return the title of the file (just the sourcename if there is no title)
-                return $title ? $title : $this->_xmlEntities(\dokuwiki\Utf8\PhpString::basename(noNS($src)));
+                return $this->_xmlEntities($title ? $title : \dokuwiki\Utf8\PhpString::basename(noNS($src)));
             }
 
             $att          = array();


### PR DESCRIPTION
`{{video.mp4|Single quote: ' Ampersand: &}}`
Audio/video files like the above will have double-encoded HTML entities showing in their `title` attribute.

This fixes that by removing an unnecessary `_xmlEntities()` call.
The title gets escaped later by `_audio()`/`_video()` which passes it through `buildAttributes()`:

https://github.com/splitbrain/dokuwiki/blob/c22dd092c4c44d7d648d88cb32606880af5156c7/inc/parser/xhtml.php#L1871

https://github.com/splitbrain/dokuwiki/blob/246d33375d7a319f09d2b596725e38a48dd90794/inc/common.php#L376