### PR TITLE
Remove Accept-Encoding from auth_browseruid()

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -294,7 +294,6 @@ function auth_browseruid() {
     $uid = implode("\n", [
         $INPUT->server->str('HTTP_USER_AGENT'),
         $INPUT->server->str('HTTP_ACCEPT_LANGUAGE'),
-        $INPUT->server->str('HTTP_ACCEPT_ENCODING'),
         substr($pip, 0, strlen($pip) / 2), // use half of the IP address (works for both IPv4 and IPv6)
     ]);
     return hash('sha256', $uid);


### PR DESCRIPTION
Browsers do not send the same Accept-Encoding header for all requests, so using
it as part of auth_browseruid() can break things. For example, the audio
CAPTCHA in the official CAPTCHA plugin stopped matching its corresponding
image. Details here:

https://github.com/splitbrain/dokuwiki-plugin-captcha/issues/115#issuecomment-1215007408