### PR TITLE
change Revert permission to EDIT from manager

### DIFF
--- a/_test/tests/inc/Action/general.test.php
+++ b/_test/tests/inc/Action/general.test.php
@@ -23,7 +23,7 @@ class action_general extends DokuWikiTest {
             array('Resendpwd', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
             array('Backlink', AUTH_NONE, array('exists' => true, 'ismanager' => false)),
 
-            array('Revert', AUTH_ADMIN, array('exists' => true, 'ismanager' => false)),
+            array('Revert', AUTH_EDIT, array('exists' => true, 'ismanager' => false)),
             array('Revert', AUTH_EDIT, array('exists' => true, 'ismanager' => true)),
 
             array('Admin', AUTH_READ, array('exists' => true, 'ismanager' => false)), // let in, check later again

--- a/inc/Action/Revert.php
+++ b/inc/Action/Revert.php
@@ -16,12 +16,7 @@ class Revert extends AbstractAction {
 
     /** @inheritdoc */
     public function minimumPermission() {
-        global $INFO;
-        if($INFO['ismanager']) {
-            return AUTH_EDIT;
-        } else {
-            return AUTH_ADMIN;
-        }
+        return AUTH_EDIT;
     }
 
     /**

--- a/inc/Menu/Item/Revert.php
+++ b/inc/Menu/Item/Revert.php
@@ -15,7 +15,7 @@ class Revert extends AbstractItem {
         global $INFO;
         parent::__construct();
 
-        if(!$INFO['ismanager'] || !$REV || !$INFO['writable']) {
+        if(!$REV || !$INFO['writable']) {
             throw new \RuntimeException('revert not available');
         }
         $this->params['rev'] = $REV;


### PR DESCRIPTION
Revert is another type of edit, which may be simulated by manual editing without using this shortcut. This patch thus relaxes the permission check.

Thank you @Klap-in for pointing this out.