### PR TITLE
Cache results of isAdmin and isManager

### DIFF
--- a/_test/tests/inc/auth_admincheck.test.php
+++ b/_test/tests/inc/auth_admincheck.test.php
@@ -1,122 +1,129 @@
 <?php
 
-use dokuwiki\test\mock\AuthPlugin;
 use dokuwiki\test\mock\AuthCaseInsensitivePlugin;
+use dokuwiki\test\mock\AuthPlugin;
 
-class auth_admin_test extends DokuWikiTest {
+class auth_admin_test extends DokuWikiTest
+{
 
     private $oldauth;
 
-    function setUp() {
+    function setUp()
+    {
         parent::setUp();
         global $auth;
         $this->oldauth = $auth;
     }
 
-    function setSensitive() {
+    function setSensitive()
+    {
         global $auth;
         $auth = new AuthPlugin();
     }
 
-    function setInSensitive() {
+    function setInSensitive()
+    {
         global $auth;
         $auth = new AuthCaseInsensitivePlugin();
     }
 
-    function teardown() {
+    function teardown()
+    {
         global $auth;
         global $AUTH_ACL;
         unset($AUTH_ACL);
         $auth = $this->oldauth;
     }
 
-    function test_ismanager_insensitive(){
+    function test_ismanager_insensitive()
+    {
         $this->setInSensitive();
         global $conf;
         $conf['superuser'] = 'john,@admin,@Mötly Görls, Dörte';
         $conf['manager'] = 'john,@managers,doe, @Mötly Böys, Dänny';
 
         // anonymous user
-        $this->assertEquals(auth_ismanager('jill', null,false), false);
+        $this->assertFalse(auth_ismanager('jill', null, false, true));
 
         // admin or manager users
-        $this->assertEquals(auth_ismanager('john', null,false), true);
-        $this->assertEquals(auth_ismanager('doe',  null,false), true);
+        $this->assertTrue(auth_ismanager('john', null, false, true));
+        $this->assertTrue(auth_ismanager('doe', null, false, true));
 
-        $this->assertEquals(auth_ismanager('dörte', null,false), true);
-        $this->assertEquals(auth_ismanager('dänny', null,false), true);
+        $this->assertTrue(auth_ismanager('dörte', null, false, true));
+        $this->assertTrue(auth_ismanager('dänny', null, false, true));
 
         // admin or manager groups
-        $this->assertEquals(auth_ismanager('jill', array('admin'),false), true);
-        $this->assertEquals(auth_ismanager('jill', array('managers'),false), true);
+        $this->assertTrue(auth_ismanager('jill', array('admin'), false, true));
+        $this->assertTrue(auth_ismanager('jill', array('managers'), false, true));
 
-        $this->assertEquals(auth_ismanager('jill', array('mötly görls'),false), true);
-        $this->assertEquals(auth_ismanager('jill', array('mötly böys'),false), true);
+        $this->assertTrue(auth_ismanager('jill', array('mötly görls'), false, true));
+        $this->assertTrue(auth_ismanager('jill', array('mötly böys'), false, true));
     }
 
-    function test_isadmin_insensitive(){
+    function test_isadmin_insensitive()
+    {
         $this->setInSensitive();
         global $conf;
         $conf['superuser'] = 'john,@admin,doe,@roots';
 
         // anonymous user
-        $this->assertEquals(auth_ismanager('jill', null,true), false);
+        $this->assertFalse(auth_ismanager('jill', null, true, true));
 
         // admin user
-        $this->assertEquals(auth_ismanager('john', null,true), true);
-        $this->assertEquals(auth_ismanager('doe',  null,true), true);
+        $this->assertTrue(auth_ismanager('john', null, true, true));
+        $this->assertTrue(auth_ismanager('doe', null, true, true));
 
         // admin groups
-        $this->assertEquals(auth_ismanager('jill', array('admin'),true), true);
-        $this->assertEquals(auth_ismanager('jill', array('roots'),true), true);
-        $this->assertEquals(auth_ismanager('john', array('admin'),true), true);
-        $this->assertEquals(auth_ismanager('doe',  array('admin'),true), true);
+        $this->assertTrue(auth_ismanager('jill', array('admin'), true, true));
+        $this->assertTrue(auth_ismanager('jill', array('roots'), true, true));
+        $this->assertTrue(auth_ismanager('john', array('admin'), true, true));
+        $this->assertTrue(auth_ismanager('doe', array('admin'), true, true));
     }
 
-    function test_ismanager_sensitive(){
+    function test_ismanager_sensitive()
+    {
         $this->setSensitive();
         global $conf;
         $conf['superuser'] = 'john,@admin,@Mötly Görls, Dörte';
         $conf['manager'] = 'john,@managers,doe, @Mötly Böys, Dänny';
 
         // anonymous user
-        $this->assertEquals(auth_ismanager('jill', null,false), false);
+        $this->assertFalse(auth_ismanager('jill', null, false, true));
 
         // admin or manager users
-        $this->assertEquals(auth_ismanager('john', null,false), true);
-        $this->assertEquals(auth_ismanager('doe',  null,false), true);
+        $this->assertTrue(auth_ismanager('john', null, false, true));
+        $this->assertTrue(auth_ismanager('doe', null, false, true));
 
-        $this->assertEquals(auth_ismanager('dörte', null,false), false);
-        $this->assertEquals(auth_ismanager('dänny', null,false), false);
+        $this->assertFalse(auth_ismanager('dörte', null, false, true));
+        $this->assertFalse(auth_ismanager('dänny', null, false, true));
 
         // admin or manager groups
-        $this->assertEquals(auth_ismanager('jill', array('admin'),false), true);
-        $this->assertEquals(auth_ismanager('jill', array('managers'),false), true);
+        $this->assertTrue(auth_ismanager('jill', array('admin'), false, true));
+        $this->assertTrue(auth_ismanager('jill', array('managers'), false, true));
 
-        $this->assertEquals(auth_ismanager('jill', array('mötly görls'),false), false);
-        $this->assertEquals(auth_ismanager('jill', array('mötly böys'),false), false);
+        $this->assertFalse(auth_ismanager('jill', array('mötly görls'), false, true));
+        $this->assertFalse(auth_ismanager('jill', array('mötly böys'), false, true));
     }
 
-    function test_isadmin_sensitive(){
+    function test_isadmin_sensitive()
+    {
         $this->setSensitive();
         global $conf;
         $conf['superuser'] = 'john,@admin,doe,@roots';
 
         // anonymous user
-        $this->assertEquals(auth_ismanager('jill', null,true), false);
+        $this->assertFalse(auth_ismanager('jill', null, true, true));
 
         // admin user
-        $this->assertEquals(auth_ismanager('john', null,true), true);
-        $this->assertEquals(auth_ismanager('Doe',  null,true), false);
+        $this->assertTrue(auth_ismanager('john', null, true, true));
+        $this->assertFalse(auth_ismanager('Doe', null, true, true));
 
         // admin groups
-        $this->assertEquals(auth_ismanager('jill', array('admin'),true), true);
-        $this->assertEquals(auth_ismanager('jill', array('roots'),true), true);
-        $this->assertEquals(auth_ismanager('john', array('admin'),true), true);
-        $this->assertEquals(auth_ismanager('doe',  array('admin'),true), true);
-        $this->assertEquals(auth_ismanager('Doe',  array('admin'),true), true);
+        $this->assertTrue(auth_ismanager('jill', array('admin'), true, true));
+        $this->assertTrue(auth_ismanager('jill', array('roots'), true, true));
+        $this->assertTrue(auth_ismanager('john', array('admin'), true, true));
+        $this->assertTrue(auth_ismanager('doe', array('admin'), true, true));
+        $this->assertTrue(auth_ismanager('Doe', array('admin'), true, true));
     }
 
 }
-
-//Setup VIM: ex: et ts=4 :

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -453,7 +453,7 @@ function auth_logoff($keepbc = false) {
  * @param string $user Username
  * @param array $groups List of groups the user is in
  * @param bool $adminonly when true checks if user is admin
- * @param bool $recache set to true to skip cached results
+ * @param bool $recache set to true to refresh the cache
  * @return bool
  * @see    auth_isadmin
  *
@@ -482,7 +482,7 @@ function auth_ismanager($user = null, $groups = null, $adminonly = false, $recac
 
     // prefer cached result
     static $cache = [];
-    $cachekey = 'c-' . $user . '-' . $adminonly . '-' . join(':', $groups);
+    $cachekey = serialize([$user, $adminonly, $groups]);
     if (!isset($cache[$cachekey]) || $recache) {
         // check superuser match
         $ok = auth_isMember($conf['superuser'], $user, $groups);
@@ -507,7 +507,7 @@ function auth_ismanager($user = null, $groups = null, $adminonly = false, $recac
  *
  * @param string $user Username
  * @param array $groups List of groups the user is in
- * @param bool $recache set to true to skip cached results
+ * @param bool $recache set to true to refresh the cache
  * @return bool
  * @author Andreas Gohr <andi@splitbrain.org>
  * @see auth_ismanager()


### PR DESCRIPTION
isAdmin() is called within the ACL check (and probably various other
places in DokuWiki core). In a Wiki with lots of ACL checks (most
noticable with the indexmenu) and users with a lot of groups (as typical
in corporate ActiveDirectory environments) this check can take a
significant portion of the time of a request time doing exactly the same
thing again and again.

This introduces a static request level cache for the result of the
isAdmin and isManager checks based on the requested user and groups.

A new parameter allows to skip the cache, though I don't think there
should be a good reason to skip the cache except for testing purposes.