### PR TITLE
lazy load images

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1747,6 +1747,7 @@ function media_printimgdetail($item, $fullscreen=false){
         $p['height'] = $h;
     }
     $p['alt']    = $item['id'];
+    $p['loading'] = 'lazy';
     $att = buildAttributes($p);
 
     // output

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1657,6 +1657,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
                     )
                 ) . '"';
             $ret .= ' class="media'.$align.'"';
+            $ret .= ' loading="lazy"';
 
             if($title) {
                 $ret .= ' title="'.$title.'"';


### PR DESCRIPTION
This adds the loading="lazy" attribute to embedded images and the thumbnails in the media manager. This instructs modern broswers to load images on demand when they come into view. It can reduce used bandwith and improve perceived speed.