### PR TITLE
implemented only_new option for RSS feed

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -133,6 +133,8 @@ function rss_parseOptions() {
                 'items'        => array('int', 'num', $conf['recent']),
                 // Boolean, only used in rc mode
                 'show_minor'   => array('bool', 'minor', false),
+                // Boolean, only used in rc mode
+                'only_new'     => array('bool', 'onlynewpages', false),
                 // String, only used in list mode
                 'sort'         => array('str', 'sort', 'natural'),
                 // String, only used in search mode
@@ -146,6 +148,7 @@ function rss_parseOptions() {
 
     $opt['items']      = max(0, (int) $opt['items']);
     $opt['show_minor'] = (bool) $opt['show_minor'];
+    $opt['only_new']   = (bool) $opt['only_new'];
     $opt['sort'] = valid_input_set('sort', array('default' => 'natural', 'date'), $opt);
 
     $opt['guardmail'] = ($conf['mailguard'] != '' && $conf['mailguard'] != 'none');
@@ -469,6 +472,7 @@ function rssRecentChanges($opt) {
     $flags = 0;
     if(!$conf['rss_show_deleted']) $flags += RECENTS_SKIP_DELETED;
     if(!$opt['show_minor']) $flags += RECENTS_SKIP_MINORS;
+    if($opt['only_new']) $flags += RECENTS_ONLY_NEW_PAGES;
     if($opt['content_type'] == 'media' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_CHANGES;
     if($opt['content_type'] == 'both' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_PAGES_MIXED;
 

--- a/feed.php
+++ b/feed.php
@@ -472,7 +472,7 @@ function rssRecentChanges($opt) {
     $flags = 0;
     if(!$conf['rss_show_deleted']) $flags += RECENTS_SKIP_DELETED;
     if(!$opt['show_minor']) $flags += RECENTS_SKIP_MINORS;
-    if($opt['only_new']) $flags += RECENTS_ONLY_NEW_PAGES;
+    if($opt['only_new']) $flags += RECENTS_ONLY_CREATION;
     if($opt['content_type'] == 'media' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_CHANGES;
     if($opt['content_type'] == 'both' && $conf['mediarevisions']) $flags += RECENTS_MEDIA_PAGES_MIXED;
 

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -205,7 +205,7 @@ function addMediaLogEntry(
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_NEW_PAGES - only include new created pages
+ * RECENTS_ONLY_CREATION - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  * RECENTS_MEDIA_PAGES_MIXED  - return both media changes and page changes
@@ -300,7 +300,7 @@ function getRecents($first,$num,$ns='',$flags=0){
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_NEW_PAGES - only include new created pages
+ * RECENTS_ONLY_CREATION - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  *
@@ -375,8 +375,8 @@ function _handleRecent($line,$ns,$flags,&$seen){
     // skip seen ones
     if(isset($seen[$recent['id']])) return false;
 
-    // skip changes, of only new pages are requested
-    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_NEW_PAGES)) return false;
+    // skip changes, of only new items are requested
+    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_CREATION)) return false;
 
     // skip minors
     if($recent['type']===DOKU_CHANGE_TYPE_MINOR_EDIT && ($flags & RECENTS_SKIP_MINORS)) return false;

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -205,7 +205,7 @@ function addMediaLogEntry(
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_CREATION - only include new created pages and media
+ * RECENTS_ONLY_CREATION  - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  * RECENTS_MEDIA_PAGES_MIXED  - return both media changes and page changes
@@ -300,7 +300,7 @@ function getRecents($first,$num,$ns='',$flags=0){
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
- * RECENTS_ONLY_CREATION - only include new created pages and media
+ * RECENTS_ONLY_CREATION  - only include new created pages and media
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  *

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -205,6 +205,7 @@ function addMediaLogEntry(
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
+ * RECENTS_ONLY_NEW_PAGES - only include new created pages
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  * RECENTS_MEDIA_PAGES_MIXED  - return both media changes and page changes
@@ -299,6 +300,7 @@ function getRecents($first,$num,$ns='',$flags=0){
  *
  * RECENTS_SKIP_DELETED   - don't include deleted pages
  * RECENTS_SKIP_MINORS    - don't include minor changes
+ * RECENTS_ONLY_NEW_PAGES - only include new created pages
  * RECENTS_SKIP_SUBSPACES - don't include subspaces
  * RECENTS_MEDIA_CHANGES  - return media changes instead of page changes
  *
@@ -372,6 +374,9 @@ function _handleRecent($line,$ns,$flags,&$seen){
 
     // skip seen ones
     if(isset($seen[$recent['id']])) return false;
+
+    // skip changes, of only new pages are requested
+    if($recent['type']!==DOKU_CHANGE_TYPE_CREATE && ($flags & RECENTS_ONLY_NEW_PAGES)) return false;
 
     // skip minors
     if($recent['type']===DOKU_CHANGE_TYPE_MINOR_EDIT && ($flags & RECENTS_SKIP_MINORS)) return false;

--- a/inc/common.php
+++ b/inc/common.php
@@ -22,6 +22,7 @@ define('RECENTS_SKIP_MINORS', 4);
 define('RECENTS_SKIP_SUBSPACES', 8);
 define('RECENTS_MEDIA_CHANGES', 16);
 define('RECENTS_MEDIA_PAGES_MIXED', 32);
+define('RECENTS_ONLY_NEW_PAGES', 64);
 
 /**
  * Wrapper around htmlspecialchars()

--- a/inc/common.php
+++ b/inc/common.php
@@ -22,7 +22,7 @@ define('RECENTS_SKIP_MINORS', 4);
 define('RECENTS_SKIP_SUBSPACES', 8);
 define('RECENTS_MEDIA_CHANGES', 16);
 define('RECENTS_MEDIA_PAGES_MIXED', 32);
-define('RECENTS_ONLY_NEW_PAGES', 64);
+define('RECENTS_ONLY_CREATION', 64);
 
 /**
  * Wrapper around htmlspecialchars()


### PR DESCRIPTION
This is the rebased version of #2553 (I cannot force-push to @kivinen's repo because we introduced github actions file). Copied from the original PR:

> This option allows you to RSS feed that contains only new files. This is useful if there is lots of changes, but you are not interested on them, but you are interested in new files or pages created in the wiki.
>
> I did submit this as a patch few years back, and as I said in my reply to email which asked for me to create pull request out of this patch, that it might take few years for me to be able to do that, and I was correct. It took me two years to find time to learn how to use github (and 2 days to get the stupid git/github to work) and to create this pull request. Hopefully this is now in correct format and can be included.