### PR TITLE
Add event to modify text in denied action

### DIFF
--- a/inc/Action/Denied.php
+++ b/inc/Action/Denied.php
@@ -2,6 +2,7 @@
 
 namespace dokuwiki\Action;
 
+use dokuwiki\Extension\Event;
 use dokuwiki\Ui;
 
 /**
@@ -22,11 +23,18 @@ class Denied extends AbstractAction
     /** @inheritdoc */
     public function tplContent()
     {
-        global $INPUT;
-        $this->showBanner();
-        if (empty($INPUT->server->str('REMOTE_USER')) && actionOK('login')) {
-            (new Ui\Login)->show();
+        $data = null;
+        $event = new Event('ACTION_DENIED_TPLCONTENT', $data);
+
+        if ($event->advise_before(true)) {
+            global $INPUT;
+            $this->showBanner();
+            if (empty($INPUT->server->str('REMOTE_USER')) && actionOK('login')) {
+                (new Ui\Login)->show();
+            }
         }
+
+        $event->advise_after();
     }
 
     /**

--- a/inc/Action/Denied.php
+++ b/inc/Action/Denied.php
@@ -23,17 +23,16 @@ class Denied extends AbstractAction
     /** @inheritdoc */
     public function tplContent()
     {
+        $this->showBanner();
+
         $data = null;
         $event = new Event('ACTION_DENIED_TPLCONTENT', $data);
-
-        if ($event->advise_before(true)) {
+        if ($event->advise_before()) {
             global $INPUT;
-            $this->showBanner();
             if (empty($INPUT->server->str('REMOTE_USER')) && actionOK('login')) {
                 (new Ui\Login)->show();
             }
         }
-
         $event->advise_after();
     }
 


### PR DESCRIPTION
Let plugins suppress/replace the text displayed on the denied page.

The event is very simple and it does not handle the text and the login form separately.