### PR TITLE
use POSIX standard 'dot' built-in rather than 'source'

### DIFF
--- a/lib/scripts/jquery/update.sh
+++ b/lib/scripts/jquery/update.sh
@@ -9,7 +9,7 @@
 # @link   http://code.jquery.com/
 
 # load version infor from external file
-source ./versions
+. versions
 JQUI_HOST="https://code.jquery.com/ui/$JQUI_VERSION"
 JQUI_GIT="https://raw.githubusercontent.com/jquery/jquery-ui/$JQUI_VERSION/ui"
 


### PR DESCRIPTION
I ran into some trouble with an internal shell script when running Dokuwiki on FreeBSD. This change allowed me to execute the script. It replaces the use of 'source' to include an external file with the POSIX-standard 'dot' built-in. I have not tested this in bash, but it should work fine.

For reference:

- https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_18
- https://ss64.com/bash/source.html
