### PR TITLE
Avoid potential horizontal overflow in mobile view

### DIFF
--- a/lib/tpl/dokuwiki/css/design.less
+++ b/lib/tpl/dokuwiki/css/design.less
@@ -303,6 +303,7 @@ form.search {
 .dokuwiki .docInfo {
     font-size: 0.875em;
     text-align: right;
+    overflow-wrap: break-word;
 }
 
 /* license note under edit window */


### PR DESCRIPTION
Long page names cause overflow in this element, which makes the whole page scroll horizontally in mobile Safari. This rule prevents that from happening by wrapping long text.