### PR TITLE
inc/template.php on line 1805 dokuwiki mode_ tpl_readthedokus loggedIn notFound ">

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -1802,7 +1802,7 @@ function tpl_classes() {
         'mode_'.$ACT,
         'tpl_'.$conf['template'],
         $INPUT->server->bool('REMOTE_USER') ? 'loggedIn' : '',
-        (isset($INFO) && $INFO['exists']) ? '' : 'notFound',
+        (isset($INFO['exists']) && $INFO['exists']) ? '' : 'notFound',
         ($ID == $conf['start']) ? 'home' : '',
     );
     return join(' ', $classes);


### PR DESCRIPTION
This PR fixes a message shown at the top of the Media Manager into Argon Alternative and Read the Dokus templates, as can be seen at https://github.com/my17560/dokuwiki-template-readthedokus/issues/29