### PR TITLE
check if user is empty in userSubscription

### DIFF
--- a/inc/Subscriptions/SubscriberManager.php
+++ b/inc/Subscriptions/SubscriberManager.php
@@ -124,6 +124,11 @@ class SubscriberManager
             $user = $INPUT->server->str('REMOTE_USER');
         }
 
+        if (empty($user)) {
+            // not logged in
+            return false;
+        }
+
         $subs = $this->subscribers($id, $user);
         if (!count($subs)) {
             return false;

--- a/inc/common.php
+++ b/inc/common.php
@@ -217,12 +217,8 @@ function pageinfo() {
     $info['id']  = $ID;
     $info['rev'] = $REV;
 
-    if($INPUT->server->has('REMOTE_USER')) {
-        $subManager = new SubscriberManager();
-        $info['subscribed'] = $subManager->userSubscription();
-    } else {
-        $info['subscribed'] = false;
-    }
+    $subManager = new SubscriberManager();
+    $info['subscribed'] = $subManager->userSubscription();
 
     $info['locked']     = checklock($ID);
     $info['filepath']   = wikiFN($ID);


### PR DESCRIPTION
This makes sure SubscriberRegexBuilder is used properly and won't throw exception in userSubscription.

This fixes #2003.