### PR TITLE
Support the multiple attribute in Form selects

### DIFF
--- a/_test/tests/inc/form/dropdownelement.test.php
+++ b/_test/tests/inc/form/dropdownelement.test.php
@@ -177,7 +177,7 @@ class form_dropdownelement_test extends DokuWikiTest {
     /**
      * check that posted values overwrite preset default
      */
-    function test_prefill() {
+    public function test_prefill() {
         global $INPUT;
         $INPUT->post->set('foo', 'second');
 
@@ -193,5 +193,25 @@ class form_dropdownelement_test extends DokuWikiTest {
         $this->assertTrue($option->length == 1);
         $this->assertEquals('second', $option->val());
         $this->assertEquals('The second Label', $option->text());
+    }
+
+
+    public function test_multiple() {
+        $form = new Form\Form();
+
+        $options = array ('first'=>'A first Label', 'second'=>'The second Label', 'third'=>'Just 3');
+        $element = $form->addDropdown('foo', $options, 'label text')->attr('multiple', '1');
+
+        // only two of these values are valid
+        $element->val(['first', 'third', 'fourth']);
+        $this->assertEquals(['first', 'third'], $element->val());
+
+        // check HTML
+        $html = $form->toHTML();
+        $pq = phpQuery::newDocumentXHTML($html);
+        $option = $pq->find('option[selected=selected]');
+
+        $this->assertEquals('A first Label', $option->get(0)->textContent);
+        $this->assertEquals('Just 3', $option->get(1)->textContent);
     }
 }

--- a/inc/Form/DropdownElement.php
+++ b/inc/Form/DropdownElement.php
@@ -5,18 +5,21 @@ namespace dokuwiki\Form;
 /**
  * Class DropdownElement
  *
- * Represents a HTML select. Please note that this does not support multiple selected options!
+ * Represents a HTML select. Please not that prefilling with input data only works for single values.
  *
  * @package dokuwiki\Form
  */
 class DropdownElement extends InputElement
 {
     /** @var array OptGroup[] */
-    protected $optGroups = array();
+    protected $optGroups = [];
+
+    /** @var string[] the currently set values */
+    protected $values = [];
 
     /**
      * @param string $name The name of this form element
-     * @param array  $options The available options
+     * @param array $options The available options
      * @param string $label The label text for this element (will be autoescaped)
      */
     public function __construct($name, $options, $label = '')
@@ -31,9 +34,9 @@ class DropdownElement extends InputElement
      * Add an `<optgroup>` and respective options
      *
      * @param string $label
-     * @param array  $options
+     * @param array $options
      * @return OptGroup a reference to the added optgroup
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function addOptGroup($label, $options)
     {
@@ -49,10 +52,10 @@ class DropdownElement extends InputElement
      *
      * optgroups have to be given as associative array
      *   * the key being the label of the group
-     *   * the value being an array of options as defined in @see OptGroup::options()
-     *
-     * @param null|array $optGroups
+     *   * the value being an array of options as defined in @param null|array $optGroups
      * @return OptGroup[]|DropdownElement
+     * @see OptGroup::options()
+     *
      */
     public function optGroups($optGroups = null)
     {
@@ -95,92 +98,76 @@ class DropdownElement extends InputElement
     }
 
     /**
-     * Gets or sets an attribute
-     *
-     * When no $value is given, the current content of the attribute is returned.
-     * An empty string is returned for unset attributes.
-     *
-     * When a $value is given, the content is set to that value and the Element
-     * itself is returned for easy chaining
-     *
-     * @param string $name Name of the attribute to access
-     * @param null|string $value New value to set
-     * @return string|$this
-     */
-    public function attr($name, $value = null)
-    {
-        if (strtolower($name) == 'multiple') {
-            throw new \InvalidArgumentException(
-                'Sorry, the dropdown element does not support the "multiple" attribute'
-            );
-        }
-        return parent::attr($name, $value);
-    }
-
-    /**
      * Get or set the current value
      *
      * When setting a value that is not defined in the options, the value is ignored
      * and the first option's value is selected instead
      *
-     * @param null|string $value The value to set
-     * @return $this|string
+     * @param null|string|string[] $value The value to set
+     * @return $this|string|string[]
      */
     public function val($value = null)
     {
-        if ($value === null) return $this->value;
+        // getter
+        if ($value === null) {
+            if (isset($this->attributes['multiple'])) {
+                return $this->values;
+            } else {
+                return $this->values[0];
+            }
+        }
 
-        $value_exists = $this->setValueInOptGroups($value);
-
-        if ($value_exists) {
-            $this->value = $value;
-        } else {
+        // setter
+        $this->values = $this->setValuesInOptGroups((array) $value);
+        if(!$this->values) {
             // unknown value set, select first option instead
-            $this->value = $this->getFirstOption();
-            $this->setValueInOptGroups($this->value);
+            $this->values = $this->setValuesInOptGroups((array) $this->getFirstOptionKey());
         }
 
         return $this;
     }
 
     /**
-     * Returns the first options as it will be rendered in HTML
+     * Returns the first option's key
      *
      * @return string
      */
-    protected function getFirstOption()
+    protected function getFirstOptionKey()
     {
         $options = $this->options();
         if (!empty($options)) {
             $keys = array_keys($options);
-            return (string) array_shift($keys);
+            return (string)array_shift($keys);
         }
         foreach ($this->optGroups as $optGroup) {
             $options = $optGroup->options();
             if (!empty($options)) {
                 $keys = array_keys($options);
-                return (string) array_shift($keys);
+                return (string)array_shift($keys);
             }
         }
+
+        return ''; // should not happen
     }
 
     /**
      * Set the value in the OptGroups, including the optgroup for the options without optgroup.
      *
-     * @param string $value
-     * @return bool
+     * @param string[] $values The values to be set
+     * @return string[] The values actually set
      */
-    protected function setValueInOptGroups($value)
+    protected function setValuesInOptGroups($values)
     {
-        $value_exists = false;
+        $valueset = [];
+
         /** @var OptGroup $optGroup */
         foreach ($this->optGroups as $optGroup) {
-            $value_exists = $optGroup->storeValue($value) || $value_exists;
-            if ($value_exists) {
-                $value = null;
-            }
+            $found = $optGroup->storeValues($values);
+            $values = array_diff($values, $found);
+            $valueset = array_merge($valueset, $found);
         }
-        return $value_exists;
+
+        return $valueset;
     }
 
     /**
@@ -190,9 +177,16 @@ class DropdownElement extends InputElement
      */
     protected function mainElementHTML()
     {
-        if ($this->useInput) $this->prefillInput();
+        $attr = $this->attrs();
+        if (isset($attr['multiple'])) {
+            // use array notation when multiple values are allowed
+            $attr['name'] .= '[]';
+        } elseif ($this->useInput) {
+            // prefilling is only supported for non-multi fields
+            $this->prefillInput();
+        }
 
-        $html = '<select ' . buildAttributes($this->attrs()) . '>';
+        $html = '<select ' . buildAttributes($attr) . '>';
         $html = array_reduce(
             $this->optGroups,
             function ($html, OptGroup $optGroup) {

--- a/inc/Form/OptGroup.php
+++ b/inc/Form/OptGroup.php
@@ -2,15 +2,14 @@
 
 namespace dokuwiki\Form;
 
-
 class OptGroup extends Element
 {
-    protected $options = array();
-    protected $value;
+    protected $options = [];
+    protected $values = [];
 
     /**
      * @param string $label The label text for this element (will be autoescaped)
-     * @param array  $options The available options
+     * @param array $options The available options
      */
     public function __construct($label, $options)
     {
@@ -19,17 +18,24 @@ class OptGroup extends Element
     }
 
     /**
-     * Store the given value so it can be used during rendering
+     * Store the given values so they can be used during rendering
      *
-     * This is intended to be only called from within @see DropdownElement::val()
+     * This is intended to be only called from within DropdownElement::val()
      *
-     * @param string $value
-     * @return bool true if an option with the given value exists, false otherwise
+     * @param string[] $values the values to set
+     * @return string[] the values that have been set (options exist)
+     * @see DropdownElement::val()
      */
-    public function storeValue($value)
+    public function storeValues($values)
     {
-        $this->value = $value;
-        return isset($this->options[$value]);
+        $this->values = [];
+        foreach ($values as $value) {
+            if(isset($this->options[$value])) {
+                $this->values[] = $value;
+            }
+        }
+
+        return $this->values;
     }
 
     /**
@@ -55,9 +61,11 @@ class OptGroup extends Element
         $this->options = array();
         foreach ($options as $key => $val) {
             if (is_array($val)) {
-                if (!key_exists('label', $val)) throw new \InvalidArgumentException(
-                    'If option is given as array, it has to have a "label"-key!'
-                );
+                if (!key_exists('label', $val)) {
+                    throw new \InvalidArgumentException(
+                        'If option is given as array, it has to have a "label"-key!'
+                    );
+                }
                 if (key_exists('attrs', $val) && is_array($val['attrs']) && key_exists('selected', $val['attrs'])) {
                     throw new \InvalidArgumentException(
                         'Please use function "DropdownElement::val()" to set the selected option'
@@ -65,9 +73,9 @@ class OptGroup extends Element
                 }
                 $this->options[$key] = $val;
             } elseif (is_int($key)) {
-                $this->options[$val] = array('label' => (string) $val);
+                $this->options[$val] = array('label' => (string)$val);
             } else {
-                $this->options[$key] = array('label' => (string) $val);
+                $this->options[$key] = array('label' => (string)$val);
             }
         }
         return $this;
@@ -83,12 +91,11 @@ class OptGroup extends Element
         if ($this->attributes['label'] === null) {
             return $this->renderOptions();
         }
-        $html = '<optgroup '. buildAttributes($this->attrs()) . '>';
+        $html = '<optgroup ' . buildAttributes($this->attrs()) . '>';
         $html .= $this->renderOptions();
         $html .= '</optgroup>';
         return $html;
     }
-
 
     /**
      * @return string
@@ -97,12 +104,12 @@ class OptGroup extends Element
     {
         $html = '';
         foreach ($this->options as $key => $val) {
-            $selected = ((string)$key === (string)$this->value) ? ' selected="selected"' : '';
+            $selected = in_array((string)$key, $this->values) ? ' selected="selected"' : '';
             $attrs = '';
             if (!empty($val['attrs']) && is_array($val['attrs'])) {
                 $attrs = buildAttributes($val['attrs']);
             }
-            $html .= '<option' . $selected . ' value="' . hsc($key) . '" '.$attrs.'>';
+            $html .= '<option' . $selected . ' value="' . hsc($key) . '" ' . $attrs . '>';
             $html .= hsc($val['label']);
             $html .= '</option>';
         }


### PR DESCRIPTION
This should fix a problem mentioned in https://github.com/splitbrain/dokuwiki-plugin-data/pull/229#issuecomment-1196367602

Note that prefilling from $INPUT is still only supported for single value selects.


Not sure if we want to merge this into Igor. On the one hand it makes it easier for plugin authors to switch to the new Form methods, as this feature was missing, on the other hand it might introduce unforeseen bugs and my test cases are not super extensive.