### PR TITLE
plugins/extension: Fix git recognition for plugin installations via git-submodules.

### DIFF
--- a/lib/plugins/extension/helper/extension.php
+++ b/lib/plugins/extension/helper/extension.php
@@ -112,7 +112,7 @@ class helper_plugin_extension_extension extends DokuWiki_Plugin
     public function isGitControlled()
     {
         if (!$this->isInstalled()) return false;
-        return is_dir($this->getInstallDir().'/.git');
+        return file_exists($this->getInstallDir().'/.git');
     }
 
     /**


### PR DESCRIPTION
New git versions only add .git file with a reference to the git dir in the superdirectory in the submodule. See git-submodule(1).