### PR TITLE
Fixes for HTML export mode

### DIFF
--- a/lib/tpl/dokuwiki/css/content.less
+++ b/lib/tpl/dokuwiki/css/content.less
@@ -297,6 +297,16 @@
     border-right: 1px solid @ini_border;
 }
 
+.dokuwiki.export #dw__toc {
+    margin-top: 0;
+    margin-right: 0;
+}
+
+[dir=rtl] .dokuwiki.export #dw__toc {
+    margin-top: 0;
+    margin-left: 0;
+}
+
 .dokuwiki h3.toggle {
     padding: .5em 1em;
     margin-bottom: 0;

--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -7,6 +7,10 @@
  * @author Clarence Lee <clarencedglee@gmail.com>
  */
 
+.dokuwiki.export {
+    background-color: @ini_background;
+}
+
 /* header
 ********************************************************************/
 


### PR DESCRIPTION
When using the `export_html` mode (page without surrounding layout) the page's background colour is grey with a gradient.
That is the same background that the page with layout has but different to the background the text is on.
What you would want is the same colour the text is on, which is white.

This also fixes the TOC being cut off in that mode.

I was contemplating adding a bit of spacing. But I'm not sure how people actually use the export mode. If they display exported pages within a different layout, they will have control over the spacing around it, so adding spacing within DokuWiki will not be necessary.
When looking at an exported page on its own, it sure looks much better with a some `padding: 1em;`. But I don't know if people use it that way at all.

Before:
![](https://user-images.githubusercontent.com/108893/106275948-a61f0300-622e-11eb-8f51-7367607a9e48.png)

After:
![](https://user-images.githubusercontent.com/108893/106275969-ad461100-622e-11eb-87d7-6da82cd00022.png)
