### PR TITLE
Add missing `;` causing syntax error in js.php

### DIFF
--- a/lib/scripts/behaviour.js
+++ b/lib/scripts/behaviour.js
@@ -228,12 +228,12 @@ var dw_behaviour = {
             // successful check will not be repeated during session
             $checkDiv.remove();
             sessionStorage.setItem('dw-security-check:' + DOKU_BASE, true);
-        }
+        };
         img.onload = function () {
             // check failed, display a warning message
             $checkDiv.html(LANG.data_insecure);
             $checkDiv.addClass('error');
-        }
+        };
         img.src = $checkDiv.data('src') + '?t=' + Date.now();
     }
 };


### PR DESCRIPTION
Trying to edit a page on my dev box, I noticed that there were no toolbar buttons

![image](https://user-images.githubusercontent.com/449891/110203223-31626880-7e6d-11eb-9f00-5cc22953dd58.png)

Browser console shows
```
Uncaught SyntaxError: unexpected token: identifier js.php:1:89775
```

![image](https://user-images.githubusercontent.com/449891/110203276-928a3c00-7e6d-11eb-9863-6540fe4d9e3f.png)
