### PR TITLE
catch ArgumentCountError and return XML error message for remoteAPI

### DIFF
--- a/_test/mock/AuthCaseInsensitivePlugin.php
+++ b/_test/mock/AuthCaseInsensitivePlugin.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace dokuwiki\test\mock;
+
+/**
+ * Class dokuwiki\Plugin\DokuWiki_Auth_Plugin
+ */
+class AuthCaseInsensitivePlugin extends AuthPlugin {
+    function isCaseSensitive(){
+        return false;
+    }
+}

--- a/_test/mock/AuthDeletePlugin.php
+++ b/_test/mock/AuthDeletePlugin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace dokuwiki\test\mock;
+
+/**
+ * Class dokuwiki\Plugin\DokuWiki_Auth_Plugin
+ */
+class AuthDeletePlugin extends AuthPlugin {
+
+    public $loggedOff = false;
+
+    public function __construct($canDeleteUser = true) {
+        $this->cando['delUser'] = $canDeleteUser;
+    }
+
+    public function checkPass($user, $pass) {
+        return $pass == 'password';
+    }
+
+    public function deleteUsers($users) {
+        return in_array($_SERVER['REMOTE_USER'], $users);
+    }
+
+    public function logoff() {
+        $this->loggedOff = true;
+    }
+
+}

--- a/_test/tests/inc/auth_aclcheck_caseinsensitive.test.php
+++ b/_test/tests/inc/auth_aclcheck_caseinsensitive.test.php
@@ -1,12 +1,6 @@
 <?php
 
