### PR TITLE
media: Fix media_resize_image cache check

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -2061,14 +2061,14 @@ function media_resize_image($file, $ext, $w, $h=0){
 
     //cache
     $local = getCacheName($file,'.media.'.$w.'x'.$h.'.'.$ext);
-    $mtime = @filemtime($local); // 0 if not exists
+    $mtime = (int) @filemtime($local); // 0 if not exists
 
     $options = [
         'quality' => $conf['jpg_quality'],
         'imconvert' => $conf['im_convert'],
     ];
 
-    if( $mtime > @filemtime($file) ) {
+    if( $mtime <= (int) @filemtime($file) ) {
         try {
             \splitbrain\slika\Slika::run($file, $options)
                                    ->autorotate()


### PR DESCRIPTION
The check was backwards, and it also caused a failure when there is no cache file (mtime=0) because the function would still return the path to the nonexistent cache file.
