### PR TITLE
Test Autoloading Cleanup

### DIFF
--- a/_test/tests/conf/CascadeExtraDefaultsTest.php
+++ b/_test/tests/conf/CascadeExtraDefaultsTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class CascadeExtraDefaultsTest extends DokuWikiTest
+namespace dokuwiki\test\conf;
+
+class CascadeExtraDefaultsTest extends \DokuWikiTest
 {
 
     protected $oldSetting = [];

--- a/_test/tests/conf/CascadeNormalTest.php
+++ b/_test/tests/conf/CascadeNormalTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class CascadeNormalTest extends DokuWikiTest
+namespace dokuwiki\test\conf;
+
+class CascadeNormalTest extends \DokuWikiTest
 {
 
     public function setUp(): void

--- a/_test/tests/conf/CascadeProtectedTest.php
+++ b/_test/tests/conf/CascadeProtectedTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class CascadeProtectedTest extends DokuWikiTest
+namespace dokuwiki\test\conf;
+
+class CascadeProtectedTest extends \DokuWikiTest
 {
 
     public function setUp(): void

--- a/_test/tests/inc/File/PageResolverTest.php
+++ b/_test/tests/inc/File/PageResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\inc\File;
+namespace dokuwiki\test\inc\File;
 
 use dokuwiki\File\PageResolver;
 

--- a/_test/tests/inc/Subscriptions/BulkSubscriptionsSenderTest.php
+++ b/_test/tests/inc/Subscriptions/BulkSubscriptionsSenderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\inc\Subscriptions;
+namespace dokuwiki\test\inc\Subscriptions;
 
 use dokuwiki\Subscriptions\BulkSubscriptionSender;
 use dokuwiki\Subscriptions\SubscriberManager;

--- a/_test/tests/inc/Subscriptions/SubscriberManagerTest.php
+++ b/_test/tests/inc/Subscriptions/SubscriberManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\inc\Subscriptions;
+namespace dokuwiki\test\inc\Subscriptions;
 
 use dokuwiki\Subscriptions\SubscriberManager;
 use DokuWikiTest;

--- a/_test/tests/inc/Subscriptions/SubscriberRegexBuilderTest.php
+++ b/_test/tests/inc/Subscriptions/SubscriberRegexBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\inc\Subscriptions;
+namespace dokuwiki\test\inc\Subscriptions;
 
 use dokuwiki\Subscriptions\SubscriberRegexBuilder;
 use DokuWikiTest;

--- a/inc/load.php
+++ b/inc/load.php
@@ -85,10 +85,19 @@ function load_autoload($name){
     // namespace to directory conversion
     $name = str_replace('\\', '/', $name);
 
-    // test namespace
-    if(substr($name, 0, 14) === 'dokuwiki/test/') {
-        $file = DOKU_INC . '_test/' . substr($name, 14) . '.php';
-        if(file_exists($file)) {
+    // test mock namespace
+    if (substr($name, 0, 19) === 'dokuwiki/test/mock/') {
+        $file = DOKU_INC . '_test/mock/' . substr($name, 19) . '.php';
+        if (file_exists($file)) {
+            require $file;
+            return true;
+        }
+    }
+
+    // tests namespace
+    if (substr($name, 0, 14) === 'dokuwiki/test/') {
+        $file = DOKU_INC . '_test/tests/' . substr($name, 14) . '.php';
+        if (file_exists($file)) {
             require $file;
             return true;
         }


### PR DESCRIPTION
Namespacing and autoloading for our tests was a bit messed up. Some classes used the wrong `tests` namespace instead of the proper `dokuwiki\test` namespace. Our autoloader did not correctly map the namespace to `_test\tests` either. This all didn't matter much as long as no test wanted to inherit from or use a sibling test - a problem I encountered while working on #3810. The fix suggested there in 12ebce974be688ac34bf4389645d5fc7baa29cc7 however was too shortsighted and does not work as intended.

This PR fixes the autoloading properly and updates the namespaces for those tests that already use a PSR4 style naming. Others will need renaming later on.

