### PR TITLE
HTTPClient: Fix missing processing of redirections with status code 303, 307 and 308.

### DIFF
--- a/lib/plugins/extension/helper/extension.php
+++ b/lib/plugins/extension/helper/extension.php
@@ -112,7 +112,7 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
     public function isGitControlled()
     {
         if (!$this->isInstalled()) return false;
-        return is_dir($this->getInstallDir().'/.git');
+        return file_exists($this->getInstallDir().'/.git');
     }
 
     /**


### PR DESCRIPTION
HTTP/1.1 (RFC 7231) and RFC 7538 also define the redirection status codes 303, 307 and 308. These should be also supported as they are used more widely nowadays (e.g. Google Docs).