### PR TITLE
set page context in Handler

### DIFF
--- a/inc/parser/handler.php
+++ b/inc/parser/handler.php
@@ -30,11 +30,37 @@ class Doku_Handler {
     /** @var bool should blocks be rewritten? FIXME seems to always be true */
     protected $rewriteBlocks = true;
 
+    /** @var string|null the currently processed page, null for on the fly renders */
+    protected $page = null;
+
     /**
      * Doku_Handler constructor.
      */
     public function __construct() {
         $this->callWriter = new CallWriter($this);
+    }
+
+    /**
+     * Set the currently processed page
+     *
+     * @param string $id
+     */
+    public function setPage($id)
+    {
+        $this->page = $id;
+    }
+
+    /**
+     * Get the currently processed page
+     *
+     * This may return null when the parsing/handling process is called "on the fly", eg. to
+     * render a wiki text snippet somewhere.
+     *
+     * @return string|null
+     */
+    public function getPage()
+    {
+        return $this->page;
     }
 
     /**

--- a/inc/parserutils.php
+++ b/inc/parserutils.php
@@ -80,7 +80,7 @@ function p_wiki_xhtml($id, $rev='', $excuse=true,$date_at=''){
     if($rev || $date_at){
         if(file_exists($file)){
             //no caching on old revisions
-            $ret = p_render('xhtml',p_get_instructions(io_readWikiPage($file,$id,$rev)),$info,$date_at);
+            $ret = p_render('xhtml',p_get_instructions(io_readWikiPage($file,$id,$rev), $id),$info,$date_at);
         }elseif($excuse){
             $ret = p_locale_xhtml('norev');
         }
@@ -193,27 +193,32 @@ function p_cached_instructions($file,$cacheonly=false,$id='') {
 /**
  * turns a page into a list of instructions
  *
- * @author Harry Fuecks <hfuecks@gmail.com>
+ * @param string $text raw wiki syntax text
+ * @param string $id optional hint on the currently processed page
+ * @return array a list of instruction arrays
  * @author Andreas Gohr <andi@splitbrain.org>
  *
- * @param string $text  raw wiki syntax text
- * @return array a list of instruction arrays
+ * @author Harry Fuecks <hfuecks@gmail.com>
  */
-function p_get_instructions($text){
+function p_get_instructions($text, $id=''){
 
     $modes = p_get_parsermodes();
 
     // Create the parser and handler
-    $Parser = new Parser(new Doku_Handler());
+    $handler = new Doku_Handler();
+    if($id !== '') {
+        $handler->setPage($id);
+    }
+    $parser = new Parser($handler);
 
     //add modes to parser
     foreach($modes as $mode){
-        $Parser->addMode($mode['mode'],$mode['obj']);
+        $parser->addMode($mode['mode'],$mode['obj']);
     }
 
     // Do the parsing
     Event::createAndTrigger('PARSER_WIKITEXT_PREPROCESS', $text);
-    $p = $Parser->parse($text);
+    $p = $parser->parse($text);
     //  dbg($p);
     return $p;
 }


### PR DESCRIPTION
Under some circumstances it is useful to know if the current parsing process is running in a page context or not.

One of the examples is the struct plugin's use of the PARSER_HANDLER_DONE event to automatically inject its own output instruction. Currently this instruction is injected in each and every processing and only on rendering is decided if there is anything to output.

This patch injects a page hint into the Handler when the handler was created from our p_wiki_xhtml() method (and only then). Plugins can use the getPage() method to check the context if needed.

Note: currently p_wiki_xhtml() also modifies the global $ID variable which might also used as context hint (but will also be set during on-the-fly renders, eg. the preview intro text).

It would probably be a good idea to check if it would be better when all handle methods rely on getPage() instead of global $ID instead. This would be a major change in parsing though and needs serious testing while this addition has basically no consequences currently.