### PR TITLE
Rough fix for ActiveDirectory caching

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -64,8 +64,6 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
      */
     protected $pattern = array();
 
-    protected $actualstart = 0;
-
     protected $grpsusers = array();
 
     /**
@@ -460,12 +458,18 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
      */
     protected function fillGroupUserArray($filter, $numberOfAdds)
     {
-        $this->grpsusers[$this->filterToString($filter)];
-        $i = 0;
+        if (isset($this->grpsusers[$this->filterToString($filter)])) {
+            $actualstart = count($this->grpsusers[$this->filterToString($filter)]);
+        } else {
+            $this->grpsusers[$this->filterToString($filter)] = [];
+            $actualstart = 0;
+        }
+
+        $i=0;
         $count = 0;
         $this->constructPattern($filter);
         foreach ($this->users as $user => &$info) {
-            if ($i++ < $this->actualstart) {
+            if ($i++ < $actualstart) {
                 continue;
             }
             if ($info === false) {
@@ -476,7 +480,6 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
                 if (($numberOfAdds > 0) && (++$count >= $numberOfAdds)) break;
             }
         }
-        $this->actualstart = $i;
         return $count;
     }
 
@@ -495,12 +498,12 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
         $adldap = $this->initAdLdap(null);
         if (!$adldap) return array();
 
-        if (!$this->users) {
+        //if (!$this->users) {
             //get info for given user
             $result = $adldap->user()->all(false, $this->constructSearchString($filter));
             if (!$result) return array();
             $this->users = array_fill_keys($result, false);
-        }
+        //}
 
         $i     = 0;
         $count = 0;
@@ -528,6 +531,10 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
             if (!isset($this->grpsusers[$this->filterToString($filter)]) ||
                 count($this->grpsusers[$this->filterToString($filter)]) < ($start+$limit)
             ) {
+                if(!isset($this->grpsusers[$this->filterToString($filter)])) {
+                    $this->grpsusers[$this->filterToString($filter)] = [];
+                }
+
                 $this->fillGroupUserArray(
                     $filter,
                     $start+$limit - count($this->grpsusers[$this->filterToString($filter)]) +1


### PR DESCRIPTION
This is a very rough fix for (some) of the problems described in #3025. It should at least ensure that subsequent calls to authad->retrieveUsers() will return the correct data (or data at all).

The changes in here are as ugly as the original code but should be simple enough to backport to stable for affected users.

A proper fix would involve setting this whole thing on fire and restart from the ashes. :fire: 