### PR TITLE
Exclude namespace in page look-ups

### DIFF
--- a/_test/tests/inc/FulltextPageLookupTest.php
+++ b/_test/tests/inc/FulltextPageLookupTest.php
@@ -1,0 +1,22 @@
+<?php
+
+// must be run within Dokuwiki
+if (!defined('DOKU_INC')) die();
+
+/**
+ * Test cases search only in a namespace or exclude a namespace
+ */
+class FulltextPageLookupTest extends DokuWikiTest {
+
+    public function test_inoutns() {
+        saveWikiText('test:page1', 'Some text', 'Test initialization');
+        idx_addPage('test:page1');
+        saveWikiText('ns:page2', 'Other text', 'Test initialization');
+        idx_addPage('ns:page2');
+
+        $this->assertEquals(['test:page1' => null, 'ns:page2' => null], ft_pageLookup('page'));
+        $this->assertEquals(['test:page1' => null], ft_pageLookup('page @test'));
+        $this->assertEquals(['ns:page2' => null], ft_pageLookup('page ^test'));
+    }
+
+}

--- a/inc/fulltext.php
+++ b/inc/fulltext.php
@@ -268,6 +268,10 @@ function _ft_pageLookup(&$data){
         $ns = cleanID($parsedQuery['ns'][0]) . ':';
         $id = implode(' ', $parsedQuery['highlight']);
     }
+    if (count($parsedQuery['notns']) > 0) {
+        $notns = cleanID($parsedQuery['notns'][0]) . ':';
+        $id = implode(' ', $parsedQuery['highlight']);
+    }
 
     $in_ns    = $data['in_ns'];
     $in_title = $data['in_title'];
@@ -295,6 +299,13 @@ function _ft_pageLookup(&$data){
     if (isset($ns)) {
         foreach (array_keys($pages) as $p_id) {
             if (strpos($p_id, $ns) !== 0) {
+                unset($pages[$p_id]);
+            }
+        }
+    }
+    if (isset($notns)) {
+        foreach (array_keys($pages) as $p_id) {
+            if (strpos($p_id, $notns) === 0) {
                 unset($pages[$p_id]);
             }
         }


### PR DESCRIPTION
Enables excluding namespaces in the quick search of the searchform
Supports quick search in https://github.com/Klap-in/dokuwiki-plugin-searchform/issues/7