### PR TITLE
XMLRPC Remote API enabling CORS

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -66,6 +66,7 @@ $conf['auth_security_timeout'] = 900;    //time (seconds) auth data is considere
 $conf['securecookie'] = 1;               //never send HTTPS cookies via HTTP
 $conf['remote']      = 0;                //Enable/disable remote interfaces
 $conf['remoteuser']  = '!!not set!!';    //user/groups that have access to remote interface (comma separated). leave empty to allow all users
+$conf['remotecors']  = '';               //enable Cross-Origin Resource Sharing (CORS) for the remote interfaces. Asterisk (*) to allow all origins. leave empty to deny.
 
 /* Antispam Features */
 $conf['usewordblock']= 1;                //block spam based on words? 0|1

--- a/inc/Remote/XmlRpcServer.php
+++ b/inc/Remote/XmlRpcServer.php
@@ -32,6 +32,7 @@ class XmlRpcServer extends Server
         if (!$conf['remote']) {
             throw new ServerException("XML-RPC server not enabled.", -32605);
         }
+		if(!empty($conf['remotecors'])) header('Access-Control-Allow-Origin: ' . $conf['remotecors']);
         parent::serve($data);
     }
 

--- a/lib/plugins/config/lang/de-informal/lang.php
+++ b/lib/plugins/config/lang/de-informal/lang.php
@@ -96,6 +96,7 @@ $lang['auth_security_timeout'] = 'Zeitüberschreitung bei der Authentifizierung 
 $lang['securecookie']          = 'Sollen Cookies, die via HTTPS gesetzt wurden nur per HTTPS versendet werden? Deaktiviere diese Option, wenn nur der Login deines Wikis mit SSL gesichert ist, aber das Betrachten des Wikis ungesichert geschieht.';
 $lang['remote']                = 'Aktiviert den externen API-Zugang. Diese Option erlaubt es externen Anwendungen von außen auf die XML-RPC-Schnittstelle oder anderweitigen Schnittstellen zuzugreifen.';
 $lang['remoteuser']            = 'Zugriff auf die externen Schnittstellen durch kommaseparierte Angabe von Benutzern oder Gruppen einschränken. Ein leeres Feld erlaubt Zugriff für jeden.';
+$lang['remotecors']            = 'Erlaubt externen Clients API-Zugriff per Cross-Origin Resource Sharing (CORS). Asterisk (*), um alle Quellen zu erlauben. Leer lassen, um CORS zu deaktivieren.';
 $lang['usewordblock']          = 'Blockiere Spam basierend auf der Wortliste';
 $lang['relnofollow']           = 'rel="nofollow" verwenden';
 $lang['indexdelay']            = 'Zeit bevor Suchmaschinenindexierung erlaubt ist';

--- a/lib/plugins/config/lang/de/lang.php
+++ b/lib/plugins/config/lang/de/lang.php
@@ -110,6 +110,7 @@ $lang['auth_security_timeout'] = 'Authentifikations-Timeout (Sekunden)';
 $lang['securecookie']          = 'Sollen Cookies, die via HTTPS gesetzt wurden nur per HTTPS versendet werden? Deaktivieren Sie diese Option, wenn nur der Login Ihres Wikis mit SSL gesichert ist, aber das Betrachten des Wikis ungesichert geschieht.';
 $lang['remote']                = 'Aktiviert den externen API-Zugang. Diese Option erlaubt es externen Anwendungen von außen auf die XML-RPC-Schnittstelle oder anderweitigen Schnittstellen zu zugreifen.';
 $lang['remoteuser']            = 'Zugriff auf die externen Schnittstellen durch kommaseparierte Angabe von Benutzern oder Gruppen einschränken. Ein leeres Feld erlaubt Zugriff für jeden.';
+$lang['remotecors']            = 'Erlaubt externen Clients API-Zugriff per Cross-Origin Resource Sharing (CORS). Asterisk (*), um alle Quellen zu erlauben. Leer lassen, um CORS zu deaktivieren.';
 $lang['usewordblock']          = 'Spam-Blocking (nach Wörterliste) benutzen';
 $lang['relnofollow']           = 'rel="nofollow" verwenden';
 $lang['indexdelay']            = 'Zeit bevor Suchmaschinenindexierung erlaubt ist (in Sekunden)';

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -108,6 +108,7 @@ $lang['auth_security_timeout'] = 'Authentication Security Timeout (seconds)';
 $lang['securecookie'] = 'Should cookies set via HTTPS only be sent via HTTPS by the browser? Disable this option when only the login of your wiki is secured with SSL but browsing the wiki is done unsecured.';
 $lang['remote']      = 'Enable the remote API system. This allows other applications to access the wiki via XML-RPC or other mechanisms.';
 $lang['remoteuser']  = 'Restrict remote API access to the comma separated groups or users given here. Leave empty to give access to everyone.';
+$lang['remotecors']  = 'Enable Cross-Origin Resource Sharing (CORS) for the remote interfaces. Asterisk (*) to allow all origins. Leave empty to deny CORS.';
 
 /* Anti-Spam Settings */
 $lang['usewordblock']= 'Block spam based on wordlist';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -160,6 +160,7 @@ $meta['auth_security_timeout'] = array('numeric');
 $meta['securecookie'] = array('onoff');
 $meta['remote']       = array('onoff','_caution' => 'security');
 $meta['remoteuser']   = array('string');
+$meta['remotecors']   = array('string', '_caution' => 'security');
 
 $meta['_anti_spam']  = array('fieldset');
 $meta['usewordblock']= array('onoff');


### PR DESCRIPTION
It's quite useful to enable Cross-Origin Resource Sharing (CORS) on the Remote API. The existing "Corsharing" plugin doesn't get the job done because it uses the "DOKUWIKI_STARTED" hook which is only working for the usual dw view but not for the remote API. Couldn't find any existing hook fixing that problem. BTW: the plugin seems not to be actively maintained at the moment.
So I decided to make it work as a config option considering that this might be quite an important option to access the remote API by JS application running in a browser.

**Attention: These Changes are working properly on "release_stable_2020_07_29". To make them work on the current master, I inserted the additional line (14) in file lib/exe/xmlrpc.php into inc/Remote/XmlRpcServer.php in between line 34 an 35. Assuming it to work because as far as I see its only a positional change but it is not tested by me on the master. **