### PR TITLE
New option for the info plugin

### DIFF
--- a/inc/Extension/EventHandler.php
+++ b/inc/Extension/EventHandler.php
@@ -40,13 +40,12 @@ class EventHandler
      *
      * register a hook for an event
      *
-     * @param  string $event string   name used by the event, (incl '_before' or '_after' for triggers)
-     * @param  string $advise
-     * @param  object $obj object in whose scope method is to be executed,
-     *                             if NULL, method is assumed to be a globally available function
-     * @param  string $method event handler function
-     * @param  mixed $param data passed to the event handler
-     * @param  int $seq sequence number for ordering hook execution (ascending)
+     * @param string $event name used by the event
+     * @param string $advise BEFORE|AFTER
+     * @param object $obj scope for the method be executed on, NULL for global function or callable
+     * @param string|callable $method event handler function
+     * @param mixed $param data passed to the event handler
+     * @param int $seq sequence number for ordering hook execution (ascending)
      */
     public function register_hook($event, $advise, $obj, $method, $param = null, $seq = 0)
     {
@@ -104,5 +103,17 @@ class EventHandler
         }
 
         return isset($this->hooks[$name . '_BEFORE']) || isset($this->hooks[$name . '_AFTER']);
+    }
+
+    /**
+     * Get all hooks and their currently registered handlers
+     *
+     * The handlers are sorted by sequence, then by register time
+     *
+     * @return array
+     */
+    public function getEventHandlers()
+    {
+        return $this->hooks;
     }
 }

--- a/lib/plugins/info/syntax.php
+++ b/lib/plugins/info/syntax.php
@@ -101,6 +101,9 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
                 case 'helpermethods':
                     $this->renderHelperMethods($renderer);
                     break;
+                case 'hooks':
+                    $this->renderHooks($renderer);
+                    break;
                 case 'datetime':
                     $renderer->doc .= date('r');
                     break;
@@ -271,6 +274,41 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
 
         $doc .= '</tbody></table></div>';
         return $doc;
+    }
+
+    /**
+     * Render all currently registered event handlers
+     *
+     * @param Doku_Renderer $renderer
+     */
+    protected function renderHooks(Doku_Renderer $renderer)
+    {
+        global $EVENT_HANDLER;
+
+        $list = $EVENT_HANDLER->getEventHandlers();
+        ksort($list);
+
+        $renderer->listu_open();
+        foreach ($list as $event => $handlers) {
+            $renderer->listitem_open(1);
+            $renderer->listcontent_open();
+            $renderer->cdata($event);
+            $renderer->listcontent_close();
+
+            $renderer->listo_open();
+            foreach ($handlers as $sequence) {
+                foreach ($sequence as $handler) {
+                    $renderer->listitem_open(2);
+                    $renderer->listcontent_open();
+                    $renderer->cdata(get_class($handler[0]) . '::' . $handler[1] . '()');
+                    $renderer->listcontent_close();
+                    $renderer->listitem_close();
+                }
+            }
+            $renderer->listo_close();
+            $renderer->listitem_close();
+        }
+        $renderer->listu_close();
     }
 
     /**

--- a/lib/plugins/info/syntax.php
+++ b/lib/plugins/info/syntax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Info Plugin: Displays information about various DokuWiki internals
  *
@@ -33,7 +34,6 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
         return 155;
     }
 
-
     /**
      * Connect pattern to lexer
      */
@@ -45,10 +45,10 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
     /**
      * Handle the match
      *
-     * @param   string       $match   The text matched by the patterns
-     * @param   int          $state   The lexer state for the match
-     * @param   int          $pos     The character position of the matched text
-     * @param   Doku_Handler $handler The Doku_Handler object
+     * @param string $match The text matched by the patterns
+     * @param int $state The lexer state for the match
+     * @param int $pos The character position of the matched text
+     * @param Doku_Handler $handler The Doku_Handler object
      * @return  array Return an array with all data you want to use in render
      */
     public function handle($match, $state, $pos, Doku_Handler $handler)
