### PR TITLE
Move defines to their own file

### DIFF
--- a/inc/Parsing/Lexer/Lexer.php
+++ b/inc/Parsing/Lexer/Lexer.php
@@ -9,14 +9,6 @@
 
 namespace dokuwiki\Parsing\Lexer;
 
-// FIXME move elsewhere
-
-define("DOKU_LEXER_ENTER", 1);
-define("DOKU_LEXER_MATCHED", 2);
-define("DOKU_LEXER_UNMATCHED", 3);
-define("DOKU_LEXER_EXIT", 4);
-define("DOKU_LEXER_SPECIAL", 5);
-
 /**
  * Accepts text and breaks it into tokens.
  *

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -9,20 +9,11 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 
-// some ACL level defines
 use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\Event;
 use dokuwiki\Extension\PluginController;
 use dokuwiki\PassHash;
 use dokuwiki\Subscriptions\RegistrationSubscriptionSender;
-
-define('AUTH_NONE', 0);
-define('AUTH_READ', 1);
-define('AUTH_EDIT', 2);
-define('AUTH_CREATE', 4);
-define('AUTH_UPLOAD', 8);
-define('AUTH_DELETE', 16);
-define('AUTH_ADMIN', 255);
 
 /**
  * Initialize the auth system.

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -6,14 +6,6 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 
-// Constants for known core changelog line types.
-// Use these in place of string literals for more readable code.
-define('DOKU_CHANGE_TYPE_CREATE',       'C');
-define('DOKU_CHANGE_TYPE_EDIT',         'E');
-define('DOKU_CHANGE_TYPE_MINOR_EDIT',   'e');
-define('DOKU_CHANGE_TYPE_DELETE',       'D');
-define('DOKU_CHANGE_TYPE_REVERT',       'R');
-
 /**
  * parses a changelog line into it's components
  *

--- a/inc/common.php
+++ b/inc/common.php
@@ -15,16 +15,6 @@ use dokuwiki\Extension\AuthPlugin;
 use dokuwiki\Extension\Event;
 
 /**
- * These constants are used with the recents function
- */
-define('RECENTS_SKIP_DELETED', 2);
-define('RECENTS_SKIP_MINORS', 4);
-define('RECENTS_SKIP_SUBSPACES', 8);
-define('RECENTS_MEDIA_CHANGES', 16);
-define('RECENTS_MEDIA_PAGES_MIXED', 32);
-define('RECENTS_ONLY_CREATION', 64);
-
-/**
  * Wrapper around htmlspecialchars()
  *
  * @author Andreas Gohr <andi@splitbrain.org>

--- a/inc/defines.php
+++ b/inc/defines.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Set up globally available constants
+ */
+
+/**
+ * Auth Levels
+ * @file inc/auth.php
+ */
+define('AUTH_NONE', 0);
+define('AUTH_READ', 1);
+define('AUTH_EDIT', 2);
+define('AUTH_CREATE', 4);
+define('AUTH_UPLOAD', 8);
+define('AUTH_DELETE', 16);
+define('AUTH_ADMIN', 255);
+
+/**
+ * Message types
+ * @see msg()
+ */
+define('MSG_PUBLIC', 0);
+define('MSG_USERS_ONLY', 1);
+define('MSG_MANAGERS_ONLY', 2);
+define('MSG_ADMINS_ONLY', 4);
+
+/**
+ * Lexer constants
+ * @see \dokuwiki\Parsing\Lexer\Lexer
+ */
+define('DOKU_LEXER_ENTER', 1);
+define('DOKU_LEXER_MATCHED', 2);
+define('DOKU_LEXER_UNMATCHED', 3);
+define('DOKU_LEXER_EXIT', 4);
+define('DOKU_LEXER_SPECIAL', 5);
+
+/**
+ * Constants for known core changelog line types.
+ * @file inc/changelog.php
+ */
+define('DOKU_CHANGE_TYPE_CREATE', 'C');
+define('DOKU_CHANGE_TYPE_EDIT', 'E');
+define('DOKU_CHANGE_TYPE_MINOR_EDIT', 'e');
+define('DOKU_CHANGE_TYPE_DELETE', 'D');
+define('DOKU_CHANGE_TYPE_REVERT', 'R');
+
+/**
+ * Changelog filter constants
+ * @file inc/changelog.php
+ */
+define('RECENTS_SKIP_DELETED', 2);
+define('RECENTS_SKIP_MINORS', 4);
+define('RECENTS_SKIP_SUBSPACES', 8);
+define('RECENTS_MEDIA_CHANGES', 16);
+define('RECENTS_MEDIA_PAGES_MIXED', 32);
+define('RECENTS_ONLY_CREATION', 64);
+
+/**
+ * Media error types
+ * @file inc/media.php
+ */
+define('DOKU_MEDIA_DELETED', 1);
+define('DOKU_MEDIA_NOT_AUTH', 2);
+define('DOKU_MEDIA_INUSE', 4);
+define('DOKU_MEDIA_EMPTY_NS', 8);

--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -305,33 +305,15 @@ function check(){
 }
 
 /**
- * print a message
+ * Display a message to the user
  *
  * If HTTP headers were not sent yet the message is added
  * to the global message array else it's printed directly
  * using html_msgarea()
  *
- *
- * Levels can be:
- *
- * -1 error
- *  0 info
- *  1 success
- *
- * @author Andreas Gohr <andi@splitbrain.org>
- * @see    html_msgarea
- */
-
-define('MSG_PUBLIC', 0);
-define('MSG_USERS_ONLY', 1);
-define('MSG_MANAGERS_ONLY',2);
-define('MSG_ADMINS_ONLY',4);
-
-/**
- * Display a message to the user
- *
  * Triggers INFOUTIL_MSG_SHOW
  *
+ * @see    html_msgarea()
  * @param string $message
  * @param int    $lvl   -1 = error, 0 = info, 1 = success, 2 = notify
  * @param string $line  line number

--- a/inc/load.php
+++ b/inc/load.php
@@ -12,6 +12,7 @@ spl_autoload_register('load_autoload');
 
 // require all the common libraries
 // for a few of these order does matter
+require_once(DOKU_INC.'inc/defines.php');
 require_once(DOKU_INC.'inc/actions.php');
 require_once(DOKU_INC.'inc/changelog.php');
 require_once(DOKU_INC.'inc/common.php');

--- a/inc/media.php
+++ b/inc/media.php
@@ -230,11 +230,6 @@ function media_inuse($id) {
     }
 }
 
-define('DOKU_MEDIA_DELETED', 1);
-define('DOKU_MEDIA_NOT_AUTH', 2);
-define('DOKU_MEDIA_INUSE', 4);
-define('DOKU_MEDIA_EMPTY_NS', 8);
-
 /**
  * Handles media file deletions
  *


### PR DESCRIPTION
As described in https://github.com/dwp-forge/columns/issues/5#issuecomment-638467603
sometime the Lexer constants have not been (auto)loaded when a syntax plugin is invoked (I'm not sure why).

In general PSR2 discourages a mix of main code and function/class setup with the call to define() being considered main code.

This patch moves these the define calls to a separate new file, solving both of the above problems.

These are not all our defines. Instead I focused on the ones that are ENUM-like.

In the future we should think about what defines can be replaced by class constants and what other define() calls should be moved.

Fixes #3146.