### PR TITLE
Avoid some unnecessary index file writes.

### DIFF
--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -120,10 +120,10 @@ class Indexer {
         }
 
         // arrive here with $words = array(wordlen => array(word => frequency))
-        $word_idx_modified = false;
         $index = array();   //resulting index
         foreach (array_keys($words) as $wlen) {
             $word_idx = $this->getIndex('w', $wlen);
+            $word_idx_modified = false;
             foreach ($words[$wlen] as $word => $freq) {
                 $word = (string)$word;
                 $wid = array_search($word, $word_idx, true);


### PR DESCRIPTION
The variable `word_idx modified` in the `getPageWords` indexer method should be reset to false for each word index file, or all unchanged word index files after the first changed one will be resaved unnecessarily.