### PR TITLE
generate curid class by jQuery

### DIFF
--- a/_test/tests/inc/parser/renderer_xhtml.test.php
+++ b/_test/tests/inc/parser/renderer_xhtml.test.php
@@ -269,7 +269,7 @@ class renderer_xhtml_test extends DokuWikiTest {
         $this->assertSame('0', $header);
 
         $this->R->internallink($id);
-        $expected = '<a href="/./doku.php?id='.$id.'" class="wikilink1" title="'.$id.'">0</a>';
+        $expected = '<a href="/./doku.php?id='.$id.'" class="wikilink1" title="'.$id.'" data-wiki-id="blanktest">0</a>';
         $this->assertEquals($expected, trim($this->R->doc));
     }
 }

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -916,12 +916,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         $link['style']  = '';
         $link['pre']    = '';
         $link['suf']    = '';
-        // highlight link to current page
-        if(isset($INFO) && $id == $INFO['id']) {
-            $link['pre'] = '<span class="curid">';
-            $link['suf'] = '</span>';
-        }
-        $link['more']   = '';
+        $link['more']   = 'data-wiki-id="'.$id.'"'; // id is already cleaned
         $link['class']  = $class;
         if($this->date_at) {
             $params = $params.'&at='.rawurlencode($this->date_at);

--- a/lib/scripts/page.js
+++ b/lib/scripts/page.js
@@ -9,6 +9,7 @@ dw_page = {
      */
     init: function(){
         dw_page.sectionHighlight();
+        dw_page.currentIDHighlight();
         jQuery('a.fn_top').on('mouseover', dw_page.footnoteDisplay);
         dw_page.makeToggle('#dw__toc h3','#dw__toc > div');
     },
@@ -44,6 +45,16 @@ dw_page = {
                 // ...and remove the section highlight wrapper
                 $highlightWrap.detach();
             });
+    },
+
+
+    /**
+     * Highlight internal link pointing to current page
+     *
+     * @author Henry Pan <dokuwiki@phy25.com>
+     */
+    currentIDHighlight: function(){
+        jQuery('a.wikilink1, a.wikilink2').filter('[data-wiki-id="'+JSINFO.id+'"]').wrap('<span class="curid"></div>');
     },
 
     /**


### PR DESCRIPTION
internallink's output <a> tag gets a new attribute, data-wiki-id, so that jQuery doesn't need to parse the various link format to get the ID.

Any plugin javascript that loads after DokuWiki's script should be able to discover curid class as usual, as long as they use the default js.php facility.

Fixes #1511, fixes #2968.