### PR TITLE
introduce sexplode() as a PHP8 safe explode()

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -30,6 +30,26 @@ function hsc($string) {
 }
 
 /**
+ * A safer explode for fixed length lists
+ *
+ * This works just like explode(), but will always return the wanted number of elements.
+ * If the $input string does not contain enough elements, the missing elements will be
+ * filled up with the $default value. If the input string contains more elements, the last
+ * one will NOT be split up and will still contain $separator
+ *
+ * @param string $separator The boundary string
+ * @param string $string The input string
+ * @param int $limit The number of expected elements
+ * @param mixed $default The value to use when filling up missing elements
+ * @see explode
+ * @return array
+ */
+function sexplode($separator, $string, $limit, $default = null)
+{
+    return array_pad(explode($separator, $string, $limit), $limit, $default);
+}
+
+/**
  * Checks if the given input is blank
  *
  * This is similar to empty() but will return false for "0".


### PR DESCRIPTION
We often have constructs like

```php
list($foo, $bar) = explode(',', $input, 2);
```

In PHP8+ this will throw warnings when the explode returns fewer than 2 elements. Our code usually (always?) will anticipate missing elements so the construct isn't really problematic.

The implementation here wraps the solution suggested at https://stackoverflow.com/a/56971347 into a new utility function.

I anticipate that people might object to the function name. It was chosen as a short form of "safe explode". This makes fixing the warning easy by simply adding a single letter. I also find it slightly amusing and would be open to change it to just sex() just for the fun of it.