### PR TITLE
Fix PHP warning if query part is stripped from search engine referrer URL

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1382,6 +1382,7 @@ function getGoogleQuery() {
     if(!preg_match('/(google|bing|yahoo|ask|duckduckgo|babylon|aol|yandex)/',$url['host'])) return '';
 
     $query = array();
+    if(!array_key_exists('query', $url)) return '';
     parse_str($url['query'], $query);
 
     $q = '';


### PR DESCRIPTION
Hey,
we noticed some unsightly PHP warnings when accessing our DokuWiki instance via Google search (not master, so line numbers are not accurate):
`Undefined array key "query" in [...]/inc/common.php on line 1365`
I think the issue is a missing check in `getGoogleQuery`:
```php
function getGoogleQuery() {
    /* @var Input $INPUT */
    global $INPUT;

    if(!$INPUT->server->has('HTTP_REFERER')) {
        return '';
    }
    $url = parse_url($INPUT->server->str('HTTP_REFERER'));

    // only handle common SEs
    if(!preg_match('/(google|bing|yahoo|ask|duckduckgo|babylon|aol|yandex)/',$url['host'])) return '';

    $query = array();
    parse_str($url['query'], $query); // <- No check if URL has a query part (i.e. if $url has key 'query')
    //...
}
```
The warning can be reproduced via
```bash
curl --header "Referer: https://www.google.com/" localhost:8000
```
`php -S` output:
```
[Fri Dec  9 18:28:54 2022] PHP 8.1.13 Development Server (http://localhost:8000) started
[Fri Dec  9 18:29:01 2022] [::1]:48210 Accepted
[Fri Dec  9 18:29:01 2022] PHP Warning:  Undefined array key "query" in /home/dromedar/Projects/PHP/dokuwiki/inc/common.php on line 1386
```
I believe a simple `if(!array_key_exists('query', $url)) return '';` before the line marked above should fix that.