### PR TITLE
Remove clientIP() verification from page locking

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -942,7 +942,7 @@ function checklock($id) {
 
     //my own lock
     @list($ip, $session) = explode("\n", io_readFile($lock));
-    if($ip == $INPUT->server->str('REMOTE_USER') || $ip == clientIP() || (session_id() && $session == session_id())) {
+    if($ip == $INPUT->server->str('REMOTE_USER') || (session_id() && $session == session_id())) {
         return false;
     }
 
@@ -988,7 +988,7 @@ function unlock($id) {
     $lock = wikiLockFN($id);
     if(file_exists($lock)) {
         @list($ip, $session) = explode("\n", io_readFile($lock));
-        if($ip == $INPUT->server->str('REMOTE_USER') || $ip == clientIP() || $session == session_id()) {
+        if($ip == $INPUT->server->str('REMOTE_USER') || $session == session_id()) {
             @unlink($lock);
             return true;
         }


### PR DESCRIPTION
For editing without a user account, session_id() verification is more appropriate.

This will make page locking work for people editing the wiki from the same IP (which can happen in an office space, for example).

As discussed in https://forum.dokuwiki.org/d/18284-dont-store-ip-addresses/5