### PR TITLE
Fix #3619 and correctly handle exceptions in XMLRPC

### DIFF
--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -19,15 +19,20 @@ class XmlRpcServer extends Server
      */
     public function __construct($wait=false)
     {
-        global $conf;
-        if (!$conf['remote']) {
-            throw new ServerException("XML-RPC server not enabled.", -32605);
-        }
-
         $this->remote = new Api();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));
         parent::__construct(false, false, $wait);
+    }
+
+    /** @inheritdoc  */
+    public function serve($data = false)
+    {
+        global $conf;
+        if (!$conf['remote']) {
+            throw new ServerException("XML-RPC server not enabled.", -32605);
+        }
+        parent::serve($data);
     }
 
     /**

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -19,6 +19,11 @@ class XmlRpcServer extends Server
      */
     public function __construct($wait=false)
     {
+        global $conf;
+        if (!$conf['remote']) {
+            throw new ServerException("XML-RPC server not enabled.", -32605);
+        }
+
         $this->remote = new Api();
         $this->remote->setDateTransformation(array($this, 'toDate'));
         $this->remote->setFileTransformation(array($this, 'toFile'));

--- a/lib/exe/xmlrpc.php
+++ b/lib/exe/xmlrpc.php
@@ -5,11 +5,14 @@
 
 use dokuwiki\Remote\XmlRpcServer;
 
-if(!defined('DOKU_INC')) define('DOKU_INC', dirname(__FILE__).'/../../');
+if (!defined('DOKU_INC')) define('DOKU_INC', __DIR__ . '/../../');
 
-require_once(DOKU_INC.'inc/init.php');
+require_once(DOKU_INC . 'inc/init.php');
 session_write_close();  //close session
 
-if(!$conf['remote']) die((new IXR_Error(-32605, "XML-RPC server not enabled."))->getXml());
-
-$server = new XmlRpcServer();
+$server = new XmlRpcServer(true);
+try {
+    $server->serve();
+} catch (\Exception $e) {
+    $server->error($e->getCode(), $e->getMessage());
+}


### PR DESCRIPTION
This ensures that any exception happening during XMLRPC processing is
signalled correctly to the client as XML encoded error message.