### PR TITLE
Fix loading order of extra defaults settings in the Configuration Manager

### DIFF
--- a/_test/conf/local.php
+++ b/_test/conf/local.php
@@ -9,3 +9,5 @@ $conf['superuser']   = 'testuser';        //password: testpass
 
 $conf['dnslookups']  = 0;                 //speedup tests
 $conf['updatecheck']  = 0;                //speedup tests
+
+$conf['plugin']['testing']['second'] = 'Local setting';

--- a/_test/tests/conf/CascadeExtraDefaultsTest.php
+++ b/_test/tests/conf/CascadeExtraDefaultsTest.php
@@ -1,10 +1,11 @@
 <?php
 
-class CascadeExtraDefaultsTest extends DokuWikiTest {
+class CascadeExtraDefaultsTest extends DokuWikiTest
+{
 
     protected $oldSetting = [];
 
-    public function setUp() : void
+    public function setUp(): void
     {
         global $config_cascade;
 
@@ -43,7 +44,7 @@ class CascadeExtraDefaultsTest extends DokuWikiTest {
         $this->assertEquals('Local setting', $testing->getConf('second'), 'local value still overrides default');
     }
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
         global $config_cascade;
 

--- a/_test/tests/conf/CascadeExtraDefaultsTest.php
+++ b/_test/tests/conf/CascadeExtraDefaultsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+class CascadeExtraDefaultsTest extends DokuWikiTest {
+
+    protected $oldSetting = [];
+
+    public function setUp() : void
+    {
+        global $config_cascade;
+
+        $this->pluginsEnabled = [
+            'testing'
+        ];
+
+        $out = "<?php\n/*\n * protected settings, cannot modified in the Config manager\n" .
+            " * Some test data */\n";
+        $out .= "\$conf['title'] = 'New default Title';\n";
+        $out .= "\$conf['tagline'] = 'New default Tagline';\n";
+        $out .= "\$conf['plugin']['testing']['schnibble'] = 1;\n";
+        $out .= "\$conf['plugin']['testing']['second'] = 'New default setting';\n";
+
+        $file = DOKU_CONF . 'otherdefaults.php';
+        file_put_contents($file, $out);
+
+        //store original settings
+        $this->oldSetting = $config_cascade['main']['default'];
+        //add second file with defaults, which override the defaults of DokuWiki
+        $config_cascade['main']['default'][] = $file;
+
+        parent::setUp();
+    }
+
+    public function testNewDefaults()
+    {
+        global $conf;
+
+        $this->assertEquals('New default Tagline', $conf['tagline'], 'new default value');
+        $testing = plugin_load('action', 'testing');
+        $this->assertEquals(1, $testing->getConf('schnibble'), 'new default value');
+
+
+        $this->assertEquals('My Test Wiki', $conf['title'], 'local value still overrides default');
+        $this->assertEquals('Local setting', $testing->getConf('second'), 'local value still overrides default');
+    }
+
+    public function tearDown() : void
+    {
+        global $config_cascade;
+
+        $config_cascade['main']['default'] = $this->oldSetting;
+        unlink(DOKU_CONF . 'otherdefaults.php');
+
+        parent::tearDown();
+    }
+}

--- a/_test/tests/conf/CascadeNormalTest.php
+++ b/_test/tests/conf/CascadeNormalTest.php
@@ -1,0 +1,34 @@
+<?php
+
+class CascadeNormalTest extends DokuWikiTest {
+
+    public function setUp() : void {
+        $this->pluginsEnabled = [
+            'testing'
+        ];
+
+        parent::setUp();
+    }
+
+    public function testDefaults()
+    {
+        global $conf;
+
+        $this->assertEquals('start', $conf['start'], 'default value');
+        $this->assertEquals('', $conf['tagline'], 'default value');
+
+        $this->assertFalse(isset($conf['plugin']['testing']['schnibble']), 'not set before plugin call');
+
+        $testing = plugin_load('action', 'testing');
+        $this->assertEquals(0, $testing->getConf('schnibble'), 'default value');
+    }
+
+    public function testLocal() {
+        global $conf;
+
+        $this->assertEquals('My Test Wiki', $conf['title'], 'overriden in local.php (values from Config manager)');
+
+        $testing = plugin_load('action', 'testing');
+        $this->assertEquals('Local setting', $testing->getConf('second'), 'overriden in local.php');
+    }
+}

--- a/_test/tests/conf/CascadeNormalTest.php
+++ b/_test/tests/conf/CascadeNormalTest.php
@@ -1,8 +1,10 @@
 <?php
 
-class CascadeNormalTest extends DokuWikiTest {
+class CascadeNormalTest extends DokuWikiTest
+{
 
-    public function setUp() : void {
+    public function setUp(): void
+    {
         $this->pluginsEnabled = [
             'testing'
         ];
@@ -23,7 +25,8 @@ class CascadeNormalTest extends DokuWikiTest {
         $this->assertEquals(0, $testing->getConf('schnibble'), 'default value');
     }
 
-    public function testLocal() {
+    public function testLocal()
+    {
         global $conf;
 
         $this->assertEquals('My Test Wiki', $conf['title'], 'overriden in local.php (values from Config manager)');

--- a/_test/tests/conf/CascadeProtectedTest.php
+++ b/_test/tests/conf/CascadeProtectedTest.php
@@ -1,8 +1,10 @@
 <?php
 
-class CascadeProtectedTest extends DokuWikiTest {
+class CascadeProtectedTest extends DokuWikiTest
+{
 
-    public function setUp() : void {
+    public function setUp(): void
+    {
         global $config_cascade;
 
         $this->pluginsEnabled = [
@@ -21,7 +23,8 @@ class CascadeProtectedTest extends DokuWikiTest {
         parent::setUp();
     }
 
-    public function testDefaults() {
+    public function testDefaults()
+    {
         global $conf;
 
         $this->assertEquals('Protected Title', $conf['title'], 'protected local value, overrides local');
@@ -32,7 +35,7 @@ class CascadeProtectedTest extends DokuWikiTest {
         $this->assertEquals('Protected setting', $testing->getConf('second'), 'protected local value');
     }
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
         global $config_cascade;
 

--- a/_test/tests/conf/CascadeProtectedTest.php
+++ b/_test/tests/conf/CascadeProtectedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class CascadeProtectedTest extends DokuWikiTest {
+
+    public function setUp() : void {
+        global $config_cascade;
+
+        $this->pluginsEnabled = [
+            'testing'
+        ];
+
+        $out = "<?php\n/*\n * protected settings, cannot modified in the Config manager\n" .
+            " * Some test data */\n";
+        $out .= "\$conf['title'] = 'Protected Title';\n";
+        $out .= "\$conf['tagline'] = 'Protected Tagline';\n";
+        $out .= "\$conf['plugin']['testing']['schnibble'] = 1;\n";
+        $out .= "\$conf['plugin']['testing']['second'] = 'Protected setting';\n";
+
+        file_put_contents(end($config_cascade['main']['protected']), $out);
+
+        parent::setUp();
+    }
+
+    public function testDefaults() {
+        global $conf;
+
+        $this->assertEquals('Protected Title', $conf['title'], 'protected local value, overrides local');
+        $this->assertEquals('Protected Tagline', $conf['tagline'], 'protected local value, override default');
+
+        $testing = plugin_load('action', 'testing');
+        $this->assertEquals(1, $testing->getConf('schnibble'), 'protected local value, ');
+        $this->assertEquals('Protected setting', $testing->getConf('second'), 'protected local value');
+    }
+
+    public function tearDown() : void
+    {
+        global $config_cascade;
+
+        unlink(end($config_cascade['main']['protected']));
+
+        parent::tearDown();
+    }
+}

--- a/lib/plugins/config/_test/LoaderExtraDefaultsTest.php
+++ b/lib/plugins/config/_test/LoaderExtraDefaultsTest.php
@@ -11,13 +11,14 @@ use dokuwiki\plugin\config\core\Loader;
  * @group plugins
  * @group bundled_plugins
  */
-class LoaderExtraDefaultsTest extends \DokuWikiTest {
+class LoaderExtraDefaultsTest extends \DokuWikiTest
+{
 
     protected $pluginsEnabled = ['testing'];
 
     protected $oldSetting = [];
 
-    public function setUp() : void
+    public function setUp(): void
     {
         global $config_cascade;
 
@@ -38,11 +39,13 @@ class LoaderExtraDefaultsTest extends \DokuWikiTest {
 
         parent::setUp();
     }
+
     /**
      * Ensure loading the defaults work, and that the extra default for plugins provided via an extra main default file
      * override the plugin defaults as well
      */
-    public function testDefaultsOverwriting() {
+    public function testDefaultsOverwriting()
+    {
         $loader = new Loader(new ConfigParser());
 
         $conf = $loader->loadDefaults();
@@ -60,7 +63,7 @@ class LoaderExtraDefaultsTest extends \DokuWikiTest {
 
     }
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
         global $config_cascade;
 

--- a/lib/plugins/config/_test/LoaderExtraDefaultsTest.php
+++ b/lib/plugins/config/_test/LoaderExtraDefaultsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace dokuwiki\plugin\config\test;
+
+use dokuwiki\plugin\config\core\ConfigParser;
+use dokuwiki\plugin\config\core\Loader;
+
+/**
+ * @group plugin_config
+ * @group admin_plugins
+ * @group plugins
+ * @group bundled_plugins
+ */
+class LoaderExtraDefaultsTest extends \DokuWikiTest {
+
+    protected $pluginsEnabled = ['testing'];
+
+    protected $oldSetting = [];
+
+    public function setUp() : void
+    {
+        global $config_cascade;
+
+        $out = "<?php\n/*\n * protected settings, cannot modified in the Config manager\n" .
+            " * Some test data */\n";
+        $out .= "\$conf['title'] = 'New default Title';\n";
+        $out .= "\$conf['tagline'] = 'New default Tagline';\n";
+        $out .= "\$conf['plugin']['testing']['schnibble'] = 1;\n";
+        $out .= "\$conf['plugin']['testing']['second'] = 'New default setting';\n";
+
+        $file = DOKU_CONF . 'otherdefaults.php';
+        file_put_contents($file, $out);
+
+        //store original settings
+        $this->oldSetting = $config_cascade['main']['default'];
+        //add second file with defaults, which override the defaults of DokuWiki
+        $config_cascade['main']['default'][] = $file;
+
+        parent::setUp();
+    }
+    /**
+     * Ensure loading the defaults work, and that the extra default for plugins provided via an extra main default file
+     * override the plugin defaults as well
+     */
+    public function testDefaultsOverwriting() {
+        $loader = new Loader(new ConfigParser());
+
+        $conf = $loader->loadDefaults();
+        $this->assertTrue(is_array($conf));
+
+        // basic defaults
+        $this->assertArrayHasKey('title', $conf);
+        $this->assertEquals('New default Title', $conf['title']);
+        $this->assertEquals('New default Tagline', $conf['tagline']);
+
+        // plugin defaults
+        $this->assertArrayHasKey('plugin____testing____schnibble', $conf);
+        $this->assertEquals(1, $conf['plugin____testing____schnibble']);
+        $this->assertEquals('New default setting', $conf['plugin____testing____second']);
+
+    }
+
+    public function tearDown() : void
+    {
+        global $config_cascade;
+
+        $config_cascade['main']['default'] = $this->oldSetting;
+        unlink(DOKU_CONF . 'otherdefaults.php');
+
+        parent::tearDown();
+    }
+
+}

--- a/lib/plugins/config/_test/LoaderTest.php
+++ b/lib/plugins/config/_test/LoaderTest.php
@@ -53,6 +53,7 @@ class LoaderTest extends \DokuWikiTest {
         // plugin defaults
         $this->assertArrayHasKey('plugin____testing____schnibble', $conf);
         $this->assertEquals(0, $conf['plugin____testing____schnibble']);
+        $this->assertEquals('Default value', $conf['plugin____testing____second']);
     }
 
     /**

--- a/lib/plugins/config/core/Loader.php
+++ b/lib/plugins/config/core/Loader.php
@@ -77,13 +77,14 @@ class Loader {
      *
      * @return array
      */
-    public function loadDefaults() {
+    public function loadDefaults()
+    {
 
         // initialize array
         $conf = array();
 
         // plugins
-        foreach($this->plugins as $plugin) {
+        foreach ($this->plugins as $plugin) {
             $conf = array_merge(
                 $conf,
                 $this->loadExtensionConf(
@@ -103,15 +104,13 @@ class Loader {
                 $this->template
             )
         );
-		
-		// load main files
-		global $config_cascade;
-		$conf = array_merge(
-			$conf,
-			$this->loadConfigs($config_cascade['main']['default'])
-		);
-        
-        return $conf;
+
+        // load main files
+        global $config_cascade;
+        return array_merge(
+            $conf,
+            $this->loadConfigs($config_cascade['main']['default'])
+        );
     }
 
     /**

--- a/lib/plugins/config/core/Loader.php
+++ b/lib/plugins/config/core/Loader.php
@@ -78,6 +78,10 @@ class Loader {
      * @return array
      */
     public function loadDefaults() {
+
+        // initialize array
+        $conf = array();
+
         // plugins
         foreach($this->plugins as $plugin) {
             $conf = array_merge(
@@ -99,10 +103,13 @@ class Loader {
                 $this->template
             )
         );
-
-        // load main files
-        global $config_cascade;
-        $conf = $this->loadConfigs($config_cascade['main']['default']);
+		
+		// load main files
+		global $config_cascade;
+		$conf = array_merge(
+			$conf,
+			$this->loadConfigs($config_cascade['main']['default'])
+		);
         
         return $conf;
     }

--- a/lib/plugins/config/core/Loader.php
+++ b/lib/plugins/config/core/Loader.php
@@ -78,10 +78,6 @@ class Loader {
      * @return array
      */
     public function loadDefaults() {
-        // load main files
-        global $config_cascade;
-        $conf = $this->loadConfigs($config_cascade['main']['default']);
-
         // plugins
         foreach($this->plugins as $plugin) {
             $conf = array_merge(
@@ -104,6 +100,10 @@ class Loader {
             )
         );
 
+        // load main files
+        global $config_cascade;
+        $conf = $this->loadConfigs($config_cascade['main']['default']);
+        
         return $conf;
     }
 

--- a/lib/plugins/testing/conf/default.php
+++ b/lib/plugins/testing/conf/default.php
@@ -5,3 +5,5 @@
  * They don't do anything and are just there for testing config reading
  */
 $conf['schnibble'] = 0;
+$conf['second'] = 'Default value';
+

--- a/lib/plugins/testing/conf/metadata.php
+++ b/lib/plugins/testing/conf/metadata.php
@@ -5,3 +5,4 @@
  * They don't do anything and are just there for testing config reading
  */
 $meta['schnibble'] = array('onoff');
+$meta['second'] = array('string');


### PR DESCRIPTION
The config options are read in the order plugin-standard-values -> template-standard-values -> dokuwiki.php -> local.php -> local.protected.php into DokuWiki.
But when entering the configuration manger, they options are displayed in the order dokuwiki.php -> plugin-standard-values -> template-standard-values -> local.php -> local.protected.php

This patch fixes the issue, so that the right values are displayed if there are no configs set in local.php or local.protected.php

See also https://forum.dokuwiki.org/d/18489-issues-with-modifying-confdokuwikiphp for further information.

This is a second version of this change, because on the first try, there was unnoticed php-error.