### PR TITLE
Fix for PHP 8.1 Warning

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -1379,6 +1379,7 @@ function getGoogleQuery() {
     $url = parse_url($INPUT->server->str('HTTP_REFERER'));
 
     // only handle common SEs
+    if(!array_key_exists('host', $url)) return '';
     if(!preg_match('/(google|bing|yahoo|ask|duckduckgo|babylon|aol|yandex)/',$url['host'])) return '';
 
     $query = array();


### PR DESCRIPTION
I am running Dokuwiki Release 2022-07-31a "Igor" and I noticed the following variety of PHP logs generated:
[01-Feb-2023 07:21:37 Asia/Kolkata] PHP Warning:  Undefined array key "host" in /home/ekvastra/wiki.ekvastra.in/inc/common.php on line 1362