### PR TITLE
Add unit tests for noNS ending with colon

### DIFF
--- a/_test/tests/inc/pageutils_nons.test.php
+++ b/_test/tests/inc/pageutils_nons.test.php
@@ -43,6 +43,8 @@ class init_noNS_test extends DokuWikiTest {
             ['0:foo', 'foo'],
             ['foo:0', '0'],
             ['0', '0'],
+            ['0:', '0'],
+            ['a:b:', 'b'], // breadcrumbs code passes IDs ending with a colon #3114
         ];
     }
 


### PR DESCRIPTION
> `$p` used to be compared loosely to `false` which made it true for empty strings. The breadcrumbs code passes IDs ending with a colon, so `noNS` always returns an empty string, which consequently is returned...
>
> *From @splitbrain*

Added unit test to have the behavior defined.