### PR TITLE
fix slash regression in toolbar signature

### DIFF
--- a/_test/tests/inc/toolbar.test.php
+++ b/_test/tests/inc/toolbar.test.php
@@ -1,0 +1,20 @@
+<?php
+
+class toolbar_test extends DokuWikiTest {
+
+    function test_encode_toolbar_signature() {
+        global $conf, $INFO, $INPUT;
+
+        $conf['signature'] = '" --- \\\\n //[[@MAIL@|@NAME@]] (@USER@) @DATE@//"';
+        $_SERVER['REMOTE_USER'] = 'john';
+        $INFO['userinfo']['name'] = '/*!]]>*/</script><script>alert("\123\")</script>';
+        $INFO['userinfo']['mail'] = 'example@example.org';
+
+        $date = str_replace('/', '\/', dformat());
+
+        $expected = '"\" --- \\\n \/\/[[example@example.org|\/*!]]>*\/<\/script><script>'.
+                    'alert(\"\\\\123\\\\\\")<\/script>]] (john) '.$date.'\/\/\""';
+
+        $this->assertEquals($expected, toolbar_signature());
+    }
+}

--- a/inc/toolbar.php
+++ b/inc/toolbar.php
@@ -270,7 +270,7 @@ function toolbar_signature(){
     $sig = str_replace('@NAME@',$INFO['userinfo']['name'],$sig);
     $sig = str_replace('@MAIL@',$INFO['userinfo']['mail'],$sig);
     $sig = str_replace('@DATE@',dformat(),$sig);
-    $sig = str_replace('\\\\n','\\n',addslashes($sig));
+    $sig = str_replace('\\\\n','\\n',$sig);
     return json_encode($sig);
 }
 


### PR DESCRIPTION
Removed redundant `addslashes()` and added a unit test for #3045.