### PR TITLE
index array with braces rather than unsupported curly braces

### DIFF
--- a/lib/plugins/authad/adLDAP/classes/adLDAPUsers.php
+++ b/lib/plugins/authad/adLDAP/classes/adLDAPUsers.php
@@ -519,7 +519,7 @@ class adLDAPUsers {
     {
         $password="\"".$password."\"";
         $encoded="";
-        for ($i=0; $i <strlen($password); $i++){ $encoded.="{$password{$i}}\000"; }
+        for ($i=0; $i <strlen($password); $i++){ $encoded.="{$password[$i]}\000"; }
         return $encoded;
     }
      


### PR DESCRIPTION
PHP 8 raises a fatal error when encountering curly brace indexing of arrays and strings. This patch uses brackets instead.