### PR TITLE
Remove empty action attributes from forms

### DIFF
--- a/install.php
+++ b/install.php
@@ -159,7 +159,7 @@ function print_form($d){
     if(!isset($d['pop'])) $d['pop']=1;
 
     ?>
-    <form action="" method="post">
+    <form method="post">
     <input type="hidden" name="l" value="<?php echo $LC ?>" />
     <fieldset>
         <label for="title"><?php echo $lang['i_wikiname']?>
@@ -245,7 +245,7 @@ function print_retry() {
     global $lang;
     global $LC;
     ?>
-    <form action="" method="get">
+    <form method="get">
       <fieldset>
         <input type="hidden" name="l" value="<?php echo $LC ?>" />
         <button type="submit"><?php echo $lang['i_retry'];?></button>
@@ -634,7 +634,7 @@ function langsel(){
     closedir($dh);
     sort($langs);
 
-    echo '<form action="">';
+    echo '<form>';
     echo $lang['i_chooselang'];
     echo ': <select name="l" onchange="submit()">';
     foreach($langs as $l){

--- a/lib/plugins/revert/admin.php
+++ b/lib/plugins/revert/admin.php
@@ -69,7 +69,7 @@ class admin_plugin_revert extends DokuWiki_Admin_Plugin
     protected function printSearchForm()
     {
         global $lang, $INPUT;
-        echo '<form action="" method="post"><div class="no">';
+        echo '<form method="post"><div class="no">';
         echo '<label>'.$this->getLang('filter').': </label>';
         echo '<input type="text" name="filter" class="edit" value="'.hsc($INPUT->str('filter')).'" /> ';
         echo '<button type="submit">'.$lang['btn_search'].'</button> ';
@@ -123,7 +123,7 @@ class admin_plugin_revert extends DokuWiki_Admin_Plugin
         global $conf;
         global $lang;
         echo '<hr /><br />';
-        echo '<form action="" method="post"><div class="no">';
+        echo '<form method="post"><div class="no">';
         echo '<input type="hidden" name="filter" value="'.hsc($filter).'" />';
         formSecurityToken();
 


### PR DESCRIPTION
Empty `action` attribute is an error in HTML5, according to specs,

> The action and formaction content attributes, if specified, must have
> a value that is a valid non-empty URL potentially surrounded by
> spaces.

See: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action

So, in HTML5, providing an empty `action` attribute is an error and
therefore should be removed.

### Note on older versions

However, in older versions (HTML 4.01 and XHTML, for example), `action`
attribute is **required** and has to contain an URI:

```
<!ATTLIST form
  %attrs;
  action      %URI;          #REQUIRED
...
```

See:
* https://www.w3.org/TR/html401/strict.dtd
* https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd

### Conclusion

So, hereby I just suggest if it would not be better to delete this attribute
completely as it shows as error in HTML5 validation. But, although DokuWiki
runs HTML5, keep in mind that in HTML 4.01 or XHTML the attribute `action`
is required (i.e. maybe really old browsers could have problems, IE 11 is fine,
I have tested that).