### PR TITLE
Fix warning from toolbar.php when $INFO is null

### DIFF
--- a/inc/toolbar.php
+++ b/inc/toolbar.php
@@ -267,8 +267,12 @@ function toolbar_signature(){
     $sig = $conf['signature'];
     $sig = dformat(null,$sig);
     $sig = str_replace('@USER@',$INPUT->server->str('REMOTE_USER'),$sig);
-    $sig = str_replace('@NAME@', $INFO['userinfo']['name'] ?? "" ,$sig);
-    $sig = str_replace('@MAIL@', $INFO['userinfo']['mail'] ?? "",$sig);
+    if (is_null($INFO)) {
+        $sig = str_replace(['@NAME@', '@MAIL@'], '', $sig);
+    } else {
+        $sig = str_replace('@NAME@', $INFO['userinfo']['name'] ?? "", $sig);
+        $sig = str_replace('@MAIL@', $INFO['userinfo']['mail'] ?? "", $sig);
+    }
     $sig = str_replace('@DATE@',dformat(),$sig);
     $sig = str_replace('\\\\n','\\n',$sig);
     return json_encode($sig);


### PR DESCRIPTION
This commit fixes an issue observed in this context:
1. Run Dokuwiki with PHP 8.1
2. Install the "sync" plugin
3. Run the "sync" plugin, and when prompted whether you want to keep the remote of the local file, click to show the diff

That's it: on the window which opens to display the diff, there is a warning saying that $INFO is null.

(Perhaps an even better fix would be to ensure that $INFO is set in this case
 but at least this commit fixes this issue and shouldn't have any detrimental
 side effects)