### PR TITLE
Add remote API to extension manager

### DIFF
--- a/lib/plugins/extension/ExtensionApiResponse.php
+++ b/lib/plugins/extension/ExtensionApiResponse.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace dokuwiki\plugin\extension;
+
+use dokuwiki\Remote\Response\ApiResponse;
+
+class ExtensionApiResponse extends ApiResponse
+{
+    protected Extension $extension;
+
+    /** @var string The type of this extension ("plugin" or "template") */
+    public $type;
+
+    /** @var string The id of this extension (templates are prefixed with "template") */
+    public $id;
+
+    /** @var string The base name of this extension */
+    public $base;
+
+    /** @var string The display name of this extension */
+    public $name;
+
+    /** @var string The installed version/date of this extension */
+    public $version;
+
+    /** @var string The author of this extension */
+    public $author;
+
+    /** @var string The description of this extension */
+    public $description;
+
+    /** @var bool Whether this extension is installed */
+    public $isInstalled;
+
+    /** @var bool Whether this extension is enabled */
+    public $isEnabled;
+
+    /** @var bool Whether an update is available */
+    public $updateAvailable;
+
+    /** @var bool Whether this extension is bundled with DokuWiki */
+    public $isBundled;
+
+    /** @var bool Whether this extension is under git control */
+    public $isGitControlled;
+
+    /** @var string[] Notices for this extension */
+    public $notices;
+
+    /** @var string Documentation URL for this extension */
+    public $url;
+
+    /** @var string[] The component types this plugin provides */
+    public $componentTypes;
+
+    /** @var string The last available remote update date */
+    public $lastUpdate;
+
+    /** @var string The download URL for this extension */
+    public string $downloadURL;
+
+    /**
+     * Constructor
+     *
+     * @param Extension $extension The extension to create the response for
+     */
+    public function __construct(Extension $extension)
+    {
+        $this->extension = $extension;
+        $this->type = $extension->getType();
+        $this->id = $extension->getId();
+        $this->base = $extension->getBase();
+        $this->name = $extension->getDisplayName();
+        $this->version = $extension->getInstalledVersion();
+        $this->author = $extension->getAuthor();
+        $this->description = $extension->getDescription();
+        $this->isInstalled = $extension->isInstalled();
+        $this->isEnabled = $extension->isEnabled();
+        $this->updateAvailable = $extension->isUpdateAvailable();
+        $this->isBundled = $extension->isBundled();
+        $this->isGitControlled = $extension->isGitControlled();
+        $this->componentTypes = $extension->getComponentTypes();
+        $this->lastUpdate = $extension->getLastUpdate();
+        $this->url = $extension->getURL();
+        $this->downloadURL = $extension->getDownloadURL();
+
+        // Add notices
+        $this->notices = array_merge(...array_values(Notice::list($extension)));
+    }
+
+    /** @inheritdoc */
+    public function __toString()
+    {
+        return $this->extension->getId();
+    }
+}

--- a/lib/plugins/extension/remote.php
+++ b/lib/plugins/extension/remote.php
@@ -1,0 +1,149 @@
+<?php
+
+use dokuwiki\Extension\RemotePlugin;
+use dokuwiki\plugin\extension\Extension;
+use dokuwiki\plugin\extension\ExtensionApiResponse;
+use dokuwiki\plugin\extension\Installer;
+use dokuwiki\plugin\extension\Local;
+use dokuwiki\plugin\extension\Repository;
+use dokuwiki\Remote\AccessDeniedException;
+
+/**
+ * DokuWiki Plugin extension (Remote Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author Andreas Gohr <andi@splitbrain.org>
+ */
+class remote_plugin_extension extends RemotePlugin
+{
+    /**
+     * List installed extensions
+     *
+     * This lists all installed extensions. The list is not sorted in any way.
+     *
+     * @return ExtensionApiResponse[] The list of installed extensions and their details
+     */
+    public function list()
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to access extensions', 114);
+        }
+
+        $extensions = (new Local())->getExtensions();
+        Repository::getInstance()->initExtensions(array_keys($extensions));
+
+        return array_values(
+            array_map(
+                static fn($extension) => new ExtensionApiResponse($extension),
+                $extensions
+            )
+        );
+    }
+
+    /**
+     * Search for extensions in the repository
+     *
+     * @param string $query The keyword(s) to search for
+     * @param int $max Maximum number of results (default 10)
+     * @return ExtensionApiResponse[] List of matching extensions
+     */
+    public function search($query, $max = 10)
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to access extensions', 114);
+        }
+
+        $repo = Repository::getInstance();
+        $result = $repo->searchExtensions($query);
+
+        if ($max > 0) {
+            $result = array_slice($result, 0, $max);
+        }
+
+        return array_values(
+            array_map(
+                static fn($extension) => new ExtensionApiResponse($extension),
+                $result
+            )
+        );
+    }
+
+    /**
+     * Enable a specific extension
+     *
+     * @param string $extension Extension ID to enable
+     * @return bool Success status
+     */
+    public function enable($extension)
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to manage extensions', 114);
+        }
+
+        $ext = Extension::createFromId($extension);
+        $ext->enable();
+        return true;
+    }
+
+    /**
+     * Disable a specific extension
+     *
+     * @param string $extension Extension ID to disable
+     * @return bool Success status
+     */
+    public function disable($extension)
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to manage extensions', 114);
+        }
+
+        $ext = Extension::createFromId($extension);
+        $ext->disable();
+        return true;
+    }
+
+    /**
+     * Install a specific extension
+     *
+     * This will also install dependencies, so more than the given extension may be installed.
+     *
+     * @param string $extension Extension ID or download URL
+     * @return string[] List of installed extensions
+     */
+    public function install($extension)
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to manage extensions', 114);
+        }
+
+        $installer = new Installer(true);
+        $installer->installFromId($extension);
+
+        return array_keys(
+            array_filter(
+                $installer->getProcessed(),
+                static fn($status) => (
+                    $status == Installer::STATUS_INSTALLED || $status == Installer::STATUS_UPDATED
+                )
+            )
+        );
+    }
+
+    /**
+     * Uninstall a specific extension
+     *
+     * @param string $extension Extension ID to uninstall
+     * @return bool Success status
+     */
+    public function uninstall($extension)
+    {
+        if (!auth_isadmin()) {
+            throw new AccessDeniedException('Only admins are allowed to manage extensions', 114);
+        }
+
+        $ext = Extension::createFromId($extension);
+        $installer = new Installer();
+        $installer->uninstall($ext);
+        return true;
+    }
+}


### PR DESCRIPTION
Adding remote support to the extension manager had been the original goal of the rewrite, but in the end I forgot to add a remote component. This remedies that. I might include it in the upcoming hotfix.