### PR TITLE
fix remaining failing tests for PHP 8

### DIFF
--- a/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
+++ b/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
@@ -9,7 +9,12 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest
     // the original plugin controller
     private $plugin_controller;
 
-    // the actual test
+    /**
+     * the actual test
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_p_set_metadata_during_rendering()
     {
         global $EVENT_HANDLER;

--- a/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
+++ b/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
@@ -77,7 +77,7 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest
     public function helper_inject_test_instruction($event)
     {
         if ($this->active) {
-            $event->data->calls[] = ['plugin', ['parserutils_test', []]];
+            $event->data->calls[] = ['plugin', ['parserutils_test', []], -9000];
         }
     }
 

--- a/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
+++ b/_test/tests/inc/parserutils_set_metadata_during_rendering.test.php
@@ -1,6 +1,7 @@
 <?php
 
-class parserutils_set_metadata_during_rendering_test extends DokuWikiTest {
+class parserutils_set_metadata_during_rendering_test extends DokuWikiTest
+{
     // the id used for this test case
     private $id;
     // if the test case is currently running
@@ -9,16 +10,29 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest {
     private $plugin_controller;
 
     // the actual test
-    function test_p_set_metadata_during_rendering() {
+    public function test_p_set_metadata_during_rendering()
+    {
         global $EVENT_HANDLER;
         $this->id = 'test:p_set_metadata_during_rendering';
         $this->active = true;
 
         // write the wiki page so it exists and needs to be rendered
-        saveWikiText($this->id, 'Test '.time(), 'Test data setup');
+        saveWikiText($this->id, 'Test ' . time(), 'Test data setup');
 
-        $EVENT_HANDLER->register_hook('PARSER_METADATA_RENDER', 'BEFORE', $this, 'helper_set_metadata', array('test_before_set' => 'test'));
-        $EVENT_HANDLER->register_hook('PARSER_METADATA_RENDER', 'AFTER', $this, 'helper_set_metadata', array('test_after_set' => 'test'));
+        $EVENT_HANDLER->register_hook(
+            'PARSER_METADATA_RENDER',
+            'BEFORE',
+            $this,
+            'helper_set_metadata',
+            ['test_before_set' => 'test']
+        );
+        $EVENT_HANDLER->register_hook(
+            'PARSER_METADATA_RENDER',
+            'AFTER',
+            $this,
+            'helper_set_metadata',
+            ['test_after_set' => 'test']
+        );
         $EVENT_HANDLER->register_hook('PARSER_HANDLER_DONE', 'BEFORE', $this, 'helper_inject_test_instruction');
 
         // Change the global plugin controller so this test can be a fake syntax plugin
@@ -33,9 +47,9 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest {
         $plugin_controller = $this->plugin_controller;
 
         // assert that all three calls to p_set_metadata have been successful
-        $this->assertEquals($newMeta['test_before_set'], 'test');
-        $this->assertEquals($newMeta['test_after_set'], 'test');
-        $this->assertEquals($newMeta['test_during_rendering'], 'test');
+        $this->assertEquals($newMeta[ 'test_before_set' ], 'test');
+        $this->assertEquals($newMeta[ 'test_after_set' ], 'test');
+        $this->assertEquals($newMeta[ 'test_during_rendering' ], 'test');
 
         // clean up
         $this->active = false;
@@ -47,40 +61,46 @@ class parserutils_set_metadata_during_rendering_test extends DokuWikiTest {
     }
 
     // helper for the action plugin part of the test, tries executing p_set_metadata during rendering
-    function helper_set_metadata($event, $meta) {
+    public function helper_set_metadata($event, $meta)
+    {
         if ($this->active) {
             p_set_metadata($this->id, $meta, false, true);
             $keys = array_keys($meta);
             $key = array_pop($keys);
-            $this->assertTrue(is_string($meta[$key])); // ensure we really have a key
+            $this->assertTrue(is_string($meta[ $key ])); // ensure we really have a key
             // ensure that the metadata property hasn't been set previously
-            $this->assertNotEquals($meta[$key], p_get_metadata($this->id, $key));
+            $this->assertNotEquals($meta[ $key ], p_get_metadata($this->id, $key));
         }
     }
 
     // helper for injecting an instruction for this test case
-    function helper_inject_test_instruction($event) {
-        if ($this->active)
-            $event->data->calls[] = array('plugin', array('parserutils_test', array()));
+    public function helper_inject_test_instruction($event)
+    {
+        if ($this->active) {
+            $event->data->calls[] = ['plugin', ['parserutils_test', []]];
+        }
     }
 
     // fake syntax plugin rendering method that tries calling p_set_metadata during the actual rendering process
-    function render($format, &$renderer, $data) {
+    public function render($format, &$renderer, $data)
+    {
         if ($this->active) {
             $key = 'test_during_rendering';
-            p_set_metadata($this->id, array($key => 'test'), false, true);
+            p_set_metadata($this->id, [$key => 'test'], false, true);
             // ensure that the metadata property hasn't been set previously
             $this->assertNotEquals($key, p_get_metadata($this->id, $key));
         }
     }
 
     // wrapper function for the fake plugin controller
-    function getList($type='',$all=false){
+    public function getList($type = '', $all = false)
+    {
         return $this->plugin_controller->getList();
     }
 
     // wrapper function for the fake plugin controller, return $this for the fake syntax of this test
-    function load($type,$name,$new=false,$disabled=false){
+    public function load($type, $name, $new = false, $disabled = false)
+    {
         if ($name == 'parserutils_test') {
             return $this;
         } else {


### PR DESCRIPTION
This fixes the last two failing tests in #3404 

@splitbrain [wrote](https://github.com/splitbrain/dokuwiki/pull/3404#issuecomment-780158632):
> Only two issues remaining
> 
> > parserutils_set_metadata_during_rendering_test::test_p_set_metadata_during_rendering
> > Undefined array key 2
> 
> Here I'd say fixing the test to match "normal" instructions is the way to go
> 
> > remoteapicore_test::test_getBacklinks
> > Failed asserting that false is true.
> 
> Not sure why this one is failing, yet.

The failure of those two tests was actually connected. Fixing the error resolves the failure.

I recommend reviewing this PR commit-by-commit.