### PR TITLE
add overwrite option on extension upload form

### DIFF
--- a/lib/plugins/extension/admin.php
+++ b/lib/plugins/extension/admin.php
@@ -127,7 +127,9 @@ class admin_plugin_extension extends DokuWiki_Admin_Plugin
                 }
                 send_redirect($this->gui->tabURL('', [], '&', true));
             } elseif ($INPUT->post->str('installurl') && checkSecurityToken()) {
-                $installed = $extension->installFromURL($INPUT->post->str('installurl'), $INPUT->post->bool('overwrite'));
+                $installed = $extension->installFromURL(
+                    $INPUT->post->str('installurl'),
+                    $INPUT->post->bool('overwrite'));
                 foreach ($installed as $ext => $info) {
                     msg(sprintf(
                         $this->getLang('msg_'.$info['type'].'_'.$info['action'].'_success'),

--- a/lib/plugins/extension/admin.php
+++ b/lib/plugins/extension/admin.php
@@ -127,7 +127,7 @@ class admin_plugin_extension extends DokuWiki_Admin_Plugin
                 }
                 send_redirect($this->gui->tabURL('', [], '&', true));
             } elseif ($INPUT->post->str('installurl') && checkSecurityToken()) {
-                $installed = $extension->installFromURL($INPUT->post->str('installurl'));
+                $installed = $extension->installFromURL($INPUT->post->str('installurl'), $INPUT->post->bool('overwrite'));
                 foreach ($installed as $ext => $info) {
                     msg(sprintf(
                         $this->getLang('msg_'.$info['type'].'_'.$info['action'].'_success'),
@@ -136,7 +136,7 @@ class admin_plugin_extension extends DokuWiki_Admin_Plugin
                 }
                 send_redirect($this->gui->tabURL('', [], '&', true));
             } elseif (isset($_FILES['installfile']) && checkSecurityToken()) {
-                $installed = $extension->installFromUpload('installfile');
+                $installed = $extension->installFromUpload('installfile', $INPUT->post->bool('overwrite'));
                 foreach ($installed as $ext => $info) {
                     msg(sprintf(
                         $this->getLang('msg_'.$info['type'].'_'.$info['action'].'_success'),

--- a/lib/plugins/extension/helper/extension.php
+++ b/lib/plugins/extension/helper/extension.php
@@ -615,10 +615,11 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
      * Install an extension from a user upload
      *
      * @param string $field name of the upload file
+     * @param boolean $overwrite overwrite folder if the extension name is the same
      * @throws Exception when something goes wrong
      * @return array The list of installed extensions
      */
-    public function installFromUpload($field)
+    public function installFromUpload($field, $overwrite = true)
     {
         if ($_FILES[$field]['error']) {
             throw new Exception($this->getLang('msg_upload_failed').' ('.$_FILES[$field]['error'].')');
@@ -637,7 +638,7 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
         }
 
         try {
-            $installed = $this->installArchive("$tmp/upload.archive", true, $basename);
+            $installed = $this->installArchive("$tmp/upload.archive", $overwrite, $basename);
             $this->updateManagerData('', $installed);
             $this->removeDeletedfiles($installed);
             // purge cache
@@ -652,14 +653,15 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
      * Install an extension from a remote URL
      *
      * @param string $url
+     * @param boolean $overwrite overwrite folder if the extension name is the same
      * @throws Exception when something goes wrong
      * @return array The list of installed extensions
      */
-    public function installFromURL($url)
+    public function installFromURL($url, $overwrite = true)
     {
         try {
             $path      = $this->download($url);
-            $installed = $this->installArchive($path, true);
+            $installed = $this->installArchive($path, $overwrite);
             $this->updateManagerData($url, $installed);
             $this->removeDeletedfiles($installed);
 
@@ -1040,7 +1042,9 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
             // check to make sure we aren't overwriting anything
             $target = $target_base_dir.$item['base'];
             if (!$overwrite && file_exists($target)) {
-                // TODO remember our settings, ask the user to confirm overwrite
+                // this info message is not being exposed via exception,
+                // so that it's not interrupting the installation
+                msg(sprintf($this->getLang('msg_nooverwrite'), $item['base']));
                 continue;
             }
 

--- a/lib/plugins/extension/helper/gui.php
+++ b/lib/plugins/extension/helper/gui.php
@@ -148,6 +148,7 @@ class helper_plugin_extension_gui extends DokuWiki_Plugin
      */
     public function tabInstall()
     {
+        global $lang;
         echo '<div class="panelHeader">';
         echo $this->locale_xhtml('intro_install');
         echo '</div>';
@@ -165,6 +166,9 @@ class helper_plugin_extension_gui extends DokuWiki_Plugin
         $form->addTextInput('installfile', $this->getLang('install_upload'))
             ->addClass('block')
             ->attrs(['type' => 'file']);
+        $form->addTag('br');
+        $form->addCheckbox('overwrite', $lang['js']['media_overwrt'])
+            ->addClass('block');
         $form->addTag('br');
         $form->addButton('', $this->getLang('btn_install'))
             ->attrs(['type' => 'submit', 'title' => $this->getLang('btn_install')]);

--- a/lib/plugins/extension/lang/en/lang.php
+++ b/lib/plugins/extension/lang/en/lang.php
@@ -76,6 +76,7 @@ $lang['msg_template_update_success']  = 'Template %s updated successfully';
 $lang['msg_plugin_install_success']   = 'Plugin %s installed successfully';
 $lang['msg_plugin_update_success']    = 'Plugin %s updated successfully';
 $lang['msg_upload_failed']            = 'Uploading the file failed';
+$lang['msg_nooverwrite']              = 'Extension %s already exists so it is not being overwritten; to overwrite, tick the overwrite option';
 
 $lang['missing_dependency']           = '<strong>Missing or disabled dependency:</strong> %s';
 $lang['security_issue']               = '<strong>Security Issue:</strong> %s';


### PR DESCRIPTION
By default, on frontend $overwrite is false. Backend function installFromUpload / installFromURL will have a default of true to preserve existing behavior for other API users.

installArchive now will insert a frontend msg() about not installing because of overwrite restriction. It's not being exposed by exception, but it should be reflected on its return array list of installed plugin.

This fixes #715.