### PR TITLE
Allow revert action for logged in users only

### DIFF
--- a/inc/Action/AbstractUserAction.php
+++ b/inc/Action/AbstractUserAction.php
@@ -17,7 +17,7 @@ abstract class AbstractUserAction extends AbstractAclAction {
     public function checkPreconditions() {
         parent::checkPreconditions();
         global $INPUT;
-        if(!$INPUT->server->str('REMOTE_USER')) {
+        if($INPUT->server->str('REMOTE_USER') === '') {
             throw new ActionUserRequiredException();
         }
     }

--- a/inc/Action/Revert.php
+++ b/inc/Action/Revert.php
@@ -12,10 +12,12 @@ use dokuwiki\Action\Exception\ActionException;
  *
  * @package dokuwiki\Action
  */
-class Revert extends AbstractAction {
+class Revert extends AbstractUserAction
+{
 
     /** @inheritdoc */
-    public function minimumPermission() {
+    public function minimumPermission()
+    {
         return AUTH_EDIT;
     }
 
@@ -26,8 +28,9 @@ class Revert extends AbstractAction {
      * @throws ActionException
      * @todo check for writability of the current page ($INFO might do it wrong and check the attic version)
      */
-    public function preProcess() {
-        if(!checkSecurityToken()) throw new ActionException();
+    public function preProcess()
+    {
+        if (!checkSecurityToken()) throw new ActionException();
 
         global $ID;
         global $REV;
@@ -37,14 +40,14 @@ class Revert extends AbstractAction {
         // FIXME this feature is not exposed in the GUI currently
         $text = '';
         $sum = $lang['deleted'];
-        if($REV) {
+        if ($REV) {
             $text = rawWiki($ID, $REV);
-            if(!$text) throw new ActionException(); //something went wrong
+            if (!$text) throw new ActionException(); //something went wrong
             $sum = sprintf($lang['restored'], dformat($REV));
         }
 
         // spam check
-        if(checkwordblock($text)) {
+        if (checkwordblock($text)) {
             msg($lang['wordblock'], -1);
             throw new ActionException('edit');
         }

--- a/inc/Menu/Item/Revert.php
+++ b/inc/Menu/Item/Revert.php
@@ -7,15 +7,18 @@ namespace dokuwiki\Menu\Item;
  *
  * Quick revert to the currently shown page revision
  */
-class Revert extends AbstractItem {
+class Revert extends AbstractItem
+{
 
     /** @inheritdoc */
-    public function __construct() {
+    public function __construct()
+    {
         global $REV;
         global $INFO;
+        global $INPUT;
         parent::__construct();
 
-        if(!$REV || !$INFO['writable']) {
+        if (!$REV || !$INFO['writable'] || $INPUT->server->str('REMOTE_USER') === '') {
             throw new \RuntimeException('revert not available');
         }
         $this->params['rev'] = $REV;


### PR DESCRIPTION
Since  #2995 we have reports of bots reverting wiki pages by ignoring the `rel=nofollow` attribute on the menu item:

https://forum.dokuwiki.org/d/18227-crawler-keeps-restoring-old-revisions-of-all-articles
https://forum.dokuwiki.org/d/18496-i-am-receiving-random-reverts-from-some-kind-of-bot

This changes the functionality to be available to logged in users only. This should prevent accidental reverts by bots on open wikis.