### PR TITLE
Remove `charset` attribute from `<script>` tags

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -348,7 +348,6 @@ function tpl_metaheaders($alt = true) {
     $jquery = getCdnUrls();
     foreach($jquery as $src) {
         $head['script'][] = array(
-            'charset' => 'utf-8',
             '_data' => '',
             'src' => $src,
         ) + ($conf['defer_js'] ? [ 'defer' => 'defer'] : []);
@@ -356,7 +355,7 @@ function tpl_metaheaders($alt = true) {
 
     // load our javascript dispatcher
     $head['script'][] = array(
-        'charset'=> 'utf-8', '_data'=> '',
+        '_data' => '',
         'src' => DOKU_BASE.'lib/exe/js.php'.'?t='.rawurlencode($conf['template']).'&tseed='.$tseed,
     ) + ($conf['defer_js'] ? [ 'defer' => 'defer'] : []);
 


### PR DESCRIPTION
According to the HTML5 standard, it is not necessary to specify
'charset' for scripts if the 'charset' is specified before for the node
document. Since the whole DokuWiki runs as UTF-8, I think it should
_not_ be necessary to specify that here.

Reason for this change: It shows a warning during HTML5 validation.

See:
https://html.spec.whatwg.org/multipage/scripting.html#script-processing-encoding