### PR TITLE
Update Loader.php

### DIFF
--- a/lib/plugins/config/core/Loader.php
+++ b/lib/plugins/config/core/Loader.php
@@ -78,10 +78,6 @@ class Loader {
      * @return array
      */
     public function loadDefaults() {
-        // load main files
-        global $config_cascade;
-        $conf = $this->loadConfigs($config_cascade['main']['default']);
-
         // plugins
         foreach($this->plugins as $plugin) {
             $conf = array_merge(
@@ -104,6 +100,10 @@ class Loader {
             )
         );
 
+        // load main files
+        global $config_cascade;
+        $conf = $this->loadConfigs($config_cascade['main']['default']);
+        
         return $conf;
     }
 


### PR DESCRIPTION
The config options are read in the order plugin-standard-values -> template-standard-values -> dokuwiki.php -> local.php -> local.protected.php into DokuWiki.
But when entering the configuration manger, they options are displayed in the order dokuwiki.php -> plugin-standard-values -> template-standard-values -> local.php -> local.protected.php

This patch fixes the issue, so that the right values are displayed if there are no configs set in local.php or local.protected.php

See also https://forum.dokuwiki.org/d/18489-issues-with-modifying-confdokuwikiphp for further information.