### PR TITLE
External image testing

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1715,8 +1715,12 @@ function tpl_getMediaFile($search, $abs = false, &$imginfo = null, $fallback = t
     }
 
     // fetch image data if requested
-    if(!is_null($imginfo)) {
-        $imginfo = getimagesize($file);
+    if (
+		(!is_null($imginfo))
+		&&
+		(!preg_match('#^(https?|ftp)#i',$file))
+	) {
+		$imginfo = getimagesize($file);
     }
 
     // build URL


### PR DESCRIPTION
[Sat Jul 25 20:41:12.975596 2020] [php7:warn] [pid 14861] [client <...>:39634] PHP Warning:  getimagesize(/var/www/comicslate.org/data/media/http/freefall.purrsia.com/abyother/florencehalloween.jpg): failed to open stream: No such file or directory in /var/www/comicslate.org/inc/template.php on line 1705