### PR TITLE
Public access to patterns in external link parser

### DIFF
--- a/inc/Parsing/ParserMode/Externallink.php
+++ b/inc/Parsing/ParserMode/Externallink.php
@@ -41,4 +41,12 @@ class Externallink extends AbstractMode
     {
         return 330;
     }
+
+    /**
+     * @return array
+     */
+    public function getPatterns()
+    {
+        return $this->patterns;
+    }
 }


### PR DESCRIPTION
The link patterns can be useful to plugins