-use dokuwiki\Extension\AuthPlugin;
-
-class auth_acl_caseinsensitive_auth extends AuthPlugin {
-    function isCaseSensitive() {
-        return false;
-    }
-}
+use dokuwiki\test\mock\AuthCaseInsensitivePlugin;
 
 class auth_acl_caseinsensitive_test extends DokuWikiTest {
     protected $oldAuth;
@@ -20,7 +14,7 @@ class auth_acl_caseinsensitive_test extends DokuWikiTest {
         $this->oldAuth    = $auth;
         $this->oldAuthAcl = $AUTH_ACL;
 
-        $auth = new auth_acl_caseinsensitive_auth();
+        $auth = new AuthCaseInsensitivePlugin();
     }
 
     function tearDown() {

--- a/_test/tests/inc/auth_admincheck.test.php
+++ b/_test/tests/inc/auth_admincheck.test.php
@@ -1,12 +1,7 @@
 <?php
 
 use dokuwiki\test\mock\AuthPlugin;
-
-class auth_admin_test_AuthInSensitive extends AuthPlugin {
-    function isCaseSensitive(){
-        return false;
-    }
-}
+use dokuwiki\test\mock\AuthCaseInsensitivePlugin;
 
 class auth_admin_test extends DokuWikiTest {
 
@@ -25,7 +20,7 @@ class auth_admin_test extends DokuWikiTest {
 
     function setInSensitive() {
         global $auth;
-        $auth = new auth_admin_test_AuthInSensitive();
+        $auth = new AuthCaseInsensitivePlugin();
     }
 
     function teardown() {

--- a/_test/tests/inc/auth_deleteprofile.test.php
+++ b/_test/tests/inc/auth_deleteprofile.test.php
@@ -1,29 +1,7 @@
 <?php
 
 use dokuwiki\Input\Input;
-use dokuwiki\Extension\AuthPlugin;
-
-class auth_deleteprofile_test_AuthDelete extends AuthPlugin {
-
-    public $loggedOff = false;
-
-    public function __construct($canDeleteUser = true) {
-        $this->cando['delUser'] = $canDeleteUser;
-    }
-
-    public function checkPass($user, $pass) {
-        return $pass == 'password';
-    }
-
-    public function deleteUsers($users) {
-        return in_array($_SERVER['REMOTE_USER'], $users);
-    }
-
-    public function logoff() {
-        $this->loggedOff = true;
-    }
-
-}
+use dokuwiki\test\mock\AuthDeletePlugin;
 
 class auth_deleteprofile_test extends DokuWikiTest {
 
@@ -56,7 +34,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new auth_deleteprofile_test_AuthDelete();
+        $auth = new AuthDeletePlugin();
 
         $this->assertTrue(auth_deleteprofile());
         $this->assertTrue($auth->loggedOff);
@@ -82,7 +60,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new auth_deleteprofile_test_AuthDelete();
+        $auth = new AuthDeletePlugin();
 
         // password check required - it fails, so don't delete profile
         $this->assertFalse(auth_deleteprofile());
@@ -112,7 +90,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new auth_deleteprofile_test_AuthDelete(false);
+        $auth = new AuthDeletePlugin(false);
         $conf['disableactions'] = '';
         $this->assertFalse(auth_deleteprofile());
     }
@@ -136,7 +114,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new auth_deleteprofile_test_AuthDelete();
+        $auth = new AuthDeletePlugin();
         $conf['disableactions'] = 'profile_delete';
 
         $this->assertFalse(actionOK('profile_delete'));
@@ -165,7 +143,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $input_foundation = new Input();
 
-        $auth = new auth_deleteprofile_test_AuthDelete();
+        $auth = new AuthDeletePlugin();
 
         $INPUT = clone $input_foundation;
         $INPUT->remove('delete');

--- a/_test/tests/inc/auth_deleteprofile.test.php
+++ b/_test/tests/inc/auth_deleteprofile.test.php
@@ -3,7 +3,7 @@
 use dokuwiki\Input\Input;
 use dokuwiki\Extension\AuthPlugin;
 
-class Mock_Auth_Plugin extends AuthPlugin {
+class auth_deleteprofile_test_AuthDelete extends AuthPlugin {
 
     public $loggedOff = false;
 
@@ -56,7 +56,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new Mock_Auth_Plugin();
+        $auth = new auth_deleteprofile_test_AuthDelete();
 
         $this->assertTrue(auth_deleteprofile());
         $this->assertTrue($auth->loggedOff);
@@ -82,7 +82,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new Mock_Auth_Plugin();
+        $auth = new auth_deleteprofile_test_AuthDelete();
 
         // password check required - it fails, so don't delete profile
         $this->assertFalse(auth_deleteprofile());
@@ -112,7 +112,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new Mock_Auth_Plugin(false);
+        $auth = new auth_deleteprofile_test_AuthDelete(false);
         $conf['disableactions'] = '';
         $this->assertFalse(auth_deleteprofile());
     }
@@ -136,7 +136,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $INPUT = new Input();
 
-        $auth = new Mock_Auth_Plugin();
+        $auth = new auth_deleteprofile_test_AuthDelete();
         $conf['disableactions'] = 'profile_delete';
 
         $this->assertFalse(actionOK('profile_delete'));
@@ -165,7 +165,7 @@ class auth_deleteprofile_test extends DokuWikiTest {
         $_REQUEST = $input;
         $input_foundation = new Input();
 
-        $auth = new Mock_Auth_Plugin();
+        $auth = new auth_deleteprofile_test_AuthDelete();
 
         $INPUT = clone $input_foundation;
         $INPUT->remove('delete');

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -328,7 +328,7 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        $remoteApi->call('wiki.twoArgWithDefaultArg', array());
+        @$remoteApi->call('wiki.twoArgWithDefaultArg', array());
     }
 
     function test_pluginCallMethods() {
@@ -355,7 +355,7 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        $remoteApi->call('plugin.testplugin.method2', array());
+        @$remoteApi->call('plugin.testplugin.method2', array());
     }
 
     /**

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -3,6 +3,7 @@
 use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\RemotePlugin;
 use dokuwiki\Remote\Api;
+use dokuwiki\Remote\RemoteException;
 
 class remote_test_MockAuthCase extends AuthPlugin {
     function isCaseSensitive() { return true; }
@@ -263,13 +264,16 @@ class remote_test extends DokuWikiTest {
         $this->assertTrue(true); // avoid being marked as risky for having no assertion
     }
 
-    /**
-     * @expectedException dokuwiki\Remote\RemoteException
-     */
     function test_forceAccessFail() {
         global $conf;
         $conf['remote'] = 0;
-        $this->remote->forceAccess();
+
+        try {
+            $this->remote->forceAccess();
+            $this->fail('Expects RemoteException to be raised');
+        } catch (RemoteException $th) {
+            $this->assertEquals(-32604, $th->getCode());
+        }
     }
 
     function test_generalCoreFunctionWithoutArguments() {
@@ -290,16 +294,18 @@ class remote_test extends DokuWikiTest {
         $this->assertEquals($remoteApi->call('wiki.voidTestMethod'), null);
     }
 
-    /**
-     * @expectedException dokuwiki\Remote\RemoteException
-     */
     function test_generalCoreFunctionOnArgumentMismatch() {
         global $conf;
         $conf['remote'] = 1;
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        $remoteApi->call('wiki.voidTestMethod', array('something'));
+        try {
+            $remoteApi->call('wiki.voidTestMethod', array('something'));
+            $this->fail('Expects RemoteException to be raised');
+        } catch (RemoteException $th) {
+            $this->assertEquals(-32604, $th->getCode());
+        }
     }
 
     function test_generalCoreFunctionWithArguments() {
@@ -318,9 +324,6 @@ class remote_test extends DokuWikiTest {
         $this->assertEquals($remoteApi->call('wiki.twoArgWithDefaultArg', array('string', 'another')), array('string', 'another'));
     }
 
-    /**
-     * @expectedException dokuwiki\Remote\RemoteException
-     */
     function test_generalCoreFunctionOnArgumentMissing() {
         global $conf;
         $conf['remote'] = 1;
@@ -328,7 +331,12 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        $remoteApi->call('wiki.twoArgWithDefaultArg', array());
+        try {
+            $remoteApi->call('wiki.twoArgWithDefaultArg', array());
+            $this->fail('Expects RemoteException to be raised');
+        } catch (RemoteException $th) {
+            $this->assertEquals(-32603, $th->getCode());
+        }
     }
 
     function test_pluginCallMethods() {
@@ -345,9 +353,6 @@ class remote_test extends DokuWikiTest {
         $this->assertEquals($remoteApi->call('plugin.testplugin.methodString'), 'success');
     }
 
-    /**
-     * @expectedException dokuwiki\Remote\RemoteException
-     */
     function test_pluginCallMethodsOnArgumentMissing() {
         global $conf;
         $conf['remote'] = 1;
@@ -355,18 +360,25 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        $remoteApi->call('plugin.testplugin.method2', array());
+        try {
+            $remoteApi->call('plugin.testplugin.method2', array());
+            $this->fail('Expects RemoteException to be raised');
+        } catch (RemoteException $th) {
+            $this->assertEquals(-32603, $th->getCode());
+        }
     }
 
-    /**
-     * @expectedException dokuwiki\Remote\RemoteException
-     */
     function test_notExistingCall() {
         global $conf;
         $conf['remote'] = 1;
 
         $remoteApi = new Api();
-        $remoteApi->call('dose not exist');
+        try {
+            $remoteApi->call('dose not exist');
+            $this->fail('Expects RemoteException to be raised');
+        } catch (RemoteException $th) {
+            $this->assertEquals(-32603, $th->getCode());
+        }
     }
 
     function test_publicCallCore() {

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -4,7 +4,7 @@ use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\RemotePlugin;
 use dokuwiki\Remote\Api;
 
-class MockAuth extends AuthPlugin {
+class remote_test_MockAuthCase extends AuthPlugin {
     function isCaseSensitive() { return true; }
 }
 
@@ -168,7 +168,7 @@ class remote_test extends DokuWikiTest {
         $this->userinfo = $USERINFO;
         $this->remote = new Api();
 
-        $auth = new MockAuth();
+        $auth = new remote_test_MockAuthCase();
     }
 
     function tearDown() {

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -1,13 +1,9 @@
 <?php
 
-use dokuwiki\Extension\AuthPlugin;
+use dokuwiki\test\mock\AuthPlugin;
 use dokuwiki\Extension\RemotePlugin;
 use dokuwiki\Remote\Api;
 use dokuwiki\Remote\RemoteException;
-
-class remote_test_MockAuthCase extends AuthPlugin {
-    function isCaseSensitive() { return true; }
-}
 
 class RemoteAPICoreTest {
 
@@ -169,7 +165,7 @@ class remote_test extends DokuWikiTest {
         $this->userinfo = $USERINFO;
         $this->remote = new Api();
 
-        $auth = new remote_test_MockAuthCase();
+        $auth = new AuthPlugin();
     }
 
     function tearDown() {

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -318,6 +318,19 @@ class remote_test extends DokuWikiTest {
         $this->assertEquals($remoteApi->call('wiki.twoArgWithDefaultArg', array('string', 'another')), array('string', 'another'));
     }
 
+    /**
+     * @expectedException dokuwiki\Remote\RemoteException
+     */
+    function test_generalCoreFunctionOnArgumentMissing() {
+        global $conf;
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $remoteApi = new Api();
+        $remoteApi->getCoreMethods(new RemoteAPICoreTest());
+
+        $remoteApi->call('wiki.twoArgWithDefaultArg', array());
+    }
+
     function test_pluginCallMethods() {
         global $conf;
         global $USERINFO;
@@ -330,6 +343,19 @@ class remote_test extends DokuWikiTest {
         $this->assertEquals($remoteApi->call('plugin.testplugin.method2', array('string', 7)), array('string', 7, false));
         $this->assertEquals($remoteApi->call('plugin.testplugin.method2ext', array('string', 7, true)), array('string', 7, true));
         $this->assertEquals($remoteApi->call('plugin.testplugin.methodString'), 'success');
+    }
+
+    /**
+     * @expectedException dokuwiki\Remote\RemoteException
+     */
+    function test_pluginCallMethodsOnArgumentMissing() {
+        global $conf;
+        $conf['remote'] = 1;
+        $conf['remoteuser'] = '';
+        $remoteApi = new Api();
+        $remoteApi->getCoreMethods(new RemoteAPICoreTest());
+
+        $remoteApi->call('plugin.testplugin.method2', array());
     }
 
     /**

--- a/_test/tests/inc/remote.test.php
+++ b/_test/tests/inc/remote.test.php
@@ -328,7 +328,7 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        @$remoteApi->call('wiki.twoArgWithDefaultArg', array());
+        $remoteApi->call('wiki.twoArgWithDefaultArg', array());
     }
 
     function test_pluginCallMethods() {
@@ -355,7 +355,7 @@ class remote_test extends DokuWikiTest {
         $remoteApi = new Api();
         $remoteApi->getCoreMethods(new RemoteAPICoreTest());
 
-        @$remoteApi->call('plugin.testplugin.method2', array());
+        $remoteApi->call('plugin.testplugin.method2', array());
     }
 
     /**

--- a/_test/tests/inc/remoteapicore.test.php
+++ b/_test/tests/inc/remoteapicore.test.php
@@ -452,7 +452,7 @@ You can use up to five different levels of',
     public function test_deleteUser()
     {
         global $conf, $auth;
-        $auth = new Mock_Auth_Plugin();
+        $auth = new auth_deleteprofile_test_AuthDelete();
         $conf['remote'] = 1;
         $conf['remoteuser'] = 'testuser';
         $_SERVER['REMOTE_USER'] = 'testuser';

--- a/_test/tests/inc/remoteapicore.test.php
+++ b/_test/tests/inc/remoteapicore.test.php
@@ -3,6 +3,7 @@
 use dokuwiki\Remote\Api;
 use dokuwiki\Remote\ApiCore;
 use dokuwiki\test\mock\AuthPlugin;
+use dokuwiki\test\mock\AuthDeletePlugin;
 
 /**
  * Class remoteapicore_test
@@ -452,7 +453,7 @@ You can use up to five different levels of',
     public function test_deleteUser()
     {
         global $conf, $auth;
-        $auth = new auth_deleteprofile_test_AuthDelete();
+        $auth = new AuthDeletePlugin();
         $conf['remote'] = 1;
         $conf['remoteuser'] = 'testuser';
         $_SERVER['REMOTE_USER'] = 'testuser';

--- a/inc/Remote/Api.php
+++ b/inc/Remote/Api.php
@@ -166,7 +166,11 @@ class Api
         }
         $this->checkAccess($methods[$method]);
         $name = $this->getMethodName($methods, $method);
-        return call_user_func_array(array($plugin, $name), $args);
+        try {
+            return call_user_func_array(array($plugin, $name), $args);
+        } catch (\ArgumentCountError $th) {
+            throw new RemoteException('Method does not exist - wrong parameter count.', -32603);
+        }
     }
 
     /**
@@ -185,7 +189,11 @@ class Api
             throw new RemoteException('Method does not exist', -32603);
         }
         $this->checkArgumentLength($coreMethods[$method], $args);
-        return call_user_func_array(array($this->coreMethods, $this->getMethodName($coreMethods, $method)), $args);
+        try {
+            return call_user_func_array(array($this->coreMethods, $this->getMethodName($coreMethods, $method)), $args);
+        } catch (\ArgumentCountError $th) {
+            throw new RemoteException('Method does not exist - wrong parameter count.', -32603);
+        }
     }
 
     /**

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -336,7 +336,7 @@ class ApiCore
      *    $opts['hash']    do md5 sum of content?
      * @return array
      */
-    public function readNamespace($ns, $opts)
+    public function readNamespace($ns, $opts = array())
     {
         global $conf;
 
@@ -508,7 +508,7 @@ class ApiCore
      * @throws AccessDeniedException no write access for page
      * @throws RemoteException no id, empty new page or locked
      */
-    public function putPage($id, $text, $params)
+    public function putPage($id, $text, $params = array())
     {
         global $TEXT;
         global $lang;
@@ -571,7 +571,7 @@ class ApiCore
      * @return bool|string
      * @throws RemoteException
      */
-    public function appendPage($id, $text, $params)
+    public function appendPage($id, $text, $params = array())
     {
         $currentpage = $this->rawPage($id);
         if (!is_string($currentpage)) {
@@ -610,7 +610,7 @@ class ApiCore
      * @return false|string
      * @throws RemoteException
      */
-    public function putAttachment($id, $file, $params)
+    public function putAttachment($id, $file, $params = array())
     {
         $id = cleanID($id);
         $auth = auth_quickaclcheck(getNS($id) . ':*');
@@ -836,7 +836,7 @@ class ApiCore
      * @throws AccessDeniedException no read access for page
      * @throws RemoteException empty id
      */
-    public function pageVersions($id, $first)
+    public function pageVersions($id, $first = 0)
     {
         $id = $this->resolvePageId($id);
         if (auth_quickaclcheck($id) < AUTH_READ) {


### PR DESCRIPTION
Previously,

- on PHP 5.6 and 7.0, remote API request missing arguments won't trigger any error, but a warning suppressed by DokuWiki global error_reporting level (and `call_user_func_array` will set those missing arguments to NULL);
- on PHP 7.1+, remote API request missing arguments will trigger uncaught `ArgumentCountError`.

The change is caused by a PHP 7.1 change: https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.too-few-arguments-exception

This patch fixes both behaviors and add unit tests for this, which fixes #2545. The new behavior is to throw a proper `RemoteException` -32603, so that it can be outputted as a valid XML.