### PR TITLE
Allow period and colon in section ids.

### DIFF
--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -244,7 +244,7 @@ function noNSorNS($id)
  */
 function sectionID($title, &$check)
 {
-    $title = str_replace(array(':','.'), '', cleanID($title));
+    $title = cleanID($title);
     $new = ltrim($title, '0123456789_-');
     if (empty($new)) {
         $title = 'section' . preg_replace('/[^0-9]+/', '', $title); //keep numbers from headline


### PR DESCRIPTION
A verbose explanation why including colons and periods in section IDs should be allowable and does not cause problems can be found in this 3 year old issue: https://github.com/splitbrain/dokuwiki/issues/2580
Running a DokuWiki with this small modification since 3 years, allowing '.' and ':' in section ids and anchor links to them etc. has caused no problems in all this time.