### PR TITLE
fix #3554 duplicated first line of details line in Logviewer

### DIFF
--- a/lib/plugins/logviewer/admin.php
+++ b/lib/plugins/logviewer/admin.php
@@ -95,19 +95,22 @@ class admin_plugin_logviewer extends DokuWiki_Admin_Plugin
         echo '<dl>';
         $lines = file($logfile);
         $cnt = count($lines);
+        $details_mode = false; // true when printing indented details lines
         for ($i = 0; $i < $cnt; $i++) {
             $line = $lines[$i];
 
             if ($line[0] === ' ' && $line[1] === ' ') {
                 // lines indented by two spaces are details, aggregate them
-                echo '<dd>';
-                while ($line[0] === ' ' && $line[1] === ' ') {
-                    echo hsc(substr($line, 2)) . '<br />';
-                    $line = $lines[$i++];
+                if (!$details_mode) {
+                    $details_mode = true;
+                    echo '<dd>';
                 }
-                echo '</dd>';
-                $i -= 2; // rewind the counter
+                echo hsc(substr($line, 2)) . '<br />';
             } else {
+                if ($details_mode) {
+                    $details_mode = false;
+                    echo '</dd>';
+                }
                 // other lines are actual log lines in three parts
                 list($dt, $file, $msg) = explode("\t", $line, 3);
                 echo '<dt>';
@@ -118,6 +121,10 @@ class admin_plugin_logviewer extends DokuWiki_Admin_Plugin
                 echo '</span>';
                 echo '</dt>';
             }
+        }
+        if ($details_mode) {
+            $details_mode = false;
+            echo '</dd>';
         }
         echo '</dl>';
     }


### PR DESCRIPTION
fix #3554 duplicated printing (see bellow) of first details block of a log record generated `dokuwiki\Logger::error()`

````
2021-11-24 02:18:59Error: Object of class dokuwiki\ChangeLog\PageChangeLog could not be converted to string /home/core/DokuWiki/revsionHandle3/inc/ChangeLog/ChangeLog.php(588)
    #0 /home/core/DokuWiki/revsionHandle3/inc/ChangeLog/ChangeLog.php(39): dokuwiki\ChangeLog\ChangeLog->getCurrentRevisionInfo()
    #0 /home/core/DokuWiki/revsionHandle3/inc/ChangeLog/ChangeLog.php(39): dokuwiki\ChangeLog\ChangeLog->getCurrentRevisionInfo()
    #1 /home/core/DokuWiki/revsionHandle3/inc/common.php(248): dokuwiki\ChangeLog\ChangeLog->__construct()
    #2 /home/core/DokuWiki/revsionHandle3/doku.php(93): pageinfo()
    #3 {main} 
````