### PR TITLE
correctly (re)cache modified images

### DIFF
--- a/inc/Cache/CacheImageMod.php
+++ b/inc/Cache/CacheImageMod.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace dokuwiki\Cache;
+
+/**
+ * Handle the caching of modified (resized/cropped) images
+ */
+class CacheImageMod extends Cache
+{
+
+    /** @var string source file */
+    protected $file;
+
+    /**
+     * @param string $file Original source file
+     * @param int $w new width in pixel
+     * @param int $h new height in pixel
+     * @param string $ext Image extension - no leading dot
+     * @param bool $crop Is this a crop?
+     */
+    public function __construct($file, $w, $h, $ext, $crop)
+    {
+        $fullext = '.media.' . $w . 'x' . $h;
+        $fullext .= $crop ? '.crop' : '';
+        $fullext .= ".$ext";
+
+        $this->file = $file;
+
+        $this->setEvent('IMAGEMOD_CACHE_USE');
+        parent::__construct($file, $fullext);
+    }
+
+    /** @inheritdoc */
+    public function makeDefaultCacheDecision()
+    {
+        if (!file_exists($this->file)) {
+            return false;
+        }
+        return parent::makeDefaultCacheDecision();
+    }
+
+    /**
+     * Caching depends on the source and the wiki config
+     * @inheritdoc
+     */
+    protected function addDependencies()
+    {
+        parent::addDependencies();
+
+        $this->depends['files'] = array_merge(
+            [$this->file],
+            getConfigFiles('main')
+        );
+    }
+
+}


### PR DESCRIPTION
The previous code used to cache the result of resize and crop image
operations indefinitely. They only time these caches were refreshed were
when the original source changed.

This meant that changes in configuration (eg. the image quality setting)
were never applied to existing images, neither were changes/improvements
in the resizing code.

This patch introduces a new Cache class for these kind of modification
results.

It also removes more duplicated code in media_resize_image and
media_crop_image. Future refactorings may move this code into
File\MediaFile

This code should also fix currently weird results for plugin and
screenshot in the extension manager - TBH I am not 100% sure what
happened there but refreshing the cache once seems to solve the problem.