### PR TITLE
Upgrade for jQuery.Cookie to 1.4.1

### DIFF
--- a/lib/scripts/jquery/jquery.cookie.js
+++ b/lib/scripts/jquery/jquery.cookie.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery Cookie Plugin v1.3.1
+ * jQuery Cookie Plugin v1.4.1
  * https://github.com/carhartl/jquery-cookie
  *
  * Copyright 2013 Klaus Hartl
@@ -7,51 +7,65 @@
  */
 (function (factory) {
 	if (typeof define === 'function' && define.amd) {
-		// AMD. Register as anonymous module.
+		// AMD
 		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('jquery'));
 	} else {
-		// Browser globals.
+		// Browser globals
 		factory(jQuery);
 	}
 }(function ($) {
 
 	var pluses = /\+/g;
 
-	function raw(s) {
-		return s;
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
 	}
 
-	function decoded(s) {
-		return decodeURIComponent(s.replace(pluses, ' '));
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
 	}
 
-	function converted(s) {
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
 		if (s.indexOf('"') === 0) {
-			// This is a quoted cookie as according to RFC2068, unescape
+			// This is a quoted cookie as according to RFC2068, unescape...
 			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
 		}
+
 		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
 			return config.json ? JSON.parse(s) : s;
-		} catch(er) {}
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
 	}
 
 	var config = $.cookie = function (key, value, options) {
 
-		// write
-		if (value !== undefined) {
+		// Write
+
+		if (value !== undefined && !$.isFunction(value)) {
 			options = $.extend({}, config.defaults, options);
 
 			if (typeof options.expires === 'number') {
 				var days = options.expires, t = options.expires = new Date();
-				t.setDate(t.getDate() + days);
+				t.setTime(+t + days * 864e+5);
 			}
 
-			value = config.json ? JSON.stringify(value) : String(value);
-
 			return (document.cookie = [
-				config.raw ? key : encodeURIComponent(key),
-				'=',
-				config.raw ? value : encodeURIComponent(value),
+				encode(key), '=', stringifyCookieValue(value),
 				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
 				options.path    ? '; path=' + options.path : '',
 				options.domain  ? '; domain=' + options.domain : '',
@@ -59,22 +73,29 @@
 			].join(''));
 		}
 
-		// read
-		var decode = config.raw ? raw : decoded;
-		var cookies = document.cookie.split('; ');
+		// Read
+
 		var result = key ? undefined : {};
+
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling $.cookie().
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+
 		for (var i = 0, l = cookies.length; i < l; i++) {
 			var parts = cookies[i].split('=');
 			var name = decode(parts.shift());
-			var cookie = decode(parts.join('='));
+			var cookie = parts.join('=');
 
 			if (key && key === name) {
-				result = converted(cookie);
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
 				break;
 			}
 
-			if (!key) {
-				result[name] = converted(cookie);
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
 			}
 		}
 
@@ -84,12 +105,13 @@
 	config.defaults = {};
 
 	$.removeCookie = function (key, options) {
-		if ($.cookie(key) !== undefined) {
-			// Must not alter options, thus extending a fresh object...
-			$.cookie(key, '', $.extend({}, options, { expires: -1 }));
-			return true;
+		if ($.cookie(key) === undefined) {
+			return false;
 		}
-		return false;
+
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
 	};
 
 }));


### PR DESCRIPTION
This fixes a problem with badly encoded cookies that may have been set by other software on the same domain. Eg. cookies encoded in latin1 instead of UTF-8.

Note: this library is abandoned and superseeded by js-cookie but an upgrade to that is not straight forward (and the benefits for us are unclear)