### PR TITLE
Fix accessing handler internals

### DIFF
--- a/inc/Parsing/Handler/AbstractRewriter.php
+++ b/inc/Parsing/Handler/AbstractRewriter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace dokuwiki\Parsing\Handler;
+
+/**
+ * Basic implementation of the rewriter interface to be specialized by children
+ */
+abstract class AbstractRewriter implements ReWriterInterface
+{
+    /** @var CallWriterInterface original CallWriter */
+    protected $callWriter;
+
+    /** @var array[] list of calls */
+    public $calls = array();
+
+    /** @inheritdoc */
+    public function __construct(CallWriterInterface $callWriter)
+    {
+        $this->callWriter = $callWriter;
+    }
+
+    /** @inheritdoc */
+    public function writeCall($call)
+    {
+        $this->calls[] = $call;
+    }
+
+    /** * @inheritdoc */
+    public function writeCalls($calls)
+    {
+        $this->calls = array_merge($this->calls, $calls);
+    }
+
+    /** @inheritDoc */
+    public function getCallWriter()
+    {
+        return $this->callWriter;
+    }
+}

--- a/inc/Parsing/Handler/CallWriterInterface.php
+++ b/inc/Parsing/Handler/CallWriterInterface.php
@@ -7,14 +7,14 @@ interface CallWriterInterface
     /**
      * Add a call to our call list
      *
-     * @param $call     the call to be added
+     * @param array $call the call to be added
      */
     public function writeCall($call);
 
     /**
      * Append a list of calls to our call list
      *
-     * @param $calls     list of calls to be appended
+     * @param array[] $calls list of calls to be appended
      */
     public function writeCalls($calls);
 

--- a/inc/Parsing/Handler/Lists.php
+++ b/inc/Parsing/Handler/Lists.php
@@ -2,41 +2,14 @@
 
 namespace dokuwiki\Parsing\Handler;
 
-class Lists implements ReWriterInterface
+class Lists extends AbstractRewriter
 {
-
-    /** @var CallWriterInterface original call writer */
-    protected $callWriter;
-
-    protected $calls = array();
     protected $listCalls = array();
     protected $listStack = array();
 
     protected $initialDepth = 0;
 
     const NODE = 1;
-
-
-    /** @inheritdoc */
-    public function __construct(CallWriterInterface $CallWriter)
-    {
-        $this->callWriter = $CallWriter;
-    }
-
-    /** @inheritdoc */
-    public function writeCall($call)
-    {
-        $this->calls[] = $call;
-    }
-
-    /**
-     * @inheritdoc
-     * Probably not needed but just in case...
-     */
-    public function writeCalls($calls)
-    {
-        $this->calls = array_merge($this->calls, $calls);
-    }
 
     /** @inheritdoc */
     public function finalise()

--- a/inc/Parsing/Handler/Nest.php
+++ b/inc/Parsing/Handler/Nest.php
@@ -8,13 +8,8 @@ namespace dokuwiki\Parsing\Handler;
  *
  * @author    Chris Smith <chris@jalakai.co.uk>
  */
-class Nest implements ReWriterInterface
+class Nest extends AbstractRewriter
 {
-
-    /** @var CallWriterInterface original CallWriter */
-    protected $callWriter;
-
-    protected $calls = array();
     protected $closingInstruction;
 
     /**
@@ -26,8 +21,7 @@ class Nest implements ReWriterInterface
      */
     public function __construct(CallWriterInterface $CallWriter, $close = "nest_close")
     {
-        $this->callWriter = $CallWriter;
-
+        parent::__construct($CallWriter);
         $this->closingInstruction = $close;
     }
 
@@ -69,6 +63,9 @@ class Nest implements ReWriterInterface
         return $this->callWriter;
     }
 
+    /**
+     * @param array $call
+     */
     protected function addCall($call)
     {
         $key = count($this->calls);
@@ -80,4 +77,6 @@ class Nest implements ReWriterInterface
             $this->calls[] = $call;
         }
     }
+
+
 }

--- a/inc/Parsing/Handler/Preformatted.php
+++ b/inc/Parsing/Handler/Preformatted.php
@@ -2,38 +2,11 @@
 
 namespace dokuwiki\Parsing\Handler;
 
