### PR TITLE
Let plugins access the lexer mode stack

### DIFF
--- a/inc/Parsing/Lexer/Lexer.php
+++ b/inc/Parsing/Lexer/Lexer.php
@@ -168,6 +168,16 @@ class Lexer
     }
 
     /**
+     * Gives plugins access to the mode stack
+     *
+     * @return StateStack
+     */
+    public function getModeStack()
+    {
+        return $this->modeStack;
+    }
+
+    /**
      * Sends the matched token and any leading unmatched
      * text to the parser changing the lexer to a new
      * mode if one is listed.


### PR DESCRIPTION
This PR restores the ability to use the lexer's mode stack, which was possible in the stable release.