### PR TITLE
add classname based on ns, pageid, tree level. implements #2531

### DIFF
--- a/_test/tests/inc/template_tpl_classes.test.php
+++ b/_test/tests/inc/template_tpl_classes.test.php
@@ -1,0 +1,139 @@
+<?php
+
+
+class template_tpl_classes_test extends DokuWikiTest {
+
+    function hasClass($class, $classes) {
+        /*
+         * with phpunit for php 7.3, I can't use regexp. So, instead of using
+         * $this->assertMatchesRegularExpression('/\bSOME-STRING\b/', $classes_str);
+         * I have to use
+         * $this->assertTrue(in_array('SOME-STRING', explode(' ', $classes_str)));
+         * Which I simplified a bit as
+         * $this->assertTrue($this->hasClass('SOME-STRING', $classes_str));
+         * The error messages in case of failure are not very informative.
+         */
+        return in_array($class, explode(' ', $classes));
+    }
+    function test_levels() {
+        global $ID;
+        
+        foreach( [':a', 'a:b', ':a:b:c', 'a:b:c:d', ':a:b:c:d:e'] as $level => $ID ) {
+            $classes=tpl_classes();
+            $this->assertTrue($this->hasClass("lv_$level", $classes));
+            // negative tests
+            $this->assertFalse($this->hasClass('lv_', $classes));
+            $this->assertFalse($this->hasClass('lv_'.($level - 1), $classes));
+            $this->assertFalse($this->hasClass('lv_'.($level + 1), $classes));
+        }
+    }
+
+    function test_pg() {
+        global $ID;
+        
+        $ID=':a';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_a', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_', $classes));
+
+        $ID='a:b';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_b', $classes));
+        $this->assertTrue($this->hasClass('pg_a_b', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_a', $classes));
+        $this->assertFalse($this->hasClass('pg_', $classes));
+
+        $ID=':a:b:c:d:e';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_e', $classes));
+        $this->assertTrue($this->hasClass('pg_a_b_c_d_e', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_a', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b_c', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b_c_d', $classes));
+        $this->assertFalse($this->hasClass('pg_', $classes));
+    }
+
+    function test_ns() {
+        global $ID;
+        
+        $ID=':a';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('ns__', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('ns__a', $classes));
+        $this->assertFalse($this->hasClass('ns_a_', $classes));
+
+        $ID='a:b';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('ns__a', $classes));
+        $this->assertTrue($this->hasClass('ns_a_', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('ns__a_b', $classes));
+        $this->assertFalse($this->hasClass('ns__b_', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_', $classes));
+
+        $ID=':a:b:c:d:e';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('ns__a', $classes));
+        $this->assertTrue($this->hasClass('ns__a_b', $classes));
+        $this->assertTrue($this->hasClass('ns__a_b_c', $classes));
+        $this->assertTrue($this->hasClass('ns__a_b_c_d', $classes));
+        $this->assertTrue($this->hasClass('ns__a_b_c_d', $classes));
+        $this->assertTrue($this->hasClass('ns_d_', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('ns_d', $classes));
+        $this->assertFalse($this->hasClass('ns__e_', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_c_d_e', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_c_d_e_', $classes));
+    }
+
+    function test_underscore() {
+        global $ID;
+        
+        $ID=':a_b';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_a__b', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b', $classes));
+        $this->assertFalse($this->hasClass('pg_b', $classes));
+        $this->assertFalse($this->hasClass('pg__b', $classes));
+        $this->assertFalse($this->hasClass('pg___b', $classes));
+
+        $ID='a:b_c';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_b__c', $classes));
+        $this->assertTrue($this->hasClass('pg_a_b__c', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b_c', $classes));
+        $this->assertFalse($this->hasClass('pg_b_c', $classes));
+        $this->assertFalse($this->hasClass('pg__b_c', $classes));
+        $this->assertFalse($this->hasClass('pg___b_c', $classes));
+
+        $ID=':a_b:c';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_a__b_c', $classes));
+        $this->assertTrue($this->hasClass('pg_c', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b_c', $classes));
+        $this->assertFalse($this->hasClass('pg__c', $classes));
+        $this->assertFalse($this->hasClass('pg___c', $classes));
+
+        $ID=':a_b:c_d';
+        $classes=tpl_classes();
+        $this->assertTrue($this->hasClass('pg_a__b_c__d', $classes));
+        $this->assertTrue($this->hasClass('pg_c__d', $classes));
+        // negative tests
+        $this->assertFalse($this->hasClass('pg_', $classes));
+        $this->assertFalse($this->hasClass('pg_a_b_c_d', $classes));
+        $this->assertFalse($this->hasClass('pg_c_d', $classes));
+        $this->assertFalse($this->hasClass('pg__c_d', $classes));
+        $this->assertFalse($this->hasClass('pg___c_d', $classes));
+    }
+}

--- a/_test/tests/inc/template_tpl_classes.test.php
+++ b/_test/tests/inc/template_tpl_classes.test.php
@@ -82,7 +82,6 @@ class template_tpl_classes_test extends DokuWikiTest {
         $this->assertTrue($this->hasClass('ns__a_b', $classes));
         $this->assertTrue($this->hasClass('ns__a_b_c', $classes));
         $this->assertTrue($this->hasClass('ns__a_b_c_d', $classes));
-        $this->assertTrue($this->hasClass('ns__a_b_c_d', $classes));
         $this->assertTrue($this->hasClass('ns_d_', $classes));
         // negative tests
         $this->assertFalse($this->hasClass('ns_d', $classes));
@@ -119,11 +118,16 @@ class template_tpl_classes_test extends DokuWikiTest {
         $classes=tpl_classes();
         $this->assertTrue($this->hasClass('pg_a__b_c', $classes));
         $this->assertTrue($this->hasClass('pg_c', $classes));
+        $this->assertTrue($this->hasClass('ns__a__b', $classes));
+        $this->assertTrue($this->hasClass('ns_a__b_', $classes));
         // negative tests
         $this->assertFalse($this->hasClass('pg_', $classes));
         $this->assertFalse($this->hasClass('pg_a_b_c', $classes));
         $this->assertFalse($this->hasClass('pg__c', $classes));
         $this->assertFalse($this->hasClass('pg___c', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_c', $classes));
+        $this->assertFalse($this->hasClass('ns_a_b_', $classes));
+
 
         $ID=':a_b:c_d';
         $classes=tpl_classes();
@@ -135,5 +139,8 @@ class template_tpl_classes_test extends DokuWikiTest {
         $this->assertFalse($this->hasClass('pg_c_d', $classes));
         $this->assertFalse($this->hasClass('pg__c_d', $classes));
         $this->assertFalse($this->hasClass('pg___c_d', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_c_d', $classes));
+        $this->assertFalse($this->hasClass('ns__a__b_c_d', $classes));
+        $this->assertFalse($this->hasClass('ns__a_b_c__d', $classes));
     }
 }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1873,17 +1873,17 @@ function tpl_classes() {
     $chain = explode(':', $id);
     $pgname = array_pop($chain);
 
-    $classes[] = 'dwl_' . count($chain);
-    $ns = 'dwn_';
+    $classes[] = 'lv_' . count($chain);
+    $ns = 'ns_';
     foreach($chain as $comp) {
         $ns .= "_$comp";
         $classes[] = $ns;
     }
     $parent = array_pop($chain);
-    $classes[] = "dwn_{$parent}_";
-    $classes[] = "dwp_$pgname";
+    $classes[] = "ns_{$parent}_";
+    $classes[] = "pg_$pgname";
     if('' != $parent)
-        $classes[] = 'dwp_' . str_replace(':', '_', $id);
+        $classes[] = 'pg_' . str_replace(':', '_', $id);
 
     return join(' ', $classes);
 }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1867,8 +1867,9 @@ function tpl_classes() {
         ($ID == $conf['start']) ? 'home' : '',
     );
     $id=$ID;
-    if($id[0] == ':')
+    if($id[0] == ':') {
         $id = substr($id,1);
+    }
     $id = str_replace('_', '__', $id);
     $chain = explode(':', $id);
     $pgname = array_pop($chain);
@@ -1882,8 +1883,9 @@ function tpl_classes() {
     $parent = array_pop($chain);
     $classes[] = "ns_{$parent}_";
     $classes[] = "pg_$pgname";
-    if('' != $parent)
+    if('' != $parent) {
         $classes[] = 'pg_' . str_replace(':', '_', $id);
+    }
 
     return join(' ', $classes);
 }

--- a/inc/template.php
+++ b/inc/template.php
@@ -1872,7 +1872,6 @@ function tpl_classes() {
     $id = str_replace('_', '__', $id);
     $chain = explode(':', $id);
     $pgname = array_pop($chain);
-    $classes = Array();
 
     $classes[] = 'dwl_' . count($chain);
     $ns = 'dwn_';

--- a/inc/template.php
+++ b/inc/template.php
@@ -1881,7 +1881,7 @@ function tpl_classes() {
     }
     $parent = array_pop($chain);
     $classes[] = "dwn_{$parent}_";
-    $classes[] = 'dwp_'.$pgname;
+    $classes[] = "dwp_$pgname";
     if('' != $parent)
         $classes[] = 'dwp_' . str_replace(':', '_', $id);
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -1845,11 +1845,13 @@ function tpl_media() {
 }
 
 /**
- * Return useful layout classes
+ * Return useful layout classes based on mode, pagename, namespace,
+ * existence, template, etc...
  *
  * @author Anika Henke <anika@selfthinker.org>
+ * @author Schplurtz le Déboulonné <Schplurtz@laposete.net>
  *
- * @return string
+ * @return string space separated list of css class name
  */
 function tpl_classes() {
     global $ACT, $conf, $ID, $INFO;
@@ -1864,6 +1866,26 @@ function tpl_classes() {
         (isset($INFO) && $INFO['exists']) ? '' : 'notFound',
         ($ID == $conf['start']) ? 'home' : '',
     );
+    $id=$ID;
+    if($id[0] == ':')
+        $id = substr($id,1);
+    $id = str_replace('_', '__', $id);
+    $chain = explode(':', $id);
+    $pgname = array_pop($chain);
+    $classes = Array();
+
+    $classes[] = 'dwl_' . count($chain);
+    $ns = 'dwn_';
+    foreach($chain as $comp) {
+        $ns .= "_$comp";
+        $classes[] = $ns;
+    }
+    $parent = array_pop($chain);
+    $classes[] = "dwn_{$parent}_";
+    $classes[] = 'dwp_'.$pgname;
+    if('' != $parent)
+        $classes[] = 'dwp_' . str_replace(':', '_', $id);
+
     return join(' ', $classes);
 }
 


### PR DESCRIPTION
Hi,

this PR adds classes based on pageid (relative and full), tree level, namespace, direct parent namespace.

Here are some examples
```
      start => dwl_0   dwn__      dwp_start
     :start => dwl_0   dwn__      dwp_start
   fr:start => dwl_1   dwn__fr    dwn_fr_        dwp_start   dwp_fr_start
  _fr:start => dwl_1   dwn____fr  dwn___fr_      dwp_start   dwp___fr_start
   fr:voila => dwl_1   dwn__fr    dwn_fr_        dwp_voila   dwp_fr_voila
   de:voila => dwl_1   dwn__de    dwn_de_        dwp_voila   dwp_de_voila
foo:bar:baz => dwl_2   dwn__foo   dwn__foo_bar   dwn_bar_    dwp_baz         dwp_foo_bar_baz
   :bar:baz => dwl_1   dwn__bar   dwn_bar_       dwp_baz     dwp_bar_baz
        a_b => dwl_0   dwn__      dwp_a__b
        a:b => dwl_1   dwn__a     dwn_a_         dwp_b       dwp_a_b
    b:c:d:e => dwl_3   dwn__b     dwn__b_c       dwn__b_c_d  dwn_d_          dwp_e   dwp_b_c_d_e
  a:b:c:d:e => dwl_4   dwn__a     dwn__a_b       dwn__a_b_c  dwn__a_b_c_d    dwn_d_  dwp_e        dwp_a_b_c_d_e
  c:b:a:d:e => dwl_4   dwn__c     dwn__c_b       dwn__c_b_a  dwn__c_b_a_d    dwn_d_  dwp_e        dwp_c_b_a_d_e
```
In css, it's then easy to select pages based on their location.
* select any page at root : `.dwl_0`
* any start page : `.dwp_start`
* start page in `fr` ns : `dwp_start.dwp_fr_start` (more selectors than the preceding one, so it's easy to create specific styles)
* THE start page : `.dwp_start.dwl_0` (there already exist a `.home` selector for this case)
* any page in any `d` ns, no matter how deep the ns is : `.dwn_d_`
* any page in `foo:bar` ns : `.dwn__foo_bar`

Closes #2531.