### PR TITLE
Added support for RTL text in an LTR blog

### DIFF
--- a/lib/tpl/dokuwiki/main.php
+++ b/lib/tpl/dokuwiki/main.php
@@ -51,7 +51,7 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 
                 <div class="pageId"><span><?php echo hsc($ID) ?></span></div>
 
-                <div class="page group">
+                <div class="page group" dir="auto">
                     <?php tpl_flush() ?>
                     <?php tpl_includeFile('pageheader.html') ?>
                     <!-- wikipage start -->


### PR DESCRIPTION
Self explanatory.

I am unsure where [details.php](https://github.com/splitbrain/dokuwiki/blob/master/lib/tpl/dokuwiki/detail.php#L44) is being used. But if it's used for the same format, we'll have to apply the same modification there too.