### PR TITLE
Fix double border on `abbr` elements in Chrome

### DIFF
--- a/lib/tpl/dokuwiki/css/basic.less
+++ b/lib/tpl/dokuwiki/css/basic.less
@@ -248,6 +248,7 @@ acronym,
 abbr {
     cursor: help;
     border-bottom: 1px dotted;
+    text-decoration: none;
     font-style: normal;
 }
 em acronym,


### PR DESCRIPTION
DokuWiki styles `abbr` elements with a dotted bottom border.
In 2017 Chrome added the browser default `text-decoration: underline dotted`.
That leads to two different underlines/borders showing.
This overwrites the Chrome default so that only one line is showing.

Before:
![](https://user-images.githubusercontent.com/108893/104812801-a4038000-57fc-11eb-9172-5ed0643d37a3.png)

After:
![](https://user-images.githubusercontent.com/108893/104812800-a36ae980-57fc-11eb-8990-74f110ce2570.png)

