### PR TITLE
fix accidental overwriting of variable in bulkmailer #3862

### DIFF
--- a/inc/Subscriptions/BulkSubscriptionSender.php
+++ b/inc/Subscriptions/BulkSubscriptionSender.php
@@ -85,13 +85,13 @@ class BulkSubscriptionSender extends SubscriptionSender
                 $change_ids = [];
                 foreach ($changes as $rev) {
                     $n = 0;
+                    $pagelog = new PageChangeLog($rev['id']);
                     while (!is_null($rev) && $rev['date'] >= $lastupdate &&
                         ($INPUT->server->str('REMOTE_USER') === $rev['user'] ||
                             $rev['type'] === DOKU_CHANGE_TYPE_MINOR_EDIT)
                     ) {
-                        $pagelog = new PageChangeLog($rev['id']);
-                        $rev = $pagelog->getRevisions($n++, 1);
-                        $rev = (count($rev) > 0) ? $rev[0] : null;
+                        $revisions = $pagelog->getRevisions($n++, 1);
+                        $rev = (count($revisions) > 0) ? $pagelog->getRevisionInfo($revisions[0]) : null;
                     }
 
                     if (!is_null($rev) && $rev['date'] >= $lastupdate) {


### PR DESCRIPTION
When the bulkmailer tries to skip own or minor edits, it was overwriting $rev with a timestamp instead of using the proper array structure returned by getRevisionInfo().

This also moves the initialization of the PageChangeLog object out of the while loop to ensure it's inner caching mechanism is utilized when fetching the info.

This should fix #3862 @fiwswe can you confirm this?

To me it seems this has always been broken even when @micgro42 wrote it. At least it seems the relevant lines and functions haven't been changed in @ssahara's refactoring.
