### PR TITLE
another try to fix when github actions run

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -1,15 +1,12 @@
 name: PHP Code Style
 
-on:
-    push:
-    pull_request:
-        branches:
-        - '**:**'
+on: [push, pull_request]
 
 jobs:
     phpcs:
         name: PHP CodeSniffer
         runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/testLinux.yml
+++ b/.github/workflows/testLinux.yml
@@ -1,15 +1,12 @@
 name: Linux Unit Tests
 
-on:
-    push:
-    pull_request:
-        branches:
-            - '**:**'
+on: [push, pull_request]
 
 jobs:
     run:
         name: PHP ${{ matrix.php-versions }}
         runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
         strategy:
             matrix:

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -1,15 +1,12 @@
 name: Windows Unit Tests
 
-on:
-    push:
-    pull_request:
-        branches:
-            - '**:**'
+on: [push, pull_request]
 
 jobs:
     run:
         name: PHP ${{ matrix.php-versions }}
         runs-on: windows-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
         strategy:
             matrix:


### PR DESCRIPTION
The attempt in 7bbf38eeb4aaf5ac1c3b4a2cea4cc0b371890f4a to not run checks twice for our own internal pull requests seem not to have worked, because checks in external PRs were no longer executed.

This is another approach to achieve the same based on code found at https://github.com/Dart-Code/Dart-Code/blob/764f121f9abe5f4496528d35277946d4130af93d/.github/workflows/build-and-test.yml#L10-L12