### PR TITLE
Adds a new DOKUWIKI_INIT_DONE event

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -235,6 +235,9 @@ if (!defined('NOSESSION')) {
 // setup mail system
 mail_setup();
 
+$nil = null;
+Event::createAndTrigger('DOKUWIKI_INIT_DONE', $nil, null, false);
+
 /**
  * Initializes the session
  *


### PR DESCRIPTION
This is a simple event called at the very end of the inc/init.php process. It provides an alternative to DOKUWIKI_STARTED that is always executed regardless of the called script (eg. in lib/exe/ajax.php or in endpoints provided by plugins).