### PR TITLE
Support for Translation plugin functionality

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -126,6 +126,7 @@ function auth_loadACL() {
     global $USERINFO;
     /* @var Input $INPUT */
     global $INPUT;
+    global $conf;
 
     if(!is_readable($config_cascade['acl']['default'])) return array();
 
@@ -145,6 +146,15 @@ function auth_loadACL() {
             $id   = str_replace('%USER%',cleanID($INPUT->server->str('REMOTE_USER')),$id);
             $rest = str_replace('%USER%',auth_nameencode($INPUT->server->str('REMOTE_USER')),$rest);
         }
+
+        // support for Translation plugin functionality
+		if (
+            ( plugin_enable ( 'translation' ) == true )
+            &&
+            ( strstr ( $line, '%LANG%' ) )
+        ) {
+			$id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
+		}
 
         // substitute group wildcard (its 1:m)
         if(strstr($line, '%GROUP%')){

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -148,7 +148,7 @@ function auth_loadACL() {
         }
 
         // support for Translation plugin functionality
-		if ( ( plugin_enable ( 'translation' ) === true ) && ( strstr ( $line, '%LANG%' ) ) ) {
+        if ( ( plugin_enable ( 'translation' ) === true ) && ( strstr ( $line, '%LANG%' ) ) ) {
             $id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
         }
                                                                                               

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -148,7 +148,9 @@ function auth_loadACL() {
         }
 
         // support for Translation plugin functionality
-		if ( ( plugin_enable ( 'translation' ) === true ) && ( strstr ( $line, '%LANG%' ) ) ) $id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
+		if ( ( plugin_enable ( 'translation' ) === true ) && ( strstr ( $line, '%LANG%' ) ) ) {
+            $id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
+        }
                                                                                               
         // substitute group wildcard (its 1:m)
         if(strstr($line, '%GROUP%')){

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -148,14 +148,8 @@ function auth_loadACL() {
         }
 
         // support for Translation plugin functionality
-		if (
-            ( plugin_enable ( 'translation' ) == true )
-            &&
-            ( strstr ( $line, '%LANG%' ) )
-        ) {
-			$id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
-		}
-
+		if ( ( plugin_enable ( 'translation' ) === true ) && ( strstr ( $line, '%LANG%' ) ) ) $id = str_replace ( '%LANG%', $conf [ 'lang' ], $id );
+                                                                                              
         // substitute group wildcard (its 1:m)
         if(strstr($line, '%GROUP%')){
             // if user is not logged in, grps is empty, no output will be added (i.e. skipped)


### PR DESCRIPTION
This small fix to support the %LANG% variable (on a site with only 25 languages) reduced conf/acl.conf.php by 93.25% and raised the Google PageSpeed score from 80 to 98! This is more efficient than anything I've tried to improve in the last 8 years ≺(☉6☉)≻