### PR TITLE
honor userewrite setting in redirection from index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ if(php_sapi_name() != 'cli-server') {
     if(!defined('DOKU_INC')) define('DOKU_INC', dirname(__FILE__).'/');
     require_once(DOKU_INC.'inc/init.php');
 
-    send_redirect(DOKU_URL.'doku.php');
+    send_redirect(wl($conf['start']));
 }
 
 # ROUTER starts below


### PR DESCRIPTION
Hello.

index.php redirects to "doku.php" whatever the userewrite setting is. This PR uses `wl()`. The redirection will respect configured userewrite.

Fixes #3164.