### PR TITLE
do not repeat successful security checks. fixes #3363

### DIFF
--- a/inc/Ui/Admin.php
+++ b/inc/Ui/Admin.php
@@ -28,9 +28,10 @@ class Admin extends Ui {
         $this->menu = $this->getPluginList();
         echo '<div class="ui-admin">';
         echo p_locale_xhtml('admin');
-        $this->showSecurityCheck();
+
         $this->showMenu('admin');
         $this->showMenu('manager');
+        $this->showSecurityCheck();
         $this->showVersion();
         $this->showMenu('other');
         echo '</div>';
@@ -75,16 +76,16 @@ class Admin extends Ui {
      * it verifies either:
      *   'savedir' has been moved elsewhere, or
      *   has protection to prevent the webserver serving files from it
+     *
+     * The actual check is carried out via JavaScript. See behaviour.js
      */
     protected function showSecurityCheck() {
         global $conf;
         if(substr($conf['savedir'], 0, 2) !== './') return;
         $img = DOKU_URL . $conf['savedir'] .
             '/dont-panic-if-you-see-this-in-your-logs-it-means-your-directory-permissions-are-correct.png';
-        echo '<a style="border:none; float:right;"
-                href="http://www.dokuwiki.org/security#web_access_security">
-                <img src="' . $img . '" alt="Your data directory seems to be protected properly."
-                onerror="this.parentNode.style.display=\'none\'" /></a>';
+        echo '<a style="border:none; float:right;" id="security__check"
+                href="http://www.dokuwiki.org/security#web_access_security" data-src="' . $img . '">⚠</a>';
     }
 
     /**

--- a/inc/Ui/Admin.php
+++ b/inc/Ui/Admin.php
@@ -84,8 +84,7 @@ class Admin extends Ui {
         if(substr($conf['savedir'], 0, 2) !== './') return;
         $img = DOKU_URL . $conf['savedir'] .
             '/dont-panic-if-you-see-this-in-your-logs-it-means-your-directory-permissions-are-correct.png';
-        echo '<a style="border:none; float:right;" id="security__check"
-                href="http://www.dokuwiki.org/security#web_access_security" data-src="' . $img . '">⚠</a>';
+        echo '<div id="security__check" data-src="' . $img . '"></div>';
     }
 
     /**

--- a/inc/lang/en/lang.php
+++ b/inc/lang/en/lang.php
@@ -171,6 +171,7 @@ $lang['js']['media_done_btn']      = 'Done';
 $lang['js']['media_drop']          = 'Drop files here to upload';
 $lang['js']['media_cancel']        = 'remove';
 $lang['js']['media_overwrt']       = 'Overwrite existing files';
+$lang['js']['data_insecure'] = 'WARNING: It seems your data directory is not properly secured. Please read about <a href="https://www.dokuwiki.org/security#web_access_security">Web Access Security in DokuWiki</a>.';
 
 $lang['rssfailed']             = 'An error occurred while fetching this feed: ';
 $lang['nothingfound']          = 'Nothing was found.';

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -215,25 +215,26 @@ var dw_behaviour = {
      * avoids overeager security bans (see #3363)
      */
     securityCheck: function () {
-        var $checkA = jQuery('#security__check');
-        if (!$checkA.length) return;
-        if (sessionStorage.getItem('security-check')) {
+        var $checkDiv = jQuery('#security__check');
+        if (!$checkDiv.length) return;
+        if (sessionStorage.getItem('dw-security-check:' + DOKU_BASE)) {
             // check was already executed successfully
-            $checkA.remove();
+            $checkDiv.remove();
             return;
         }
 
-        var img = new Image(347, 63);
+        var img = new Image();
         img.onerror = function () {
             // successful check will not be repeated during session
-            $checkA.remove();
-            sessionStorage.setItem('security-check', true);
+            $checkDiv.remove();
+            sessionStorage.setItem('dw-security-check:' + DOKU_BASE, true);
         }
         img.onload = function () {
-            // check failed, display the image
-            $checkA.html(img);
+            // check failed, display a warning message
+            $checkDiv.html(LANG.data_insecure);
+            $checkDiv.addClass('error');
         }
-        img.src = $checkA.data('src');
+        img.src = $checkDiv.data('src');
     }
 };
 

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -234,7 +234,7 @@ var dw_behaviour = {
             $checkDiv.html(LANG.data_insecure);
             $checkDiv.addClass('error');
         }
-        img.src = $checkDiv.data('src');
+        img.src = $checkDiv.data('src') + '?t=' + Date.now();
     }
 };
 

--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -56,6 +56,7 @@ var dw_behaviour = {
         dw_behaviour.checkWindowsShares();
         dw_behaviour.subscription();
         dw_behaviour.pageRestoreConfirm();
+        dw_behaviour.securityCheck();
 
         dw_behaviour.revisionBoxHandler();
         jQuery(document).on('click','#page__revisions input[type=checkbox]',
@@ -204,6 +205,35 @@ var dw_behaviour = {
                 }
             });
         }
+    },
+
+    /**
+     * Check that access to the data directory is properly secured
+     *
+     * A successful check (a 403 error was returned when loading the image) is saved
+     * to session storage and not repeated again until the next browser session. This
+     * avoids overeager security bans (see #3363)
+     */
+    securityCheck: function () {
+        var $checkA = jQuery('#security__check');
+        if (!$checkA.length) return;
+        if (sessionStorage.getItem('security-check')) {
+            // check was already executed successfully
+            $checkA.remove();
+            return;
+        }
+
+        var img = new Image(347, 63);
+        img.onerror = function () {
+            // successful check will not be repeated during session
+            $checkA.remove();
+            sessionStorage.setItem('security-check', true);
+        }
+        img.onload = function () {
+            // check failed, display the image
+            $checkA.html(img);
+        }
+        img.src = $checkA.data('src');
     }
 };
 

--- a/lib/tpl/dokuwiki/css/_admin.less
+++ b/lib/tpl/dokuwiki/css/_admin.less
@@ -61,4 +61,13 @@
         clear: right;
         float: left;
     }
+
+    /* data directory security check */
+    #security__check {
+        float: right;
+        max-width: 20em;
+    }
+    [dir=rtl] & #admin__version {
+        float: left;
+    }
 }


### PR DESCRIPTION
This avoids creating lots of 403 errors for properly secured data directories. Only one successful check per browser session will be executed.