### PR TITLE
Some PHP 8.1 compatibility fixes

### DIFF
--- a/.github/workflows/testLinux.yml
+++ b/.github/workflows/testLinux.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0']
+                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
             fail-fast: false
 
         services:

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0']
+                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
             fail-fast: false
 
         steps:

--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -136,12 +136,12 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
     function testVideoInternalTitle() {
         $file = 'wiki:kind_zu_katze.ogv';
         $title = 'Single quote: \' Ampersand: &';
-        
+
         $Renderer = new Doku_Renderer_xhtml();
         $url = $Renderer->externalmedia($file, $title, null, null, null, 'cache', 'details', true);
-        
+
         // make sure the title is escaped just once
-        $this->assertEquals(htmlspecialchars($title), substr($url, 28, 32));
+        $this->assertEquals(hsc($title), substr($url, 28, 37));
     }
 
     function testSimpleLinkText() {

--- a/inc/HTTP/HTTPClient.php
+++ b/inc/HTTP/HTTPClient.php
@@ -772,7 +772,7 @@ class HTTPClient {
         foreach($lines as $line){
             @list($key, $val) = explode(':',$line,2);
             $key = trim($key);
-            $val = trim($val);
+            $val = trim($val ?? '');
             $key = strtolower($key);
             if(!$key) continue;
             if(isset($headers[$key])){

--- a/inc/Utf8/PhpString.php
+++ b/inc/Utf8/PhpString.php
@@ -268,6 +268,7 @@ class PhpString
      */
     public static function strtolower($string)
     {
+        if($string === null) return ''; // pre-8.1 behaviour
         if (UTF8_MBSTRING) {
             if (class_exists('Normalizer', $autoload = false)) {
                 return \Normalizer::normalize(mb_strtolower($string, 'utf-8'));

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -52,6 +52,9 @@ function act_clean($act){
         list($act) = array_keys($act);
     }
 
+    // no action given
+    if($act === null) return 'show';
+
     //remove all bad chars
     $act = strtolower($act);
     $act = preg_replace('/[^1-9a-z_]+/','',$act);

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -600,7 +600,7 @@ function auth_quickaclcheck($id) {
  */
 function auth_aclcheck($id, $user, $groups) {
     $data = array(
-        'id'     => $id,
+        'id'     => $id ?? '',
         'user'   => $user,
         'groups' => $groups
     );
@@ -631,6 +631,7 @@ function auth_aclcheck_cb($data) {
     // if no ACL is used always return upload rights
     if(!$conf['useacl']) return AUTH_UPLOAD;
     if(!$auth) return AUTH_NONE;
+    if(!is_array($AUTH_ACL)) return AUTH_NONE;
 
     //make sure groups is an array
     if(!is_array($groups)) $groups = array();

--- a/inc/common.php
+++ b/inc/common.php
@@ -26,7 +26,7 @@ use dokuwiki\Extension\Event;
  * @return string converted string
  */
 function hsc($string) {
-    return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+    return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8');
 }
 
 /**
@@ -367,7 +367,7 @@ function buildAttributes($params, $skipEmptyStrings = false) {
         if($white) $url .= ' ';
 
         $url .= $key.'="';
-        $url .= htmlspecialchars($val);
+        $url .= hsc($val);
         $url .= '"';
         $white = true;
     }

--- a/inc/common.php
+++ b/inc/common.php
@@ -450,6 +450,8 @@ function idfilter($id, $ue = true) {
     /* @var Input $INPUT */
     global $INPUT;
 
+    $id = (string) $id;
+
     if($conf['useslash'] && $conf['userewrite']) {
         $id = strtr($id, ':', '/');
     } elseif(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' &&
@@ -1904,7 +1906,7 @@ function set_doku_pref($pref, $val) {
             if ($parts[$i] == $enc_pref) {
                 if (!$seen){
                     if ($val !== false) {
-                        $parts[$i + 1] = rawurlencode($val);
+                        $parts[$i + 1] = rawurlencode($val ?? '');
                     } else {
                         unset($parts[$i]);
                         unset($parts[$i + 1]);

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -1054,7 +1054,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         if($conf['target']['interwiki']) $link['rel'] .= ' noopener';
 
         $link['url']   = $url;
-        $link['title'] = htmlspecialchars($link['url']);
+        $link['title'] = $this->_xmlEntities($link['url']);
 
         // output formatted
         if($returnonly) {
@@ -1739,7 +1739,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
      * @return string
      */
     public function _xmlEntities($string) {
-        return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+        return hsc($string);
     }
 
 

--- a/inc/parser/xhtml.php
+++ b/inc/parser/xhtml.php
@@ -657,7 +657,7 @@ class Doku_Renderer_xhtml extends Doku_Renderer {
         global $lang;
         global $INPUT;
 
-        $language = preg_replace(PREG_PATTERN_VALID_LANGUAGE, '', $language);
+        $language = preg_replace(PREG_PATTERN_VALID_LANGUAGE, '', $language ?? '');
 
         if($filename) {
             // add icon


### PR DESCRIPTION
This adds testing on PHP 8.1 and fixes a failing test (due to changes in htmlspecialchars default behavior). It also fixes a few but not all deprecation warnings.

This should be fine to merge as is. More work will need to be done for full compatibility. A new issue tag was added for that.