### PR TITLE
Fix handling of unknown array settings

### DIFF
--- a/lib/plugins/config/_test/WriterTest.php
+++ b/lib/plugins/config/_test/WriterTest.php
@@ -60,4 +60,11 @@ class WriterTest extends \DokuWikiTest {
         clearstatcache($config);
         $this->assertGreaterThan($old, filemtime($config));
     }
+
+    public function testEmpty() {
+        $writer = new Writer();
+        $this->expectException(\Exception::class);
+        $this->expectErrorMessage('empty config');
+        $writer->save([]);
+    }
 }

--- a/lib/plugins/config/core/Setting/Setting.php
+++ b/lib/plugins/config/core/Setting/Setting.php
@@ -221,6 +221,17 @@ class Setting {
     }
 
     /**
+     * Escaping
+     *
+     * @param string $string
+     * @return string
+     */
+    protected function escape($string) {
+        $tr = array("\\" => '\\\\', "'" => '\\\'');
+        return "'" . strtr(cleanText($string), $tr) . "'";
+    }
+
+    /**
      * Generate string to save local setting value to file according to $fmt
      *
      * @see shouldBeSaved() to check if this should be called
@@ -229,10 +240,15 @@ class Setting {
      * @return string
      */
     public function out($var, $fmt = 'php') {
-        if($fmt != 'php') return '';
+        if ($fmt != 'php') return '';
 
-        $tr = array("\\" => '\\\\', "'" => '\\\''); // escape the value
-        $out = '$' . $var . "['" . $this->getArrayKey() . "'] = '" . strtr(cleanText($this->local), $tr) . "';\n";
+        if (is_array($this->local)) {
+            $value = 'array(' . join(', ', array_map([$this, 'escape'], $this->local)) . ')';
+        } else {
+            $value = $this->escape($this->local);
+        }
+
+        $out = '$' . $var . "['" . $this->getArrayKey() . "'] = $value;\n";
 
         return $out;
     }

--- a/lib/plugins/config/core/Setting/SettingArray.php
+++ b/lib/plugins/config/core/Setting/SettingArray.php
@@ -59,26 +59,6 @@ class SettingArray extends Setting {
         return true;
     }
 
-    /**
-     * Escaping
-     *
-     * @param string $string
-     * @return string
-     */
-    protected function escape($string) {
-        $tr = array("\\" => '\\\\', "'" => '\\\'');
-        return "'" . strtr(cleanText($string), $tr) . "'";
-    }
-
-    /** @inheritdoc */
-    public function out($var, $fmt = 'php') {
-        if($fmt != 'php') return '';
-
-        $vals = array_map(array($this, 'escape'), $this->local);
-        $out = '$' . $var . "['" . $this->getArrayKey() . "'] = array(" . join(', ', $vals) . ");\n";
-        return $out;
-    }
-
     /** @inheritdoc */
     public function html(\admin_plugin_config $plugin, $echo = false) {
         $disable = '';

--- a/lib/plugins/config/core/Writer.php
+++ b/lib/plugins/config/core/Writer.php
@@ -43,12 +43,17 @@ class Writer {
             throw new \Exception('no save');
         }
 
-        $out = $this->getHeader();
+        $out = '';
         foreach($settings as $setting) {
             if($setting->shouldBeSaved()) {
                 $out .= $setting->out('conf', 'php');
             }
         }
+
+        if($out === '') {
+            throw new \Exception('empty config');
+        }
+        $out = $this->getHeader() . $out;
 
         fwrite($fh, $out);
         fclose($fh);


### PR DESCRIPTION
When a plugin used an array setting and was then installed, the old configuration can remain in local.php. It is handled by the SettingUndefined class. However this class used the base out() mechanism which didn't know about arrays. The result was a fatal error resulting in a completely empty config file.

This moves the error handling from the SettingArray class to the base class which fixes the original problem.

It also adds a check if the Writer is about to write a completely empty config file and refuses to do so, throwing an Exception.

Probably related to #3777