### PR TITLE
keep animal parameter out of rewrite location

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -90,6 +90,9 @@ function getID($param='id',$clean=true){
             if (isset($urlParameters['id'])) {
                 unset($urlParameters['id']);
             }
+            if (isset($urlParameters['animal'])) {
+                unset($urlParameters['animal']);
+            }
             send_redirect(wl($id, $urlParameters, true, '&'));
         }
     }


### PR DESCRIPTION
The solution proposed by schplurtz in https://forum.dokuwiki.org/d/19532-animal-parameter-in-wiki-farm-set-up/17 solves the issue for us. It should be merged as everyone using farming is affected.

Nonetheless, you can still manually add the parameter and read publicly available data from any other animal even if their domains are protected by the web server (e.g. htaccess authentication). Therefore, we recommend to revoke public read access for all protected animals even if there's another layer of authentication in place.