### PR TITLE
set proper revinfo when media meta file is not available

### DIFF
--- a/inc/Ui/Revisions.php
+++ b/inc/Ui/Revisions.php
@@ -193,6 +193,7 @@ class Revisions extends Ui
      * @param int  $first
      * @param bool $hasNext
      * @return array  revisions to be shown in a pagenated list
+     * @see also https://www.dokuwiki.org/devel:changelog
      */
     protected function getRevisions(&$first, &$hasNext)
     {
@@ -220,7 +221,18 @@ class Revisions extends Ui
             // add current page or media as revision[0]
             if ($this->media_id) {
                 $rev = filemtime(fullpath(mediaFN($this->media_id)));
-                $revisions[] = $changelog->getRevisionInfo($rev) + array(
+                $changelog->setChunkSize(1024);
+                $revinfo = $changelog->getRevisionInfo($rev) ?: array(
+                        'date' => $rev,
+                        'ip'   => null,
+                        'type' => null,
+                        'id'   => $this->media_id,
+                        'user' => null,
+                        'sum'  => null,
+                        'extra' => null,
+                        'sizechange' => null,
+                );
+                $revisions[] = $revinfo + array(
                         'media' => true,
                         'current' => true,
                 );


### PR DESCRIPTION
MediaChangelog::getRevision() may return false when media changes meta file is missing, cause PHP error unsupported operand types. This bug had introduced at 67ef3e885af3e80db036d3f3e271cbe3d529dcaa.
close #3339