### PR TITLE
Change text color for diff

### DIFF
--- a/lib/tpl/dokuwiki/css/_diff.css
+++ b/lib/tpl/dokuwiki/css/_diff.css
@@ -57,17 +57,17 @@
 }
 .dokuwiki table.diff .diff-addedline {
     background-color: #cfc;
-    color: inherit;
+    color: black;
     width: ~"calc(50% - .7em)";
 }
 .dokuwiki table.diff .diff-deletedline {
     background-color: #fdd;
-    color: inherit;
+    color: black;
     width: ~"calc(50% - .7em)";
 }
 .dokuwiki table.diff td.diff-context {
     background-color: #eee;
-    color: inherit;
+    color: black;
     width: ~"calc(50% - .7em)";
 }
 .dokuwiki table.diff td.diff-addedline strong,


### PR DESCRIPTION
I use the default template, changed the color scheme through the settings, the text color is white. When viewing the edit history, the text color is inherited, but the background color is always light, text and background merge. I think it's worth changing the text color to black.