### PR TITLE
Lexer with support for Unicode character properties

### DIFF
--- a/inc/Parsing/Lexer/ParallelRegex.php
+++ b/inc/Parsing/Lexer/ParallelRegex.php
@@ -198,6 +198,6 @@ class ParallelRegex
      */
     protected function getPerlMatchingFlags()
     {
-        return ($this->case ? "msS" : "msSi");
+        return ($this->case ? "umsS" : "umsSi");
     }
 }


### PR DESCRIPTION
Closes #3200 

Adds `u` to regex matching flags in class `ParallelRegex`.
Tests for all [Unicode character properties](https://www.php.net/manual/en/regexp.reference.unicode.php) are provided.