### PR TITLE
Make it easier to remove h1 around logo

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -26,10 +26,11 @@
         margin-top: .2em;
     }
 
-    h1 {
+    .logo {
         margin: 0;
         font-size: 1.5em;
         font-weight: normal;
+        line-height: 1.2;
 
         img {
             float: left;
@@ -60,7 +61,7 @@
     }
 }
 
-[dir=rtl] #dokuwiki__header h1 img {
+[dir=rtl] #dokuwiki__header .logo img {
     float: right;
     margin-left: .5em;
     margin-right: 0;

--- a/lib/tpl/dokuwiki/css/print.css
+++ b/lib/tpl/dokuwiki/css/print.css
@@ -141,18 +141,19 @@ th {
 #dokuwiki__header {
     border-bottom: 2pt solid #ccc;
 }
-#dokuwiki__header h1 {
+#dokuwiki__header .logo {
     font-size: 1.5em;
+    font-weight: bold;
 }
-#dokuwiki__header h1 a {
+#dokuwiki__header .logo a {
     text-decoration: none;
     border-width: 0;
 }
-#dokuwiki__header h1 img {
+#dokuwiki__header .logo img {
     float: left;
     margin-right: .5em;
 }
-[dir=rtl] #dokuwiki__header h1 img {
+[dir=rtl] #dokuwiki__header .logo img {
     float: right;
     margin-right: 0;
     margin-left: .5em;

--- a/lib/tpl/dokuwiki/tpl_header.php
+++ b/lib/tpl/dokuwiki/tpl_header.php
@@ -17,7 +17,7 @@ if (!defined('DOKU_INC')) die();
             <li><a href="#dokuwiki__content"><?php echo $lang['skip_to_content']; ?></a></li>
         </ul>
 
-        <h1><?php
+        <h1 class="logo"><?php
             // get logo either out of the template images folder or data/media folder
             $logoSize = array();
             $logo = tpl_getMediaFile(array(':wiki:logo.png', ':logo.png', 'images/logo.png'), false, $logoSize);


### PR DESCRIPTION
This adds a class to the h1 around the logo and changes the CSS to reference that class instead of the h1. That way it's easier to change the h1 to a div if someone prefers to have not more than one h1 per page.
Nothing changes visually. The h1 is also still in place.