### PR TITLE
use function_exists and a string in check if zlib_decode exists

### DIFF
--- a/inc/infoutils.php
+++ b/inc/infoutils.php
@@ -89,7 +89,7 @@ function getVersionData(){
             $subDir = substr($headCommit, 0, 2);
             $fileName = substr($headCommit, 2);
             $gitCommitObject = DOKU_INC . ".git/objects/$subDir/$fileName";
-            if (file_exists($gitCommitObject) && method_exists(zlib_decode)) {
+            if (file_exists($gitCommitObject) && function_exists('zlib_decode')) {
                 $commit = zlib_decode(file_get_contents($gitCommitObject));
                 $committerLine = explode("\n", $commit)[3];
                 $committerData = explode(' ', $committerLine);


### PR DESCRIPTION
?do=check in php8.1
Fixes:
- inc/infoutils.php(92)	Error: Undefined constant "zlib_decode"
- inc/infoutils.php(92)	ArgumentCountError: method_exists() expects exactly 2 arguments, 1 given

Introduces by: #2443