### PR TITLE
Fix PHP8 Warning: Undefined array key

### DIFF
--- a/inc/ChangeLog/RevisionInfo.php
+++ b/inc/ChangeLog/RevisionInfo.php
@@ -36,7 +36,7 @@ class RevisionInfo
     {
         if (is_array($info) && isset($info['id'])) {
             // define strategy context
-            $info['mode'] = $info['media'] ? 'media' : 'page';
+            $info['mode'] = ($info['media'] ?? false) ? 'media' : 'page';
         } else {
             $info = [
                 'mode' => 'page',

--- a/inc/html.php
+++ b/inc/html.php
@@ -111,7 +111,7 @@ function html_secedit_button($matches){
         return '';
     }
     $data ['target'] = strtolower($data['target']);
-    $data ['hid'] = strtolower($data['hid']);
+    $data ['hid'] = strtolower($data['hid'] ?? '');
 
     return Event::createAndTrigger('HTML_SECEDIT_BUTTON', $data,
                          'html_secedit_get_button');


### PR DESCRIPTION
Add null coalescing operator to line 114 so if `$data['hd']` is undefined or null it doesn't cause undefined key warning.