### PR TITLE
opening up CSP headers for fetch.php resources

### DIFF
--- a/lib/exe/fetch.php
+++ b/lib/exe/fetch.php
@@ -56,11 +56,11 @@ if (defined('SIMPLE_TEST')) {
         'statusmessage' => $STATUSMESSAGE,
         'ispublic'      => media_ispublic($MEDIA),
         'csp' => [
-            'sandbox' => '',
             'default-src' => "'none'",
             'style-src' => "'unsafe-inline'",
             'media-src' => "'self'",
             'object-src' => "'self'",
+            'font-src' => "'self' data:",
             'form-action' => "'none'",
             'frame-ancestors' => "'self'",
         ],


### PR DESCRIPTION
This drops the sandbox attribute as discussed in #3710 to re-enable inline display of PDFs in Safari again.

Dropping the sandbox attribute should also help with using navigational links within SVG files as discussed in https://forum.dokuwiki.org/d/20420-how-to-embed-svg-with-links-the-proper-way

It also allows the loading of fonts from within SVG files. This currently does not allow font loading from google fonts as asked for in #3709 though. I'm not sure if we should favor any font provider here.