### PR TITLE
FatalException: drop unused $status property

### DIFF
--- a/inc/Action/Exception/FatalException.php
+++ b/inc/Action/Exception/FatalException.php
@@ -13,9 +13,6 @@ namespace dokuwiki\Action\Exception;
  * @package dokuwiki\Action\Exception
  */
 class FatalException extends \Exception {
-
-    protected $status;
-
     /**
      * FatalException constructor.
      *


### PR DESCRIPTION
The property is never assigned