### PR TITLE
Enable to keep current page after logout instead of redirect to login

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -66,6 +66,7 @@ $conf['auth_security_timeout'] = 900;    //time (seconds) auth data is considere
 $conf['securecookie'] = 1;               //never send HTTPS cookies via HTTP
 $conf['remote']      = 0;                //Enable/disable remote interfaces
 $conf['remoteuser']  = '!!not set!!';    //user/groups that have access to remote interface (comma separated). leave empty to allow all users
+$conf['redirect_to_login_after_logout'] = 1; //Redirect to login page (1) or keep current page (0) after logout
 
 /* Antispam Features */
 $conf['usewordblock']= 1;                //block spam based on words? 0|1

--- a/inc/Action/Logout.php
+++ b/inc/Action/Logout.php
@@ -32,6 +32,7 @@ class Logout extends AbstractUserAction {
     public function preProcess() {
         global $ID;
         global $INPUT;
+        global $conf;
 
         if (!checkSecurityToken()) throw new ActionException();
 
@@ -43,7 +44,11 @@ class Logout extends AbstractUserAction {
 
         // do the logout stuff and redirect to login
         auth_logoff();
-        send_redirect(wl($ID, array('do' => 'login'), true, '&'));
+        $parameters = array();
+        if ($conf['redirect_to_login_after_logout']) {
+            $parameters['do'] = 'login';
+        }
+        send_redirect(wl($ID, $parameters, true, '&'));
 
         // should never be reached
         throw new ActionException('login');

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -108,6 +108,7 @@ $lang['auth_security_timeout'] = 'Authentication Security Timeout (seconds)';
 $lang['securecookie'] = 'Should cookies set via HTTPS only be sent via HTTPS by the browser? Disable this option when only the login of your wiki is secured with SSL but browsing the wiki is done unsecured.';
 $lang['remote']      = 'Enable the remote API system. This allows other applications to access the wiki via XML-RPC or other mechanisms.';
 $lang['remoteuser']  = 'Restrict remote API access to the comma separated groups or users given here. Leave empty to give access to everyone.';
+$lang['redirect_to_login_after_logout'] = 'Redirect to login page after logout, otherwise keep current page.';
 
 /* Anti-Spam Settings */
 $lang['usewordblock']= 'Block spam based on wordlist';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -160,6 +160,7 @@ $meta['auth_security_timeout'] = array('numeric');
 $meta['securecookie'] = array('onoff');
 $meta['remote']       = array('onoff','_caution' => 'security');
 $meta['remoteuser']   = array('string');
+$meta['redirect_to_login_after_logout'] = array('onoff');
 
 $meta['_anti_spam']  = array('fieldset');
 $meta['usewordblock']= array('onoff');


### PR DESCRIPTION
Dokuwiki redirects to login page after logout even if guest user is allowed to access current page.

For enable guest user to keep current page, add the setting itme named
`redirect_to_login_after_logout` whose class is onoff:

  If `$conf['redirect_to_login_after_logout']` is 1 (default), dokuwiki
  redirect to login page after logout. Otherwise it keeps current page.