### PR TITLE
Global error handling

### DIFF
--- a/inc/ErrorHandler.php
+++ b/inc/ErrorHandler.php
@@ -11,13 +11,11 @@ use dokuwiki\Exception\FatalException;
  */
 class ErrorHandler
 {
-
     /**
      * Register the default error handling
      */
     public static function register()
     {
-        set_error_handler([ErrorHandler::class, 'errorConverter']);
         if (!defined('DOKU_UNITTEST')) {
             set_exception_handler([ErrorHandler::class, 'fatalException']);
             register_shutdown_function([ErrorHandler::class, 'fatalShutdown']);
@@ -68,30 +66,6 @@ EOT;
         $msg = hsc($intro) . '<br />' . hsc(get_class($e) . ': ' . $e->getMessage());
         if (self::logException($e)) $msg .= '<br />More info is available in the _error.log';
         msg($msg, -1);
-    }
-
-    /**
-     * Default error handler to convert old school warnings, notices, etc to exceptions
-     *
-     * You should not need to call this directly!
-     *
-     * @param int $errno
-     * @param string $errstr
-     * @param string $errfile
-     * @param int $errline
-     * @return bool
-     * @throws \ErrorException
-     */
-    public static function errorConverter($errno, $errstr, $errfile, $errline)
-    {
-
-        if (!(error_reporting() & $errno)) {
-            // This error code is not included in error_reporting, so let it fall
-            // through to the standard PHP error handler
-            return false;
-        }
-
-        throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
     }
 
     /**

--- a/inc/ErrorHandler.php
+++ b/inc/ErrorHandler.php
@@ -2,6 +2,13 @@
 
 namespace dokuwiki;
 
+use dokuwiki\Exception\FatalException;
+
+/**
+ * Manage the global handling of errors and exceptions
+ *
+ * Developer may use this to log and display exceptions themselves
+ */
 class ErrorHandler
 {
 
@@ -88,7 +95,7 @@ EOT;
     }
 
     /**
-     * Last resort to handle fatal errors that still can't be cought
+     * Last resort to handle fatal errors that still can't be caught
      */
     public static function fatalShutdown()
     {
@@ -106,7 +113,7 @@ EOT;
             )
         ) {
             self::fatalException(
-                new \ErrorException($error['message'], 0, $error['type'], $error['file'], $error['line'])
+                new FatalException($error['message'], 0, $error['type'], $error['file'], $error['line'])
             );
         }
     }
