### PR TITLE
:bug: Fixes #3738 , default value for mediamanger in fullscreen mode

### DIFF
--- a/lib/exe/mediamanager.php
+++ b/lib/exe/mediamanager.php
@@ -40,6 +40,10 @@ use dokuwiki\Extension\Event;
     $JSINFO['namespace'] = '';
     $AUTH = $INFO['perm'];    // shortcut for historical reasons
 
+    // If this page is directly opened it means we are in popup mode not fullscreen
+    // $fullscreen isn't defined by default it might lead to some PHP warnings
+    $fullscreen = isset($fullscreen) ? $fullscreen : false;
+
     $tmp = array();
     Event::createAndTrigger('MEDIAMANAGER_STARTED', $tmp);
     session_write_close();  //close session


### PR DESCRIPTION
Fixes #3738, add a default value for $fullscreen to prevent warnings when mediamanager is used in popup mode.