### PR TITLE
Restrict editor textarea to vertical resizing only

### DIFF
--- a/lib/tpl/dokuwiki/css/_edit.css
+++ b/lib/tpl/dokuwiki/css/_edit.css
@@ -57,6 +57,7 @@ div.picker button.toolbutton {
 .dokuwiki textarea.edit {
     width: 100%;
     margin-bottom: .5em;
+    resize: vertical;
 }
 
 /*____________ below the textarea ____________*/


### PR DESCRIPTION
In the default template, it was previously possible to resize the editor
textarea in both directions, which made it possible to expand beyond the
edge of its container and become unusable. Restricting it to vertical
resizing still allows an expanded editing view without the possibility
of encountering these problems.

Fixes #3662