### PR TITLE
dwpage.php: add an option to get metadata

### DIFF
--- a/bin/dwpage.php
+++ b/bin/dwpage.php
@@ -118,6 +118,28 @@ class PageCLI extends CLI {
             true,
             'unlock'
         );
+
+        /* gmeta command */
+        $options->registerCommand(
+            'gmeta',
+            'Prints metadata value for a page to stdout.'
+        );
+        $options->registerArgument(
+            'wikipage',
+            'The wiki page to get the metadata for',
+            true,
+            'gmeta'
+        );
+        $options->registerArgument(
+            'key',
+            'The name of the metadata item to be retrieved.' . "\n" .
+            'If empty, an array of all the metadata items is returned.' ."\n" .
+            'For retrieving items that are stored in sub-arrays, separate the ' .
+            'keys of the different levels by spaces, in quotes, eg "date modified".',
+            false,
+            'gmeta'
+        );
+
     }
 
     /**
@@ -159,6 +181,14 @@ class PageCLI extends CLI {
                 $wiki_id = array_shift($args);
                 $this->clearLock($wiki_id);
                 $this->success("$wiki_id unlocked");
+                break;
+            case 'gmeta':
+                $wiki_id = array_shift($args);
+                $key = trim(array_shift($args));
+                $meta=print_r(p_get_metadata($wiki_id, $key), true);
+                print($meta);
+                if (strcmp(substr($meta, -1), "\n"))
+                    print("\n");
                 break;
             default:
                 echo $options->help();


### PR DESCRIPTION
This adds an option to ./bin/dwpage.php, to display metadata about a
page. This is useful in maintenance shell scripts, and debugging plugins.
There is no ability to write metadata, only read them.

`./bin/dwpage.php -u <user> gmeta [page] <meta tag>`

where `<meta tag>` can be "date modified" (in quotes) or "last_change date"
an empty `<meta tag>` returns all metadata.

Signed-off-by: Robin Getz <robin.getz@analog.com>

Once (assuming) merged, need to update https://www.dokuwiki.org/cli