### PR TITLE
Add Message-ID to all mails

### DIFF
--- a/inc/Mailer.class.php
+++ b/inc/Mailer.class.php
@@ -52,6 +52,7 @@ class Mailer {
 
         $listid = implode('.', array_reverse(explode('/', DOKU_BASE))).$server;
         $listid = strtolower(trim($listid, '.'));
+        $messageid = uniqid(mt_rand(), true) . "@$server";
 
         $this->allowhtml = (bool)$conf['htmlmail'];
 
@@ -66,6 +67,7 @@ class Mailer {
         $this->setHeader('X-Auto-Response-Suppress', 'OOF');
         $this->setHeader('List-Id', $conf['title'].' <'.$listid.'>');
         $this->setHeader('Date', date('r'), false);
+        $this->setHeader('Message-Id', "<$messageid>");
 
         $this->prepareTokenReplacements();
     }


### PR DESCRIPTION
RFC 5322 specifies that all mails SHOULD have a Message-ID field. While originating SMTP servers MAY (as per RFC 5321) add a missing Message-ID, this behavior is not mandatory.
Multiple mail providers, e.g. Gmail, reject mails without a Message-ID field, rendering their users unable to receive mails from a Dokuwiki instance using a standard-conforming mail server.

This commit simply adds a random Message-ID to a mail's headers during Mailer class initialization. With the current behavior of setHeader(), overwriting that header happens without additional changes, should another Message-ID be necessary, warranted or desired.