### PR TITLE
BUG: Logoff do not work for plugin adfs: Redirect to "do_login": this…

### DIFF
--- a/inc/Action/Logout.php
+++ b/inc/Action/Logout.php
@@ -39,9 +39,8 @@ class Logout extends AbstractUserAction {
             unlock($ID);
         }
 
-        // do the logout stuff and redirect to login
+        // do the logout stuff
         auth_logoff();
-        send_redirect(wl($ID, array('do' => 'login'), true, '&'));
 
         // should never be reached
         throw new ActionException('login');


### PR DESCRIPTION
… is not what we want if we logout! This make a loop

As saml (plugin adfs) will automatically start a authentification process, if the url with "do_login" is asked, we are sent to SAML page and automatically authenticated and we are back in docuwiki "logged in"!
Without this redirect, we arrive in the  dokuwiki connexion page : 

>Connexion
>Vous n'êtes pas connecté ! Entrez vos identifiants ci-dessous pour vous connecter. Votre navigateur doit accepter les cookies pour pouvoir vous connecter.>
>
>Login here

This is not perfect (no place to enter our credential (2 input in plain auth), and "login here" is not a button, but a link that works), May be remove the text about the credential: so still much better. 

Test done: 
- If we click on "login here, we reconnect immediatly (as the adfs plugin logout from dokuwiki, but not from SAML): this is acceptable until SAML out (slo) is implemented. (it is not currently)
- Work also for plain auth.

Finally, the logout page is the same as the login page so there really not needed to make a redirect!