### PR TITLE
Allow installing extensions from URL via the CLI

### DIFF
--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -212,27 +212,46 @@ class cli_plugin_extension extends DokuWiki_CLI_Plugin
 
         $ok = 0;
         foreach ($extensions as $extname) {
-            $ext->setExtension($extname);
-
-            if (!$ext->getDownloadURL()) {
-                $ok += 1;
-                $this->error(
-                    sprintf('Could not find download for %s', $ext->getID())
-                );
-                continue;
-            }
-
-            try {
-                $installed = $ext->installOrUpdate();
-                foreach ($installed as $name => $info) {
-                    $this->success(sprintf(
-                            $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
-                            $info['base'])
-                    );
+            if (preg_match("/^https?:\/\//i", $extname)) {
+                try {
+                    $installed = $ext->installFromURL($extname, true);
+                    foreach ($installed as $name => $info) {
+                        $this->success(
+                            sprintf(
+                                $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
+                                $info['base']
+                            )
+                        );
+                    }
+                } catch (Exception $e) {
+                    $this->error($e->getMessage());
+                    $ok += 1;
                 }
-            } catch (Exception $e) {
-                $this->error($e->getMessage());
-                $ok += 1;
+            } else {
+                $ext->setExtension($extname);
+
+                if (!$ext->getDownloadURL()) {
+                    $ok += 1;
+                    $this->error(
+                        sprintf('Could not find download for %s', $ext->getID())
+                    );
+                    continue;
+                }
+
+                try {
+                    $installed = $ext->installOrUpdate();
+                    foreach ($installed as $name => $info) {
+                        $this->success(
+                            sprintf(
+                                $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
+                                $info['base']
+                            )
+                        );
+                    }
+                } catch (Exception $e) {
+                    $this->error($e->getMessage());
+                    $ok += 1;
+                }
             }
         }
         return $ok;

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -212,17 +212,11 @@ class cli_plugin_extension extends DokuWiki_CLI_Plugin
 
         $ok = 0;
         foreach ($extensions as $extname) {
+            $installed = [];
+
             if (preg_match("/^https?:\/\//i", $extname)) {
                 try {
                     $installed = $ext->installFromURL($extname, true);
-                    foreach ($installed as $name => $info) {
-                        $this->success(
-                            sprintf(
-                                $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
-                                $info['base']
-                            )
-                        );
-                    }
                 } catch (Exception $e) {
                     $this->error($e->getMessage());
                     $ok += 1;
@@ -240,18 +234,19 @@ class cli_plugin_extension extends DokuWiki_CLI_Plugin
 
                 try {
                     $installed = $ext->installOrUpdate();
-                    foreach ($installed as $name => $info) {
-                        $this->success(
-                            sprintf(
-                                $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
-                                $info['base']
-                            )
-                        );
-                    }
                 } catch (Exception $e) {
                     $this->error($e->getMessage());
                     $ok += 1;
                 }
+            }
+
+            foreach ($installed as $name => $info) {
+                $this->success(
+                    sprintf(
+                        $this->getLang('msg_' . $info['type'] . '_' . $info['action'] . '_success'),
+                        $info['base']
+                    )
+                );
             }
         }
         return $ok;


### PR DESCRIPTION
fixes #3258

I've chosen to set `overwrite` to true when doing `installFromURL`. Maybe this should be added as an option?