### PR TITLE
fallback to auth_login check when trustExternal returns null

### DIFF
--- a/inc/Extension/AuthPlugin.php
+++ b/inc/Extension/AuthPlugin.php
@@ -165,9 +165,11 @@ abstract class AuthPlugin extends Plugin
      *
      * If this function is implemented it will be used to
      * authenticate a user - all other DokuWiki internals
-     * will not be used for authenticating, thus
-     * implementing the checkPass() function is not needed
-     * anymore.
+     * will not be used for authenticating (except this
+     * function returns null, in which case, DokuWiki will
+     * still run auth_login as a fallback, which may call
+     * checkPass()). If this function is not returning null,
+     * implementing checkPass() is not needed here anymore.
      *
      * The function can be used to authenticate against third
      * party cookies or Apache auth mechanisms and replaces
@@ -189,7 +191,8 @@ abstract class AuthPlugin extends Plugin
      * @param   string $user Username
      * @param   string $pass Cleartext Password
      * @param   bool $sticky Cookie should not expire
-     * @return  bool             true on successful auth
+     * @return  bool         true on successful auth,
+     *                       null on unknown result (fallback to checkPass)
      */
     public function trustExternal($user, $pass, $sticky = false)
     {

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -972,9 +972,11 @@ class ApiCore
         if (!$auth) return 0;
 
         @session_start(); // reopen session for login
+        $ok = null;
         if ($auth->canDo('external')) {
             $ok = $auth->trustExternal($user, $pass, false);
-        } else {
+        }
+        if ($ok === null){
             $evdata = array(
                 'user' => $user,
                 'password' => $pass,

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -100,10 +100,14 @@ function auth_setup() {
         $INPUT->set('p', stripctl($INPUT->str('p')));
     }
 
-    if(!is_null($auth) && $auth->canDo('external')) {
-        // external trust mechanism in place
-        $auth->trustExternal($INPUT->str('u'), $INPUT->str('p'), $INPUT->bool('r'));
-    } else {
+    $ok = null;
+    if (!is_null($auth) && $auth->canDo('external')) {
+        $ok = $auth->trustExternal($INPUT->str('u'), $INPUT->str('p'), $INPUT->bool('r'));
+    }
+
+    if ($ok === null) {
+        // external trust mechanism not in place, or returns no result,
+        // then attempt auth_login
         $evdata = array(
             'user'     => $INPUT->str('u'),
             'password' => $INPUT->str('p'),


### PR DESCRIPTION
This is a work based on #2701, Before this patch, it is either fully external, or fully internal (and DokuWiki's auth cookie mechanism is used in auth_login()). I believe we should provide plugin developers with a third state as out-put. Semantically $auth->trustExternal() === null to delegate auth flow back to DokuWiki makes sense to me - like no external auth result is returned, so we need to run internal auth flow.

Closes #2701.