### PR TITLE
Update ConfigParser.php to work on servers in which php_strip_whitespace is disabled

### DIFF
--- a/lib/plugins/config/core/ConfigParser.php
+++ b/lib/plugins/config/core/ConfigParser.php
@@ -28,7 +28,9 @@ class ConfigParser {
         if(!file_exists($file)) return array();
 
         $config = array();
-        $contents = @php_strip_whitespace($file);
+        if(function_exists('php_strip_whitespace')) {
+            $contents = @php_strip_whitespace($file);
+        }
 
         // fallback to simply including the file #3271
         if($contents === null) {


### PR DESCRIPTION
I am using a web server in which php_strip_whitespace is disabled, for security reasons, they say...

I noticed that the code is already prepared to work when the function does not work (// fallback to simply including the file #3271). However, when the function does not exist, the config page breaks.

To circumvent this, I just added a function_exists() condition to run php_strip_whitespace. I've performed some tests and everything seems to be working.

Thanks!