@@ -60,9 +60,9 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
     /**
      * Create output
      *
-     * @param string $format   string     output format being rendered
-     * @param Doku_Renderer    $renderer  the current renderer object
-     * @param array            $data      data created by handler()
+     * @param string $format string     output format being rendered
+     * @param Doku_Renderer $renderer the current renderer object
+     * @param array $data data created by handler()
      * @return  boolean                 rendered correctly?
      */
     public function render($format, Doku_Renderer $renderer, $data)
@@ -105,7 +105,7 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
                     $renderer->doc .= date('r');
                     break;
                 default:
-                    $renderer->doc .= "no info about ".htmlspecialchars($data[0]);
+                    $renderer->doc .= "no info about " . htmlspecialchars($data[0]);
             }
             return true;
         }
@@ -172,31 +172,31 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
             $info = $po->getInfo();
 
             $hid = $this->addToToc($info['name'], 2, $renderer);
-            $doc = '<h2><a name="'.$hid.'" id="'.$hid.'">'.hsc($info['name']).'</a></h2>';
+            $doc = '<h2><a name="' . $hid . '" id="' . $hid . '">' . hsc($info['name']) . '</a></h2>';
             $doc .= '<div class="level2">';
-            $doc .= '<p>'.strtr(hsc($info['desc']), array("\n"=>"<br />")).'</p>';
-            $doc .= '<pre class="code">$'.$p." = plugin_load('helper', '".$p."');</pre>";
+            $doc .= '<p>' . strtr(hsc($info['desc']), array("\n" => "<br />")) . '</p>';
+            $doc .= '<pre class="code">$' . $p . " = plugin_load('helper', '" . $p . "');</pre>";
             $doc .= '</div>';
             foreach ($methods as $method) {
-                $title = '$'.$p.'->'.$method['name'].'()';
+                $title = '$' . $p . '->' . $method['name'] . '()';
                 $hid = $this->addToToc($title, 3, $renderer);
-                $doc .= '<h3><a name="'.$hid.'" id="'.$hid.'">'.hsc($title).'</a></h3>';
+                $doc .= '<h3><a name="' . $hid . '" id="' . $hid . '">' . hsc($title) . '</a></h3>';
                 $doc .= '<div class="level3">';
                 $doc .= '<div class="table"><table class="inline"><tbody>';
-                $doc .= '<tr><th>Description</th><td colspan="2">'.$method['desc'].
+                $doc .= '<tr><th>Description</th><td colspan="2">' . $method['desc'] .
                     '</td></tr>';
                 if ($method['params']) {
                     $c = count($method['params']);
-                    $doc .= '<tr><th rowspan="'.$c.'">Parameters</th><td>';
+                    $doc .= '<tr><th rowspan="' . $c . '">Parameters</th><td>';
                     $params = array();
                     foreach ($method['params'] as $desc => $type) {
-                        $params[] = hsc($desc).'</td><td>'.hsc($type);
+                        $params[] = hsc($desc) . '</td><td>' . hsc($type);
                     }
-                    $doc .= join('</td></tr><tr><td>', $params).'</td></tr>';
+                    $doc .= join('</td></tr><tr><td>', $params) . '</td></tr>';
                 }
                 if ($method['return']) {
-                    $doc .= '<tr><th>Return value</th><td>'.hsc(key($method['return'])).
-                        '</td><td>'.hsc(current($method['return'])).'</td></tr>';
+                    $doc .= '<tr><th>Return value</th><td>' . hsc(key($method['return'])) .
+                        '</td><td>' . hsc(current($method['return'])) . '</td></tr>';
                 }
                 $doc .= '</tbody></table></div>';
                 $doc .= '</div>';
@@ -215,7 +215,7 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
     protected function renderSyntaxTypes()
     {
         global $PARSER_MODES;
-        $doc  = '';
+        $doc = '';
 
         $doc .= '<div class="table"><table class="inline"><tbody>';
         foreach ($PARSER_MODES as $mode => $modes) {
@@ -245,13 +245,13 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
         foreach ($modes as $mode) {
             $compactmodes[$mode['sort']][] = $mode['mode'];
         }
-        $doc  = '';
+        $doc = '';
         $doc .= '<div class="table"><table class="inline"><tbody>';
 
         foreach ($compactmodes as $sort => $modes) {
             $rowspan = '';
             if (count($modes) > 1) {
-                $rowspan = ' rowspan="'.count($modes).'"';
+                $rowspan = ' rowspan="' . count($modes) . '"';
             }
 
             foreach ($modes as $index => $mode) {
@@ -261,7 +261,7 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
                 $doc .= '</td>';
 
                 if ($index === 0) {
-                    $doc .= '<td class="rightalign" '.$rowspan.'>';
+                    $doc .= '<td class="rightalign" ' . $rowspan . '>';
                     $doc .= $sort;
                     $doc .= '</td>';
                 }
@@ -287,16 +287,14 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
 
         $hid = '';
         if (($level >= $conf['toptoclevel']) && ($level <= $conf['maxtoclevel'])) {
-            $hid  = $renderer->_headerToLink($text, true);
+            $hid = $renderer->_headerToLink($text, true);
             $renderer->toc[] = array(
-                'hid'   => $hid,
+                'hid' => $hid,
                 'title' => $text,
-                'type'  => 'ul',
-                'level' => $level - $conf['toptoclevel'] + 1
+                'type' => 'ul',
+                'level' => $level - $conf['toptoclevel'] + 1,
             );
         }
         return $hid;
     }
 }
-
-//Setup VIM: ex: et ts=4 :

--- a/lib/plugins/info/syntax.php
+++ b/lib/plugins/info/syntax.php
@@ -121,13 +121,11 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
      * uses some of the original renderer methods
      *
      * @param string $type
-     * @param Doku_Renderer_xhtml $renderer
+     * @param Doku_Renderer $renderer
      */
-    protected function renderPlugins($type, Doku_Renderer_xhtml $renderer)
+    protected function renderPlugins($type, Doku_Renderer $renderer)
     {
         global $lang;
-        $renderer->doc .= '<ul>';
-
         $plugins = plugin_list($type);
         $plginfo = array();
 
@@ -139,22 +137,23 @@ class syntax_plugin_info extends DokuWiki_Syntax_Plugin
         }
 
         // list them
+        $renderer->listu_open();
         foreach ($plginfo as $info) {
-            $renderer->doc .= '<li><div class="li">';
+            $renderer->listitem_open(1);
+            $renderer->listcontent_open();
             $renderer->externallink($info['url'], $info['name']);
-            $renderer->doc .= ' ';
-            $renderer->doc .= '<em>'.$info['date'].'</em>';
-            $renderer->doc .= ' ';
-            $renderer->doc .= $lang['by'];
-            $renderer->doc .= ' ';
+            $renderer->cdata(' ');
+            $renderer->emphasis_open();
+            $renderer->cdata($info['date']);
+            $renderer->emphasis_close();
+            $renderer->cdata(' ' . $lang['by'] . ' ');
             $renderer->emaillink($info['email'], $info['author']);
-            $renderer->doc .= '<br />';
-            $renderer->doc .= strtr(hsc($info['desc']), array("\n"=>"<br />"));
-            $renderer->doc .= '</div></li>';
-            unset($po);
+            $renderer->linebreak();
+            $renderer->cdata($info['desc']);
+            $renderer->listcontent_close();
+            $renderer->listitem_close();
         }
-
-        $renderer->doc .= '</ul>';
+        $renderer->listu_close();
     }
 
     /**


### PR DESCRIPTION
I found myself debugging strange behavior in a DokuWiki and assumed a plugin was interfering with data through an action hook, but I wasn't sure which plugins might be registered. This new `~~INFO:hooks~~` syntax will be helpful for these cases.

A bit of cleanup also ended up in this PR. See individual commits.