### PR TITLE
don't crush tables too narrow. fixes #3250

### DIFF
--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -88,6 +88,7 @@
 .dokuwiki div.table {
     overflow-x: auto;
     margin-bottom: 1.4em;
+    min-width: 50%;
 }
 
 .dokuwiki div.table table {


### PR DESCRIPTION
This ensures that the table wrapper has at least 50% of the page width
available. This allows small tables still be besides floating elements
like images or the TOC, but larger tables will get the full width.