### PR TITLE
Add flexbox to admin menu link to fix text width

### DIFF
--- a/lib/tpl/dokuwiki/css/_admin.less
+++ b/lib/tpl/dokuwiki/css/_admin.less
@@ -20,28 +20,31 @@
             list-style-type: none;
             white-space: nowrap;
 
-            a span {
-                display: inline-block;
+            a {
+                display: flex;
+                span {
+                    display: inline-block;
 
-                &.icon {
-                    width: 1.5em;
-                    min-height: 1.5em;
-                    margin: 0 0.5em;
-                    vertical-align: top;
-
-                    svg {
+                    &.icon {
                         width: 1.5em;
-                        height: 1.5em;
-                        fill: @ini_link;
-                        display: inline-block;
-                        path {
+                        min-height: 1.5em;
+                        margin: 0 0.5em;
+                        vertical-align: top;
+
+                        svg {
+                            width: 1.5em;
+                            height: 1.5em;
                             fill: @ini_link;
+                            display: inline-block;
+                            path {
+                                fill: @ini_link;
+                            }
                         }
                     }
-                }
 
-                &.prompt {
-                    white-space: normal;
+                    &.prompt {
+                        white-space: normal;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The previous implementation assigns the whole width of the parent ul to the text area, which brings some text (fr) overlapping the icon in the second row. Adding flexbox should be most backward-compatible and ensures a proper width being set.

Fixes #3143.