### PR TITLE
Fix EXIF-based image rotation in scaled images

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -2427,20 +2427,19 @@ function media_resize_imageGD($ext,$from,$from_w,$from_h,$to,$to_w,$to_h,$ofs_x=
     if($image) imagedestroy($image);
 
     // rotate the image based on the EXIF data.
-    if(function_exists("exif_read_data")){
-        $exif = @exif_read_data($from);
-        if(!empty($exif['Orientation'])) {
-            switch($exif['Orientation']) {
-            case 8:
-                $newimg = imagerotate($newimg,90,0);
-                break;
-            case 3:
-                $newimg= imagerotate($newimg,180,0);
-                break;
-            case 6:
-                $newimg = imagerotate($newimg,-90,0);
-                break;
-            }
+    $meta = new JpegMeta($from);
+    $orientation = $meta->getExifField("Orientation");
+    if(!empty($orientation)) {
+        switch($orientation) {
+        case 8:
+            $newimg = imagerotate($newimg,90,0);
+            break;
+        case 3:
+            $newimg= imagerotate($newimg,180,0);
+            break;
+        case 6:
+            $newimg = imagerotate($newimg,-90,0);
+            break;
         }
     }
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -2423,6 +2423,27 @@ function media_resize_imageGD($ext,$from,$from_w,$from_h,$to,$to_w,$to_h,$ofs_x=
         imagecopyresized($newimg, $image, 0, 0, $ofs_x, $ofs_y, $to_w, $to_h, $from_w, $from_h);
     }
 
+    // clean the old image up before we try to rotate the new image.
+    if($image) imagedestroy($image);
+
+    // rotate the image based on the EXIF data.
+    if(function_exists("exif_read_data")){
+        $exif = exif_read_data($from);
+        if(!empty($exif['Orientation'])) {
+            switch($exif['Orientation']) {
+            case 8:
+                $newimg = imagerotate($newimg,90,0);
+                break;
+            case 3:
+                $newimg= imagerotate($newimg,180,0);
+                break;
+            case 6:
+                $newimg = imagerotate($newimg,-90,0);
+                break;
+            }
+        }
+    }
+
     $okay = false;
     if ($ext == 'jpg' || $ext == 'jpeg'){
         if(!function_exists('imagejpeg')){
@@ -2445,7 +2466,6 @@ function media_resize_imageGD($ext,$from,$from_w,$from_h,$to,$to_w,$to_h,$ofs_x=
     }
 
     // destroy GD image ressources
-    if($image) imagedestroy($image);
     if($newimg) imagedestroy($newimg);
 
     return $okay;

--- a/inc/media.php
+++ b/inc/media.php
@@ -2428,7 +2428,7 @@ function media_resize_imageGD($ext,$from,$from_w,$from_h,$to,$to_w,$to_h,$ofs_x=
 
     // rotate the image based on the EXIF data.
     if(function_exists("exif_read_data")){
-        $exif = exif_read_data($from);
+        $exif = @exif_read_data($from);
         if(!empty($exif['Orientation'])) {
             switch($exif['Orientation']) {
             case 8:

--- a/inc/media.php
+++ b/inc/media.php
@@ -2286,6 +2286,7 @@ function media_resize_imageIM($ext,$from,$from_w,$from_h,$to,$to_w,$to_h){
     // prepare command
     $cmd  = $conf['im_convert'];
     $cmd .= ' -resize '.$to_w.'x'.$to_h.'!';
+    $cmd .= ' -orient';
     if ($ext == 'jpg' || $ext == 'jpeg') {
         $cmd .= ' -quality '.$conf['jpg_quality'];
     }


### PR DESCRIPTION
I recently re-became a Dokuwiki user after stepping away for a bit, and found the fact that Dokuwiki didn’t properly keep EXIF-based rotation on images when scaling them frustrating. I went through and found where the scaling takes place, and fixed both places so that images get rotated properly based on the EXIF data when scaling. 

For the imagemagick case, it’s as simple as adding `-orient` to the flags that imagemagick handles. This one works flawlessly, because it entirely is “someone else’s problem”. 

For libGD, it’s a bit more complicated. It reads the EXIF of the image file and rotates it manually after it gets scaled down. In my testing (I run my instance in docker via the linuxserver.io image, and was testing there as well), getting that to work took a little bit of configuration (I had to install the php7-exif package, for instance) and caused a “using too much memory” problem to be thrown by PHP. I free’d the original image from memory before rotating and it worked fine after that. (Specifically, it was having trouble on the “Media Manager” page when scaling to a thumbnail.)

Fixes #2293 