### PR TITLE
Update newpage.txt

### DIFF
--- a/inc/lang/en/newpage.txt
+++ b/inc/lang/en/newpage.txt
@@ -1,3 +1,3 @@
-====== This topic does not exist yet ======
+====== This topic does not exist ======
 
-You've followed a link to a topic that doesn't exist yet. If permissions allow, you may create it by clicking on **Create this page**.
+You've followed a link to a topic that doesn't exist. If permissions allow, you may create it by clicking on **Create this page**.


### PR DESCRIPTION
Specifying that the topic does not exist _yet_ can be confusing when 
viewing a page that been deleted (in which case the message should say
_anymore_ instead).

It's better to just say that the topic does not exist.