-class Preformatted implements ReWriterInterface
+class Preformatted extends AbstractRewriter
 {
 
-    /** @var CallWriterInterface original call writer */
-    protected $callWriter;
-
-    protected $calls = array();
     protected $pos;
     protected $text ='';
-
-    /**
-     * @inheritdoc
-     */
-    public function __construct(CallWriterInterface $CallWriter)
-    {
-        $this->callWriter = $CallWriter;
-    }
-
-    /** @inheritdoc */
-    public function writeCall($call)
-    {
-        $this->calls[] = $call;
-    }
-
-    /**
-     * @inheritdoc
-     * Probably not needed but just in case...
-     */
-    public function writeCalls($calls)
-    {
-        $this->calls = array_merge($this->calls, $calls);
-    }
 
     /** @inheritdoc */
     public function finalise()

--- a/inc/Parsing/Handler/Quote.php
+++ b/inc/Parsing/Handler/Quote.php
@@ -2,37 +2,9 @@
 
 namespace dokuwiki\Parsing\Handler;
 
-class Quote implements ReWriterInterface
+class Quote extends AbstractRewriter
 {
-
-    /** @var CallWriterInterface original CallWriter */
-    protected $callWriter;
-
-    protected $calls = array();
-
     protected $quoteCalls = array();
-
-    /** @inheritdoc */
-    public function __construct(CallWriterInterface $CallWriter)
-    {
-        $this->callWriter = $CallWriter;
-    }
-
-    /** @inheritdoc */
-    public function writeCall($call)
-    {
-        $this->calls[] = $call;
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * Probably not needed but just in case...
-     */
-    public function writeCalls($calls)
-    {
-        $this->calls = array_merge($this->calls, $calls);
-    }
 
     /** @inheritdoc */
     public function finalise()
@@ -101,6 +73,10 @@ class Quote implements ReWriterInterface
         return $this->callWriter;
     }
 
+    /**
+     * @param $marker
+     * @return int
+     */
     protected function getDepth($marker)
     {
         preg_match('/>{1,}/', $marker, $matches);

--- a/inc/Parsing/Handler/Quote.php
+++ b/inc/Parsing/Handler/Quote.php
@@ -74,7 +74,7 @@ class Quote extends AbstractRewriter
     }
 
     /**
-     * @param $marker
+     * @param string $marker
      * @return int
      */
     protected function getDepth($marker)

--- a/inc/Parsing/Handler/ReWriterInterface.php
+++ b/inc/Parsing/Handler/ReWriterInterface.php
@@ -5,10 +5,11 @@ namespace dokuwiki\Parsing\Handler;
 /**
  * A ReWriter takes over from the orignal call writer and handles all new calls itself until
  * the process method is called and control is given back to the original writer.
+ *
+ * @property array[] $calls The list of current calls
  */
 interface ReWriterInterface extends CallWriterInterface
 {
-
     /**
      * ReWriterInterface constructor.
      *
@@ -26,4 +27,11 @@ interface ReWriterInterface extends CallWriterInterface
      * @return CallWriterInterface the orignal call writer
      */
     public function process();
+
+    /**
+     * Accessor for this rewriter's original CallWriter
+     *
+     * @return CallWriterInterface
+     */
+    public function getCallWriter();
 }

--- a/inc/Parsing/Handler/Table.php
+++ b/inc/Parsing/Handler/Table.php
@@ -2,13 +2,9 @@
 
 namespace dokuwiki\Parsing\Handler;
 
-class Table implements ReWriterInterface
+class Table extends AbstractRewriter
 {
 
-    /** @var CallWriterInterface original CallWriter */
-    protected $callWriter;
-
-    protected $calls = array();
     protected $tableCalls = array();
     protected $maxCols = 0;
     protected $maxRows = 1;
@@ -18,27 +14,6 @@ class Table implements ReWriterInterface
     protected $inTableHead = true;
     protected $currentRow = array('tableheader' => 0, 'tablecell' => 0);
     protected $countTableHeadRows = 0;
-
-    /** @inheritdoc */
-    public function __construct(CallWriterInterface $CallWriter)
-    {
-        $this->callWriter = $CallWriter;
-    }
-
-    /** @inheritdoc */
-    public function writeCall($call)
-    {
-        $this->calls[] = $call;
-    }
-
-    /**
-     * @inheritdoc
-     * Probably not needed but just in case...
-     */
-    public function writeCalls($calls)
-    {
-        $this->calls = array_merge($this->calls, $calls);
-    }
 
     /** @inheritdoc */
     public function finalise()

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -67,6 +67,27 @@ class Doku_Handler {
         $this->callWriter = $callWriter;
     }
 
+    /**
+     * Return the current internal status of the given name
+     *
+     * @param string $status
+     * @return mixed|null
+     */
+    public function getStatus($status) {
+        if (!isset($this->status[$status])) return null;
+        return $this->status[$status];
+    }
+
+    /**
+     * Set a new internal status
+     *
+     * @param string $status
+     * @param mixed $value
+     */
+    public function setStatus($status, $value) {
+        $this->status[$status] = $value;
+    }
+
     /** @deprecated 2019-10-31 use addCall() instead */
     public function _addCall($handler, $args, $pos) {
         dbg_deprecated('addCall');

--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -49,6 +49,24 @@ class Doku_Handler {
         $this->callWriter->writeCall($call);
     }
 
+    /**
+     * Accessor for the current CallWriter
+     *
+     * @return CallWriterInterface
+     */
+    public function getCallWriter() {
+        return $this->callWriter;
+    }
+
+    /**
+     * Set a new CallWriter
+     *
+     * @param CallWriterInterface $callWriter
+     */
+    public function setCallWriter($callWriter) {
+        $this->callWriter = $callWriter;
+    }
+
     /** @deprecated 2019-10-31 use addCall() instead */
     public function _addCall($handler, $args, $pos) {
         dbg_deprecated('addCall');


### PR DESCRIPTION
Some plugins need access to the handler (and rewriter) calls. One example is the do plugin.

This adds some accessing methods to the callWriter objects, ensures $calls can be accessed and removes some duplicate code by introducing an abstract base class.

It also gives access to the internal handler status through accessors.

Fixes #3152.