### PR TITLE
SearchIndex: Rearranging the Index class structure

### DIFF
--- a/_test/tests/inc/search/Index/RowIndexTest.php
+++ b/_test/tests/inc/search/Index/RowIndexTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace tests\Search\Index;
+
+use dokuwiki\Search\Index\RowIndex;
+
+class RowIndexTest extends \DokuWikiTest
+{
+
+    public function testChangeRow()
+    {
+
+        $index = new RowIndex(__FUNCTION__);
+
+        $index->changeRow(5, 'test');
+        $full = file($index->getFilename(), FILE_IGNORE_NEW_LINES);
+        $this->assertEquals(6, count($full));
+
+        $index->changeRow(3, 'foo');
+        $full = file($index->getFilename(), FILE_IGNORE_NEW_LINES);
+        $this->assertEquals(6, count($full));
+
+        $index->changeRow(5, 'bar');
+        $index->changeRow(7, 'bang');
+
+        $full = file($index->getFilename(), FILE_IGNORE_NEW_LINES);
+        $this->assertEquals(['', '', '', 'foo', '', 'bar', '', 'bang'], $full);
+    }
+
+    public function testRetrieveRow()
+    {
+        $index = new RowIndex(__FUNCTION__);
+        $index->changeRow(5, 'test');
+        $this->assertEquals('test', $index->retrieveRow(5));
+
+        // out of bounds line should be empty
+        $this->assertEquals('', $index->retrieveRow(100));
+    }
+
+    public function testAccessValue()
+    {
+        $index = new RowIndex(__FUNCTION__);
+        $result = $index->accessValue('foo');
+        $this->assertEquals(0, $result);
+
+        $result = $index->accessValue('bar');
+        $this->assertEquals(1, $result);
+
+        $result = $index->accessValue('foo');
+        $this->assertEquals(0, $result);
+    }
+}

