### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -7,6 +7,9 @@ on:
       - old-stable
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
     phpcs:
         name: PHP CodeSniffer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/testLinux.yml
+++ b/.github/workflows/testLinux.yml
@@ -7,6 +7,9 @@ on:
       - old-stable
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
     run:
         name: PHP ${{ matrix.php-versions }}

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -7,6 +7,9 @@ on:
       - old-stable
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
     run:
         name: PHP ${{ matrix.php-versions }}


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.