### PR TITLE
fix: better max-width for images in tables

### DIFF
--- a/lib/tpl/dokuwiki/css/basic.less
+++ b/lib/tpl/dokuwiki/css/basic.less
@@ -234,6 +234,9 @@ audio {
 button img {
     max-width: none;
 }
+table img {
+    max-width: 50vw;
+}
 
 hr {
     border-top: solid @ini_border;


### PR DESCRIPTION
Tables are very aggressive with how they size the contents of their cells. That leads to sometimes tiny images with max-width:100%, especially for images that already have a small intrinsic size.

Setting the `max-width` to `50vw`, i.e. half the view-port, is chosen as a trade-off between:
* letting small images keep their full size in most view-ports
* keeping large images still pretty large on large view-ports
* prevent scrolling in most circumstances (scrolling a table is really
  bad user experience, this is the goal of the browser)

Fixes #2059