### PR TITLE
Improve auth_browseruid()

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -279,7 +279,7 @@ function auth_login($user, $pass, $sticky = false, $silent = false) {
  *
  * @author  Andreas Gohr <andi@splitbrain.org>
  *
- * @return  string  a MD5 sum of various browser headers
+ * @return  string  a SHA256 sum of various browser headers
  */
 function auth_browseruid() {
     /* @var Input $INPUT */
@@ -288,10 +288,14 @@ function auth_browseruid() {
     $ip  = clientIP(true);
     $uid = '';
     $uid .= $INPUT->server->str('HTTP_USER_AGENT');
-    $uid .= $INPUT->server->str('HTTP_ACCEPT_CHARSET');
-    $uid .= substr($ip, 0, strpos($ip, '.'));
-    $uid = strtolower($uid);
-    return md5($uid);
+    $uid .= $INPUT->server->str('HTTP_ACCEPT_LANGUAGE');
+    $uid .= $INPUT->server->str('HTTP_ACCEPT_ENCODING');
+    $uid .= $INPUT->server->str('HTTP_ACCEPT');
+    // convert IP string to packed binary representation
+    $pip = inet_pton($ip);
+    // use half of the IP address (works for both IPv4 and IPv6)
+    $uid .= substr($pip, 0, strlen($pip)/2);
+    return hash('sha256', $uid);
 }
 
 /**

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -290,7 +290,6 @@ function auth_browseruid() {
     $uid .= $INPUT->server->str('HTTP_USER_AGENT');
     $uid .= $INPUT->server->str('HTTP_ACCEPT_LANGUAGE');
     $uid .= $INPUT->server->str('HTTP_ACCEPT_ENCODING');
-    $uid .= $INPUT->server->str('HTTP_ACCEPT');
     // convert IP string to packed binary representation
     $pip = inet_pton($ip);
     // use half of the IP address (works for both IPv4 and IPv6)


### PR DESCRIPTION
As discussed in https://forum.dokuwiki.org/d/18284-dont-store-ip-addresses/5

- remove the deprecated HTTP_ACCEPT_CHARSET
- add HTTP_ACCEPT_LANGUAGE
- add HTTP_ACCEPT_ENCODING
- ~~add HTTP_ACCEPT~~ - changes based on requested resource type, so not suited for auth_browseruid()
- use half of the IP address
- add support for IPv6
- use SHA256 instead of MD5

Also:

- remove `$uid = strtolower($uid)`, as it doesn't seem to help