### PR TITLE
Match multiple levels shortcut relative link

### DIFF
--- a/_test/tests/inc/pageutils_resolve_id.test.php
+++ b/_test/tests/inc/pageutils_resolve_id.test.php
@@ -3,7 +3,7 @@
 class init_resolve_id_test extends DokuWikiTest {
 
 
-    function test1(){
+    function test(){
         // we test multiple cases here
         // format: $ns, $page, $output
         $tests   = array();
@@ -23,11 +23,14 @@ class init_resolve_id_test extends DokuWikiTest {
         $tests[] = array('','..:page','page');
 
         // relative upper in namespace
-        $tests[] = array('lev1:lev2','..page','lev1:page');
-        $tests[] = array('lev1:lev2','..:page','lev1:page');
-        $tests[] = array('lev1:lev2','..:..page','page');
-        $tests[] = array('lev1:lev2','..:..:page','page');
-        $tests[] = array('lev1:lev2','..:..:..:page','page');
+        $tests[] = array('lev1:lev2:lev3','..page','lev1:lev2:page');
+        $tests[] = array('lev1:lev2:lev3','..:page','lev1:lev2:page');
+        $tests[] = array('lev1:lev2:lev3','..:..page','lev1:page');
+        $tests[] = array('lev1:lev2:lev3','..:..:page','lev1:page');
+        $tests[] = array('lev1:lev2:lev3','..:..:..page','page');
+        $tests[] = array('lev1:lev2:lev3','..:..:..:page','page');
+        $tests[] = array('lev1:lev2:lev3','..:..:..:..page','page');
+        $tests[] = array('lev1:lev2:lev3','..:..:..:..:page','page');
 
         // strange and broken ones
         $tests[] = array('lev1:lev2','....:....:page','lev1:lev2:page');

--- a/_test/tests/inc/pageutils_resolve_id.test.php
+++ b/_test/tests/inc/pageutils_resolve_id.test.php
@@ -25,6 +25,7 @@ class init_resolve_id_test extends DokuWikiTest {
         // relative upper in namespace
         $tests[] = array('lev1:lev2','..page','lev1:page');
         $tests[] = array('lev1:lev2','..:page','lev1:page');
+        $tests[] = array('lev1:lev2','..:..page','page');
         $tests[] = array('lev1:lev2','..:..:page','page');
         $tests[] = array('lev1:lev2','..:..:..:page','page');
 
@@ -35,7 +36,7 @@ class init_resolve_id_test extends DokuWikiTest {
         $tests[] = array('lev1:lev2','..:..:lev3:..:page:....:...','page');
 
         foreach($tests as $test){
-            $this->assertEquals(resolve_id($test[0],$test[1]),$test[2]);
+            $this->assertEquals($test[2], resolve_id($test[0],$test[1]), $test[0].' >'.$test[1]);
         }
     }
 

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -466,7 +466,7 @@ function resolve_id($ns,$id,$clean=true){
     // relative stuff
     if($id && $id[0] == '.'){
         // normalize initial dots without a colon
-        $id = preg_replace('/^(\.+:)*(\.+)(?=[^:\.])/','\1\2:',$id);
+        $id = preg_replace('/^((\.+:)*)(\.+)(?=[^:\.])/','\1\3:',$id);
         // prepend the current namespace
         $id = $ns.':'.$id;
 

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -466,7 +466,7 @@ function resolve_id($ns,$id,$clean=true){
     // relative stuff
     if($id && $id[0] == '.'){
         // normalize initial dots without a colon
-        $id = preg_replace('/^(\.+)(?=[^:\.])/','\1:',$id);
+        $id = preg_replace('/^(\.+:)*(\.+)(?=[^:\.])/','\1\2:',$id);
         // prepend the current namespace
         $id = $ns.':'.$id;
 


### PR DESCRIPTION
Previously the regex only matches one level. Test added as well.

This fixes #1076.