### PR TITLE
PHP 8 compatibility of tests

### DIFF
--- a/_test/core/phpQuery-onefile.php
+++ b/_test/core/phpQuery-onefile.php
@@ -1022,20 +1022,7 @@ class Callback
 //      return new Callback($this->callback, $this->params+$params);
 //  }
 }
-/**
- * Shorthand for new Callback(create_function(...), ...);
- *
- * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
- */
-class CallbackBody extends Callback {
-    public function __construct($paramList, $code, $param1 = null, $param2 = null,
-            $param3 = null) {
-        $params = func_get_args();
-        $params = array_slice($params, 2);
-        $this->callback = create_function($paramList, $code);
-        $this->params = $params;
-    }
-}
+
 /**
  * Callback type which on execution returns reference passed during creation.
  *
@@ -2083,16 +2070,18 @@ class phpQueryObject
             break;
             case 'parent':
                 $this->elements = $this->map(
-                    create_function('$node', '
+                    function ($node) {
                         return $node instanceof DOMELEMENT && $node->childNodes->length
-                            ? $node : null;')
+                            ? $node : null;
+                    }
                 )->elements;
             break;
             case 'empty':
                 $this->elements = $this->map(
-                    create_function('$node', '
+                    function ($node) {
                         return $node instanceof DOMELEMENT && $node->childNodes->length
-                            ? null : $node;')
+                            ? null : $node;
+                    }
                 )->elements;
             break;
             case 'disabled':
@@ -2105,19 +2094,21 @@ class phpQueryObject
             break;
             case 'enabled':
                 $this->elements = $this->map(
-                    create_function('$node', '
-                        return pq($node)->not(":disabled") ? $node : null;')
+                    function ($node) {
+                        return pq($node)->not(":disabled") ? $node : null;
+                    }
                 )->elements;
             break;
             case 'header':
                 $this->elements = $this->map(
-                    create_function('$node',
-                        '$isHeader = isset($node->tagName) && in_array($node->tagName, array(
-                            "h1", "h2", "h3", "h4", "h5", "h6", "h7"
-                        ));
+                    function ($node) {
+                        $isHeader = isset($node->tagName) && in_array($node->tagName, array(
+                                "h1", "h2", "h3", "h4", "h5", "h6", "h7"
+                            ));
                         return $isHeader
                             ? $node
-                            : null;')
+                            : null;
+                    }
                 )->elements;
 //              $this->elements = $this->map(
 //                  create_function('$node', '$node = pq($node);
@@ -2134,18 +2125,23 @@ class phpQueryObject
             break;
             case 'only-child':
                 $this->elements = $this->map(
-                    create_function('$node',
-                        'return pq($node)->siblings()->size() == 0 ? $node : null;')
+                    function ($node) {
+                        return pq($node)->siblings()->size() == 0 ? $node : null;
+                    }
                 )->elements;
             break;
             case 'first-child':
                 $this->elements = $this->map(
-                    create_function('$node', 'return pq($node)->prevAll()->size() == 0 ? $node : null;')
+                    function ($node) {
+                        return pq($node)->prevAll()->size() == 0 ? $node : null;
+                    }
                 )->elements;
             break;
             case 'last-child':
                 $this->elements = $this->map(
-                    create_function('$node', 'return pq($node)->nextAll()->size() == 0 ? $node : null;')
+                    function ($node) {
+                        return pq($node)->nextAll()->size() == 0 ? $node : null;
+                    }
                 )->elements;
             break;
             case 'nth-child':
@@ -2158,45 +2154,46 @@ class phpQueryObject
                 // :nth-child(index/even/odd/equation)
                 if ($param == 'even' || $param == 'odd')
                     $mapped = $this->map(
-                        create_function('$node, $param',
-                            '$index = pq($node)->prevAll()->size()+1;
-                            if ($param == "even" && ($index%2) == 0)
+                        function ($node, $param) {
+                            $index = pq($node)->prevAll()->size() + 1;
+                            if ($param == "even" && ($index % 2) == 0)
                                 return $node;
-                            else if ($param == "odd" && $index%2 == 1)
+                            else if ($param == "odd" && $index % 2 == 1)
                                 return $node;
                             else
-                                return null;'),
-                        new CallbackParam(), $param
+                                return null;
+                        }, new CallbackParam(), $param
                     );
                 else if (mb_strlen($param) > 1 && $param[1] == 'n')
                     // an+b
                     $mapped = $this->map(
-                        create_function('$node, $param',
-                            '$prevs = pq($node)->prevAll()->size();
-                            $index = 1+$prevs;
+                        function ($node, $param) {
+                            $prevs = pq($node)->prevAll()->size();
+                            $index = 1 + $prevs;
                             $b = mb_strlen($param) > 3
-                                ? $param{3}
+                                ? $param[3]
                                 : 0;
-                            $a = $param{0};
-                            if ($b && $param{2} == "-")
+                            $a = $param[0];
+                            if ($b && $param[2] == "-")
                                 $b = -$b;
                             if ($a > 0) {
-                                return ($index-$b)%$a == 0
+                                return ($index - $b) % $a == 0
                                     ? $node
                                     : null;
-                                phpQuery::debug($a."*".floor($index/$a)."+$b-1 == ".($a*floor($index/$a)+$b-1)." ?= $prevs");
-                                return $a*floor($index/$a)+$b-1 == $prevs
-                                        ? $node
-                                        : null;
-                            } else if ($a == 0)
+                                phpQuery::debug($a . "*" . floor($index / $a) . "+$b-1 == " . ($a * floor($index / $a) + $b - 1) . " ?= $prevs");
+                                return $a * floor($index / $a) + $b - 1 == $prevs
+                                    ? $node
+                                    : null;
+                            } else if ($a == 0) {
                                 return $index == $b
-                                        ? $node
-                                        : null;
-                            else
+                                    ? $node
+                                    : null;
+                            } else {
                                 // negative value
                                 return $index <= $b
-                                        ? $node
-                                        : null;
+                                    ? $node
+                                    : null;
+                            }
 //                          if (! $b)
 //                              return $index%$a == 0
 //                                  ? $node
@@ -2205,20 +2202,21 @@ class phpQueryObject
 //                              return ($index-$b)%$a == 0
 //                                  ? $node
 //                                  : null;
-                            '),
+                        },
                         new CallbackParam(), $param
                     );
                 else
                     // index
                     $mapped = $this->map(
-                        create_function('$node, $index',
-                            '$prevs = pq($node)->prevAll()->size();
-                            if ($prevs && $prevs == $index-1)
+                        function ($node, $index) {
+                            $prevs = pq($node)->prevAll()->size();
+                            if ($prevs && $prevs == $index - 1)
                                 return $node;
-                            else if (! $prevs && $index == 1)
+                            else if (!$prevs && $index == 1)
                                 return $node;
                             else
-                                return null;'),
+                                return null;
+                        },
                         new CallbackParam(), $param
                     );
                 $this->elements = $mapped->elements;
@@ -4742,15 +4740,15 @@ abstract class phpQuery {
             while (preg_match($regex, $content))
                 $content = preg_replace_callback(
                     $regex,
-                    create_function('$m',
-                        'return $m[1].$m[2].$m[3]."<?php "
-                            .str_replace(
+                    function ($m) {
+                        return $m[1] . $m[2] . $m[3] . '<?php '
+                            . str_replace(
                                 array("%20", "%3E", "%09", "&#10;", "&#9;", "%7B", "%24", "%7D", "%22", "%5B", "%5D"),
-                                array(" ", ">", "   ", "\n", "  ", "{", "$", "}", \'"\', "[", "]"),
+                                array(" ", ">", "   ", "\n", "  ", "{", "$", "}", '"', "[", "]"),
                                 htmlspecialchars_decode($m[4])
                             )
-                            ." ?>".$m[5].$m[2];'
-                    ),
+                            . " ?>" . $m[5] . $m[2];
+                    },
                     $content
                 );
         return $content;


### PR DESCRIPTION
Removes use of deprecated create_function() in tests. Replaces them with anonymous functions. Refs #3545