--- a/_test/tests/inc/search/Index/TupleIndexTest.php
+++ b/_test/tests/inc/search/Index/TupleIndexTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace tests\Search\Index;
+
+use dokuwiki\Search\Index\TupleIndex;
+
+class TupleIndexTest extends \DokuWikiTest
+{
+
+    public function testChangeRow()
+    {
+        $index = new TupleIndex(__FUNCTION__);
+
+        $index->changeRow(5, 'test');
+        $full = $this->getInaccessibleProperty($index, 'data');
+        $this->assertEquals(6, count($full));
+
+        $index->changeRow(3, 'foo');
+        $full = $this->getInaccessibleProperty($index, 'data');
+        $this->assertEquals(6, count($full));
+
+        $index->changeRow(5, 'bar');
+        $index->changeRow(7, 'bang');
+
+        $full = $this->getInaccessibleProperty($index, 'data');
+        $this->assertEquals(['', '', '', 'foo', '', 'bar', '', 'bang'], $full);
+    }
+
+    public function testRetrieveRow()
+    {
+        $index = new TupleIndex(__FUNCTION__);
+        $index->changeRow(5, 'test');
+        $this->assertEquals('test', $index->retrieveRow(5));
+
+        // out of bounds line should be empty
+        $this->assertEquals('', $index->retrieveRow(100));
+    }
+
+    public function testSave()
+    {
+        $index = new TupleIndex(__FUNCTION__);
+        $this->assertFileNotExists($index->getFilename());
+        $index->save();
+        $this->assertFileExists($index->getFilename());
+    }
+
+    /**
+     * @see testUpdateTuple
+     */
+    public function provideUpdateTuple()
+    {
+        return [
+            ['', 'foo', 3, 'foo*3'],
+            ['', 17, 3, '17*3'],
+            ['foo*2', 'foo', 3, 'foo*3'],
+            ['17*2', 17, 3, '17*3'],
+            ['bar*2:foo*2', 'foo', 3, 'foo*3:bar*2'],
+            ['18*2:17*2', 17, 3, '17*3:18*2'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUpdateTuple
+     */
+    public function testUpdateTuple($record, $key, $count, $expect)
+    {
+        $index = new TupleIndex(__FUNCTION__);
+        $result = $this->callInaccessibleMethod($index, 'updateTuple', [$record, $key, $count]);
+        $this->assertEquals($result, $expect);
+    }
+
+    public function testAggregateTupleCounts()
+    {
+        $index = new TupleIndex(__FUNCTION__);
+        $record = '5*10:foo*2:14*100::bar*7';
+        $result = $this->callInaccessibleMethod($index, 'aggregateTupleCounts', [$record]);
+        $this->assertEquals(119, $result);
+    }
+
+    public function testParseTuples()
+    {
+        $index = new TupleIndex(__FUNCTION__);
+        $record = '5*10:foo*2:14*100::bar*7';
+        $keys = [5 => 'first', 'bar' => 'second', 'foo' => null];
+        $expect = ['first' => 10, 'second' => 7];
+        $result = $this->callInaccessibleMethod($index, 'parseTuples', [$record, $keys]);
+        $this->assertEquals($expect, $result);
+    }
+}

--- a/inc/Search/Index/AbstractIndex.php
+++ b/inc/Search/Index/AbstractIndex.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace dokuwiki\Search\Index;
+
+/**
+ * Basic Building block to access individual index files
+ */
+abstract class AbstractIndex
+{
+    /** @var string name of the index */
+    protected $idx;
+
+    /** @var string $suffix of the index */
+    protected $suffix;
+
+    /** @var string full filename to the index */
+    protected $filename;
+
+    /**
+     * Initialize the index
+     *
+     * The $suffix argument is for an index that is split into multiple parts.
+     * Different index files should use different base names.
+     *
+     * @param string $idx name of the index
+     * @param string $suffix subpart identifier
+     */
+    public function __construct($idx, $suffix = '')
+    {
+        global $conf;
+        $this->filename = $conf['indexdir'] . '/' . $idx . $suffix . '.idx';
+        $this->idx = $idx;
+        $this->suffix = $suffix;
+    }
+
+    /**
+     * @return string the full path to the underlying file
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * Change a line in the index
+     *
+     * If the line doesn't exist, it will be added, creating empty
+     * lines inbetween as necessary
+     *
+     * @param int $rid the line number, count starting at 0
+     * @param string $value line content to write
+     */
+    abstract public function changeRow($rid, $value);
+
+    /**
+     * Retrieve a line from the index
+     *
+     * Returns an empty string for non-existing lines
+     *
+     * @param int $rid the line number
+     * @return string a line with trailing whitespace removed
+     */
+    abstract public function retrieveRow($rid);
+
+    /**
+     * Clears the index by deleting its file
+     * @return void
+     */
+    public function clear()
+    {
+        @unlink($this->filename);
+    }
+
+}

--- a/inc/Search/Index/RowIndex.php
+++ b/inc/Search/Index/RowIndex.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace dokuwiki\Search\Index;
+
+use dokuwiki\Search\Exception\IndexAccessException;
+use dokuwiki\Search\Exception\IndexWriteException;
+
+/**
+ * A single index file containing one key per line
+ *
+ * Access to this index happens only on a line-by-line basis. It is usually not read in full.
+ */
+class RowIndex extends AbstractIndex
+{
+    /* entries will be marked as deleted in index */
+    const INDEX_MARK_DELETED = '#deleted:';
+
+    /** @var array RID cache for faster access */
+    protected static $ridCache = [];
+
+    /**
+     * @inheritdoc
+     * @throws IndexWriteException
+     * @author Tom N Harris <tnharris@whoopdedo.org>
+     */
+    public function changeRow($rid, $value)
+    {
+        global $conf;
+
+        if (substr($value, -1) !== "\n") {
+            $value .= "\n";
+        }
+
+        $tempname = $this->filename . '.tmp';
+        $fh = @fopen($tempname, 'w');
+        if (!$fh) throw new IndexWriteException("Failed to write {$tempname}");
+        $ih = @fopen($this->filename, 'r');
+
+        $ln = -1; // line counter
+        // copy previous index lines line-by-line, replacing the wanted line
+        if ($ih) {
+            while (($curline = fgets($ih)) !== false) {
+                fwrite($fh, (++$ln == $rid) ? $value : $curline);
+            }
+            fclose($ih);
+        }
+        // if wanted line is beyond the current line count, insert empty lines inbetween
+        if ($rid > $ln) {
+            while ($rid > ++$ln) {
+                fwrite($fh, "\n");
+            }
+            fwrite($fh, $value);
+        }
+        fclose($fh);
+
+        if ($conf['fperm']) {
+            chmod($tempname, $conf['fperm']);
+        }
+        io_rename($tempname, $this->filename);
+    }
+
+    /**
+     * @inheritdoc
+     * @author Tom N Harris <tnharris@whoopdedo.org>
+     */
+    public function retrieveRow($rid)
+    {
+        if (!file_exists($this->filename)) return '';
+        $fh = @fopen($this->filename, 'r');
+        if (!$fh) return '';
+        $ln = -1;
+        while (($line = fgets($fh)) !== false) {
+            if (++$ln == $rid) break;
+        }
+        fclose($fh);
+        return rtrim((string)$line);
+    }
+
+    /**
+     * Searches the Index for a given value and adds it if not found
+     *
+     * Entries previously marked as deleted will be restored.
+     *
+     * Note the existance of an entry in the index does not say anything about the exististance
+     * of the real world object (eg. a page)
+     *
+     * You should preferable use accessCachedValue() instead.
+     *
+     * @param string $value
+     * @return int the RID of the entry
+     * @throws IndexAccessException
+     * @throws IndexWriteException
+     */
+    public function accessValue($value)
+    {
+        $value = trim($value);
+        $deleted = self::INDEX_MARK_DELETED . $value;
+
+        // search for the value
+        $ln = 0;
+        if (file_exists($this->filename)) {
+            $fh = @fopen($this->filename, 'r');
+            if (!$fh) throw new IndexAccessException("Failed to read {$this->filename}");
+            while (($line = fgets($fh)) !== false) {
+                $line = trim($line);
+                if ($line === $value) {
+                    fclose($fh);
+                    return $ln; // value has been found
+                }
+                if ($line === $deleted) {
+                    fclose($fh);
+                    $this->changeRow($ln, $value); // undelete row
+                    return $ln;
+                }
+                $ln++;
+            }
+            fclose($fh);
+        }
+
+        // if we're still here, the value has not been found and will be appended
+        file_put_contents($this->filename, "$value\n", FILE_APPEND);
+        return $ln;
+    }
+
+    /**
+     * Cached version of accessCachedValue()
+     *
+     * @param string $value
+     * @return int the RID of the entry
+     * @throws IndexAccessException
+     * @throws IndexWriteException
+     */
+    public function accessCachedValue($value)
+    {
+        if (isset(static::$ridCache['value'])) return static::$ridCache['value'];
+
+        // limit cache to 10 entries by discarding the oldest element
+        // as in DokuWiki usually only the most recently
+        // added item will be requested again
+        if (count(static::$ridCache) > 10) array_shift(static::$ridCache);
+        static::$ridCache[$value] = $this->accessValue($value);
+        return static::$ridCache[$value];
+    }
+}

--- a/inc/Search/Index/TupleIndex.php
+++ b/inc/Search/Index/TupleIndex.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace dokuwiki\Search\Index;
+
+use dokuwiki\Search\Exception\IndexWriteException;
+
+/**
+ * A single index file storing lines containing a list of tuples
+ *
+ * Tuples consist of a key (typically a RID from another Index) and a count.
+ * Used to store page <-> word counts for example
+ *
+ * Access to these files always happens by loading the full index into memory.
+ * All modifications need to be explicitly made permanent using the save() method.
+ */
+class TupleIndex extends AbstractIndex
+{
+
+    /** @var string the raw data lines of the index, no newlines */
+    protected $data;
+
+    /**
+     * Loads the full contents of the index into memory
+     *
+     * @inheritdoc
+     */
+    public function __construct($idx, $suffix = '')
+    {
+        parent::__construct($idx, $suffix);
+
+        $this->data = [];
+        if (!file_exists($this->filename)) return;
+        $this->data = file($this->filename, FILE_IGNORE_NEW_LINES);
+
+    }
+
+    /** @inheritdoc */
+    public function changeRow($rid, $value)
+    {
+        if ($rid > count($this->data)) {
+            $this->data = array_pad($this->data, $rid, '');
+        }
+        $this->data[$rid] = $value;
+    }
+
+    /** @inheritdoc */
+    public function retrieveRow($rid)
+    {
+        if (isset($this->data[$rid])) return $this->data[$rid];
+        return '';
+    }
+
+    /**
+     * Save the changed index back to its file
+     *
+     * @throws IndexWriteException
+     */
+    public function save()
+    {
+        global $conf;
+
+        $tempname = $this->filename . '.tmp';
+
+        $fh = @fopen($tempname, 'w');
+        if (!$fh) {
+            throw new IndexWriteException("Failed to write $tempname");
+        }
+        fwrite($fh, implode("\n", $this->data));
+        if (!empty($lines)) {
+            fwrite($fh, "\n");
+        }
+        fclose($fh);
+
+        if ($conf['fperm']) {
+            chmod($tempname, $conf['fperm']);
+        }
+
+        if (!io_rename($tempname, $this->filename)) {
+            throw new IndexWriteException("Failed to write {$this->filename}");
+        }
+    }
+
+    /**
+     * Insert or replace a tuple in a line
+     *
+     * @param string $record This is the current row value to be modified
+     * @param int|string $key The foreign rid or identifier
+     * @param int $count The count to store
+     * @return string A new row value
+     * @author Tom N Harris <tnharris@whoopdedo.org>
+     *
+     */
+    protected function updateTuple($record, $key, $count)
+    {
+        if ($record != '') {
+            // remove any current version of the tuple
+            $record = preg_replace('/(^|:)' . preg_quote($key, '/') . '\*\d*/', '', $record);
+        }
+        $record = trim($record, ':');
+        if ($count) {
+            if ($record) {
+                return "{$key}*{$count}:" . $record;
+            } else {
+                return "{$key}*{$count}";
+            }
+        }
+        return $record;
+    }
+
+    /**
+     * Sum the counts in a list of tuples
+     *
+     * @param string $record The row value to parse
+     * @return int sum of all counts
+     * @author Tom N Harris <tnharris@whoopdedo.org>
+     */
+    protected function aggregateTupleCounts($record)
+    {
+        $freq = 0;
+        $parts = explode(':', $record);
+        foreach ($parts as $tuple) {
+            if ($tuple === '') continue;
+            list(/* $key */, $cnt) = explode('*', $tuple);
+            $freq += (int)$cnt;
+        }
+        return $freq;
+    }
+
+    /**
+     * Split a line into an array of tuples
+     *
+     * The given key of the given $filtermap defines which tuples to extract, the value
+     * gives the name in the output array. This basically allows to map RIDs to their
+     * respective real values. The result will contain the counts associated with the
+     * mapped keys.
+     *
+     * @param string $record The row value to parse
+     * @param array $filtermap Associative array of ($key => $mapping)
+     * @return array mapped counts
+     * @author Andreas Gohr <andi@splitbrain.org>
+     *
+     * @author Tom N Harris <tnharris@whoopdedo.org>
+     */
+    protected function parseTuples($record, $filtermap)
+    {
+        $result = array();
+        if ($record == '') return $result;
+        $parts = explode(':', $record);
+        foreach ($parts as $tuple) {
+            if ($tuple === '') continue;
+            list($key, $cnt) = explode('*', $tuple);
+            if (!$cnt) continue;
+            if (empty($filtermap[$key])) continue;
+            $mapped = $filtermap[$key];
+            $result[$mapped] = $cnt;
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
This is a first step at stuff at restructuring the indexing classes a bit more.

Some background:

We have basically two different kind of index files:

a) RowIndex (like page.idx)

Each line in the index contains a single value. The line number is used as primary ID. These files can be very large. Thus an index like that should never be read into memory completely if it can be avoided.

b) TupleIndex (like i12.idx)

Each line contains a list of tuples. The files tend to be smaller so loading them completely for search and replace is easier.

Since the the access is so completely different, I tried to model that in the two different classes, basically moving the methods from \dokuwiki\Search\AbstractIndex to the new classes.

While doing so, I tried to make the doc blocks, variable names and interface easier to understand. I also added tests for each of the methods.

The old code has not been touched yet. So these classes do not do anything outside of tests currently.

Note: the distinction between the two types of Index files might not be so clear cut in the end or we might even have a third type.

I also think that it might be useful to have a \dokuwiki\Search\Index\PageIndex inheriting from RowIndex  providing a few more page-specific methods.

The next step would be to try just remove \dokuwiki\Search\AbstractIndex and try to model the Fulltext and Metadata Indexes as Collections.

