### PR TITLE
log warnings to error log

### DIFF
--- a/conf/dokuwiki.php
+++ b/conf/dokuwiki.php
@@ -167,6 +167,7 @@ $conf['trustedproxy'] = '^(::1|[fF][eE]80:|127\.|10\.|192\.168\.|172\.((1[6-9])|
 
 /* Feature Flags */
 $conf['defer_js'] = 1;                   // Defer javascript to be executed after the page's HTML has been parsed. Setting will be removed in the next release.
+$conf['hidewarnings'] = 0;               // Hide warnings
 
 /* Network Settings */
 $conf['dnslookups'] = 1;                 //disable to disallow IP to hostname lookups

--- a/lib/plugins/config/lang/en/lang.php
+++ b/lib/plugins/config/lang/en/lang.php
@@ -192,6 +192,7 @@ $lang['trustedproxy'] = 'Trust forwarding proxies matching this regular expressi
 
 $lang['_feature_flags'] = 'Feature Flags';
 $lang['defer_js'] = 'Defer javascript to be execute after the page\'s HTML has been parsed. Improves perceived page speed but could break a small number of plugins.';
+$lang['hidewarnings'] = 'Do not display any warnings issued by PHP. This may ease the transisition to PHP8+. Warnings will still be logged in the error log and should be reported.';
 
 /* Network Options */
 $lang['dnslookups'] = 'DokuWiki will lookup hostnames for remote IP addresses of users editing pages. If you have a slow or non working DNS server or don\'t want this feature, disable this option';

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -242,6 +242,7 @@ $meta['trustedproxy'] = array('regex');
 
 $meta['_feature_flags'] = ['fieldset'];
 $meta['defer_js']       = ['onoff'];
+$meta['hidewarnings']   = ['onoff'];
 
 $meta['_network']    = array('fieldset');
 $meta['dnslookups']  = array('onoff');


### PR DESCRIPTION
This introduces an error handler that will log warnings, including a
stack trace in the error log. This should help plugin and core authors with
identifying cases of uninitilized variables in PHP8+ environments.

A feature flag (default off) will let users temporarily disable the
display of warnings in the frontend. This should allow the usage of not
yet upgraded plugins in many cases. In the future the flag can be
removed again.