@@ -139,6 +146,10 @@ EOT;
      */
     protected static function guessPlugin($e)
     {
+        if (preg_match('/lib\/plugins\/(\w+)\//', str_replace('\\', '/', $e->getFile()), $match)) {
+            return $match[1];
+        }
+
         foreach ($e->getTrace() as $line) {
             if (
                 isset($line['class']) &&

--- a/inc/ErrorHandler.php
+++ b/inc/ErrorHandler.php
@@ -57,9 +57,9 @@ EOT;
      */
     public static function showExceptionMsg($e, $intro = 'Error!')
     {
-        $msg = $intro . get_class($e) . ': ' . $e->getMessage();
-        self::logException($e);
-        msg(hsc($msg), -1);
+        $msg = hsc($intro).'<br />' . hsc(get_class($e) . ': ' . $e->getMessage());
+        if(self::logException($e)) $msg .= '<br />More info is available in the _error.log';
+        msg($msg, -1);
     }
 
     /**

--- a/inc/ErrorHandler.php
+++ b/inc/ErrorHandler.php
@@ -94,7 +94,13 @@ EOT;
     {
         global $conf;
 
-        $log = join("\t", [gmdate('c'), get_class($e), $e->getFile() . ':' . $e->getLine(), $e->getMessage()]) . "\n";
+        $log = join("\t", [
+                gmdate('c'),
+                get_class($e),
+                $e->getFile() . '(' . $e->getLine() . ')',
+                $e->getMessage(),
+            ]) . "\n";
+        $log .= $e->getTraceAsString() . "\n";
         return io_saveFile($conf['cachedir'] . '/_error.log', $log, true);
     }
 

--- a/inc/ErrorHandler.php
+++ b/inc/ErrorHandler.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace dokuwiki;
+
+class ErrorHandler
+{
+
+    /**
+     * Register the default error handling
+     */
+    public static function register()
+    {
+        set_error_handler([ErrorHandler::class, 'errorConverter']);
+        if (!defined('DOKU_UNITTEST')) {
+            set_exception_handler([ErrorHandler::class, 'fatalException']);
+        }
+    }
+
+    /**
+     * Default Exception handler to show a nice user message before dieing
+     *
+     * The exception is logged to the error log
+     *
+     * @param \Throwable $e
+     */
+    public static function fatalException($e)
+    {
+        $title = hsc(get_class($e) . ': ' . $e->getMessage());
+        $msg = 'An unforeseen error has occured. This is most likely a bug somewhere.';
+        $logged = self::logException($e)
+            ? 'More info has been written to the DokuWiki _error.log'
+            : $e->getFile() . ':' . $e->getLine();
+
+        echo <<<EOT
+<!DOCTYPE html>
+<html>
+<head><title>$title</title></head>
+<body style="font-family: Arial, sans-serif">
+    <div style="width:60%; margin: auto; background-color: #fcc;
+                border: 1px solid #faa; padding: 0.5em 1em;">
+        <h1 style="font-size: 120%">$title</h1>
+        <p>$msg</p>
+        <p>$logged</p>
+    </div>
+</body>
+</html>
+EOT;
+    }
+
+    /**
+     * Convenience method to display an error message for the given Exception
+     *
+     * @param \Throwable $e
+     * @param string $intro
+     */
+    public static function showExceptionMsg($e, $intro = 'Error!')
+    {
+        $msg = $intro . get_class($e) . ': ' . $e->getMessage();
+        self::logException($e);
+        msg(hsc($msg), -1);
+    }
+
+    /**
+     * Default error handler to convert old school warnings, notices, etc to exceptions
+     *
+     * You should not need to call this directly!
+     *
+     * @param int $errno
+     * @param string $errstr
+     * @param string $errfile
+     * @param int $errline
+     * @return bool
+     * @throws \ErrorException
+     */
+    public static function errorConverter($errno, $errstr, $errfile, $errline)
+    {
+        if (!(error_reporting() & $errno)) {
+            // This error code is not included in error_reporting, so let it fall
+            // through to the standard PHP error handler
+            return false;
+        }
+        throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+    }
+
+    /**
+     * Log the given exception to the error log
+     *
+     * @param \Throwable $e
+     * @return bool false if the logging failed
+     */
+    public static function logException($e)
+    {
+        global $conf;
+
+        $log = join("\t", [gmdate('c'), get_class($e), $e->getFile() . ':' . $e->getLine(), $e->getMessage()]) . "\n";
+        return io_saveFile($conf['cachedir'] . '/_error.log', $log, true);
+    }
+}

--- a/inc/Exception/FatalException.php
+++ b/inc/Exception/FatalException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace dokuwiki\Exception;
+
+/**
+ * Fatal Errors are converted into this Exception in out Shutdown handler
+ */
+class FatalException extends \ErrorException
+{
+
+}

--- a/inc/Extension/PluginController.php
+++ b/inc/Extension/PluginController.php
@@ -120,7 +120,8 @@ class PluginController
                 } elseif (preg_match('/^' . DOKU_PLUGIN_NAME_REGEX . '$/', $plugin) !== 1) {
                     msg(
                         sprintf(
-                            "Plugin name '%s' is not a valid plugin name, only the characters a-z and 0-9 are allowed. " .
+                            "Plugin name '%s' is not a valid plugin name, only the characters a-z ".
+                            "and 0-9 are allowed. " .
                             'Maybe the plugin has been installed in the wrong directory?', hsc($plugin)
                         ), -1
                     );

--- a/inc/Extension/PluginController.php
+++ b/inc/Extension/PluginController.php
@@ -129,7 +129,7 @@ class PluginController
             }
             $DOKU_PLUGINS[$type][$name] = new $class;
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             ErrorHandler::showExceptionMsg($e, sprintf('Failed to load plugin %s', $plugin));
             return null;
         }

--- a/inc/Extension/PluginController.php
+++ b/inc/Extension/PluginController.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\Extension;
 
