### PR TITLE
Avoid indexing into log line

### DIFF
--- a/lib/plugins/logviewer/admin.php
+++ b/lib/plugins/logviewer/admin.php
@@ -98,10 +98,10 @@ class admin_plugin_logviewer extends DokuWiki_Admin_Plugin
         for ($i = 0; $i < $cnt; $i++) {
             $line = $lines[$i];
 
-            if ($line[0] === ' ' && $line[1] === ' ') {
+            if (substr($line, 0, 2) === '  ') {
                 // lines indented by two spaces are details, aggregate them
                 echo '<dd>';
-                while (isset($line[0]) && $line[0] === ' ' && isset($line[1]) && $line[1] === ' ') {
+                while (substr($line, 0, 2) === '  ') {
                     echo hsc(substr($line, 2)) . '<br />';
                     $i++;
                     $line = $lines[$i] ?? '';


### PR DESCRIPTION
Should fix #3868

A log file should be treated as untrusted input. Thus we can make no assumptions about its content. Assuming a line has at least 2 characters length is an assumption we can avoid by using `substr($line, 0, 2) === '  '` instead of `$line[0] === ' ' && $line[1] === ' '`. No need to separately check for empty or `null` either.