### PR TITLE
Add an option to prevent password changes in authad plugin

### DIFF
--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -700,7 +700,7 @@ class auth_plugin_authad extends DokuWiki_Auth_Plugin
         $opts['admin_password'] = conf_decodeString($opts['admin_password']); // deobfuscate
 
         // we can change the password if SSL is set
-        if ($opts['use_ssl'] || $opts['use_tls']) {
+        if ($opts['update_pass'] && ($opts['use_ssl'] || $opts['use_tls'])) {
             $this->cando['modPass'] = true;
         } else {
             $this->cando['modPass'] = false;

--- a/lib/plugins/authad/conf/default.php
+++ b/lib/plugins/authad/conf/default.php
@@ -15,4 +15,5 @@ $conf['expirywarn']         = 0;
 $conf['additional']         = '';
 $conf['update_name']        = 0;
 $conf['update_mail']        = 0;
+$conf['update_pass']        = 1;
 $conf['recursive_groups']   = 0;

--- a/lib/plugins/authad/conf/metadata.php
+++ b/lib/plugins/authad/conf/metadata.php
@@ -15,4 +15,5 @@ $meta['expirywarn']         = array('numeric', '_min'=>0,'_caution' => 'danger')
 $meta['additional']         = array('string','_caution' => 'danger');
 $meta['update_name']        = array('onoff','_caution' => 'danger');
 $meta['update_mail']        = array('onoff','_caution' => 'danger');
+$meta['update_pass']        = array('onoff','_caution' => 'danger');
 $meta['recursive_groups']   = array('onoff','_caution' => 'danger');

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -15,5 +15,5 @@ $lang['expirywarn']         = 'Days in advance to warn user about expiring passw
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
 $lang['update_name']        = 'Allow users to update their AD display name?';
 $lang['update_mail']        = 'Allow users to update their email address?';
-$lang['update_pass']        = 'Allow users to update their password?';
+$lang['update_pass']        = 'Allow users to update their password? Requires SSL or TLS above.';
 $lang['recursive_groups']   = 'Resolve nested groups to their respective members (slower).';

--- a/lib/plugins/authad/lang/en/settings.php
+++ b/lib/plugins/authad/lang/en/settings.php
@@ -15,4 +15,5 @@ $lang['expirywarn']         = 'Days in advance to warn user about expiring passw
 $lang['additional']         = 'A comma separated list of additional AD attributes to fetch from user data. Used by some plugins.';
 $lang['update_name']        = 'Allow users to update their AD display name?';
 $lang['update_mail']        = 'Allow users to update their email address?';
+$lang['update_pass']        = 'Allow users to update their password?';
 $lang['recursive_groups']   = 'Resolve nested groups to their respective members (slower).';


### PR DESCRIPTION
Should be fairly self-explanatory. Added an 'update_pass' option for authad to be able to prevent password changes (in line with existing options for update_mail, update_name). It defaults to 'on' to preserve existing (and likely typical) behavior.

Rationale:
1) We have a centralized password portal and prefer users not be able to change their password outside of there.

2) Using authad in conjunction with authsplit (and authplain) I need authad to report "cando['modPass'] = false" so that the add/modify password fields in Dokuwiki User Manager are suppressed. We use this setup to allow wiki admins the ability to control access to their wikis while still using the central AD for authentication.

Thanks!