+use dokuwiki\ErrorHandler;
+
 /**
  * Class to encapsulate access to dokuwiki plugins
  *
@@ -90,42 +92,48 @@ class PluginController
 
         $class = $type . '_plugin_' . $name;
 
-        //plugin already loaded?
-        if (!empty($DOKU_PLUGINS[$type][$name])) {
-            if ($new || !$DOKU_PLUGINS[$type][$name]->isSingleton()) {
-                return class_exists($class, true) ? new $class : null;
+        try {
+            //plugin already loaded?
+            if (!empty($DOKU_PLUGINS[$type][$name])) {
+                if ($new || !$DOKU_PLUGINS[$type][$name]->isSingleton()) {
+
+                    return class_exists($class, true) ? new $class : null;
+                }
+
+                return $DOKU_PLUGINS[$type][$name];
             }
 
-            return $DOKU_PLUGINS[$type][$name];
-        }
-
-        //construct class and instantiate
-        if (!class_exists($class, true)) {
-
-            # the plugin might be in the wrong directory
-            $inf = confToHash(DOKU_PLUGIN . "$plugin/plugin.info.txt");
-            if ($inf['base'] && $inf['base'] != $plugin) {
-                msg(
-                    sprintf(
-                        "Plugin installed incorrectly. Rename plugin directory '%s' to '%s'.",
-                        hsc($plugin),
-                        hsc(
-                            $inf['base']
-                        )
-                    ), -1
-                );
-            } elseif (preg_match('/^' . DOKU_PLUGIN_NAME_REGEX . '$/', $plugin) !== 1) {
-                msg(
-                    sprintf(
-                        "Plugin name '%s' is not a valid plugin name, only the characters a-z and 0-9 are allowed. " .
-                        'Maybe the plugin has been installed in the wrong directory?', hsc($plugin)
-                    ), -1
-                );
+            //construct class and instantiate
+            if (!class_exists($class, true)) {
+                # the plugin might be in the wrong directory
+                $inf = confToHash(DOKU_PLUGIN . "$plugin/plugin.info.txt");
+                if ($inf['base'] && $inf['base'] != $plugin) {
+                    msg(
+                        sprintf(
+                            "Plugin installed incorrectly. Rename plugin directory '%s' to '%s'.",
+                            hsc($plugin),
+                            hsc(
+                                $inf['base']
+                            )
+                        ), -1
+                    );
+                } elseif (preg_match('/^' . DOKU_PLUGIN_NAME_REGEX . '$/', $plugin) !== 1) {
+                    msg(
+                        sprintf(
+                            "Plugin name '%s' is not a valid plugin name, only the characters a-z and 0-9 are allowed. " .
+                            'Maybe the plugin has been installed in the wrong directory?', hsc($plugin)
+                        ), -1
+                    );
+                }
+                return null;
             }
+            $DOKU_PLUGINS[$type][$name] = new $class;
+
+        } catch (\Exception $e) {
+            ErrorHandler::showExceptionMsg($e, sprintf('Failed to load plugin %s', $plugin));
             return null;
         }
 
-        $DOKU_PLUGINS[$type][$name] = new $class;
         return $DOKU_PLUGINS[$type][$name];
     }
 

--- a/inc/init.php
+++ b/inc/init.php
@@ -199,6 +199,9 @@ if (empty($plugin_controller_class)) $plugin_controller_class = dokuwiki\Extensi
 require_once(DOKU_INC.'vendor/autoload.php');
 require_once(DOKU_INC.'inc/load.php');
 
+// from now on everything is an exception
+\dokuwiki\ErrorHandler::register();
+
 // disable gzip if not available
 define('DOKU_HAS_BZIP', function_exists('bzopen'));
 define('DOKU_HAS_GZIP', function_exists('gzopen'));

--- a/inc/load.php
+++ b/inc/load.php
@@ -155,7 +155,7 @@ function load_autoload($name){
             try {
                 require $plg;
             } catch (\Throwable $e) {
-                \dokuwiki\ErrorHandler::showExceptionMsg($e, "Error loading plugin ${$m[2]}");
+                \dokuwiki\ErrorHandler::showExceptionMsg($e, "Error loading plugin {$m[2]}");
             }
         }
         return true;

--- a/inc/load.php
+++ b/inc/load.php
@@ -108,7 +108,11 @@ function load_autoload($name){
         $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
         $file = DOKU_PLUGIN . substr($name, 16) . '.php';
         if(file_exists($file)) {
-            require $file;
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                \dokuwiki\ErrorHandler::showExceptionMsg($e, "Error loading plugin $name");
+            }
             return true;
         }
     }
@@ -118,7 +122,11 @@ function load_autoload($name){
         $name = str_replace('/test/', '/_test/', $name); // no underscore in test namespace
         $file = DOKU_INC.'lib/tpl/' . substr($name, 18) . '.php';
         if(file_exists($file)) {
-            require $file;
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                \dokuwiki\ErrorHandler::showExceptionMsg($e, "Error loading template $name");
+            }
             return true;
         }
     }
@@ -144,7 +152,11 @@ function load_autoload($name){
         $c = ((count($m) === 4) ? "/{$m[3]}" : '');
         $plg = DOKU_PLUGIN . "{$m[2]}/{$m[1]}$c.php";
         if(file_exists($plg)){
-            require $plg;
+            try {
+                require $plg;
+            } catch (\Throwable $e) {
+                \dokuwiki\ErrorHandler::showExceptionMsg($e, "Error loading plugin ${$m[2]}");
+            }
         }
         return true;
     }


### PR DESCRIPTION
This introduces global handling of errors and exceptions. All uncaught exceptions or errors will be caught at the end, a message is shown to the user and a Stacktrace is logged to data/cache/_error.log.

The error handler also tries to identify the plugin that might have caused the problem by looking at the stacktrace.

Loading of plugins is wrapped in try/catch blocks plugins should no longer crash the wiki on load (for some errors).

This requires PHP 7+ and thus shall only be merged after the release of Hogfather.

More testing is needed. If someone knows plugins that are currently causing PHP errors in Hogfather, please let me know, because I would like to see if we can catch them correctly here.