### PR TITLE
ExtensionManager: get base from plugin classes. fixes #4484

### DIFF
--- a/lib/plugins/extension/_test/InstallerTest.php
+++ b/lib/plugins/extension/_test/InstallerTest.php
@@ -28,6 +28,7 @@ class InstallerTest extends DokuWikiTest
             'plgsub6' => ['plgsub6', ['plugin6' => 'plugin']],
             'plugin1' => ['plugin1', ['plugin1' => 'plugin']],
             'plugin2' => ['plugin2', ['plugin2' => 'plugin']],
+            'plugin3' => ['plugin3', ['foobar' => 'plugin']],
             'template1' => ['template1', ['template1' => 'template']],
             'tplfoo5' => ['tplfoo5', ['template5' => 'template']],
             'tplsub3' => ['tplsub3', ['template3' => 'template']],

--- a/lib/plugins/extension/_test/testdata/plugin3/syntax.php
+++ b/lib/plugins/extension/_test/testdata/plugin3/syntax.php
@@ -1,0 +1,5 @@
+<?php
+
+class syntax_plugin_foobar extends DokuWiki_Plugin {
+
+}

--- a/lib/plugins/extension/cli.php
+++ b/lib/plugins/extension/cli.php
@@ -206,7 +206,7 @@ class cli_plugin_extension extends CLIPlugin
 
             try {
                 if (preg_match("/^https?:\/\//i", $extname)) {
-                    $installer->installFromURL($extname, true);
+                    $installer->installFromURL($extname);
                 } else {
                     $installer->installFromId($extname);
                 }


### PR DESCRIPTION
When installing a plugin that has no plugin.info.txt, we need to figure out where it belongs from other data. Previously we checked the archive name or folder within. This will fail for archives generated from github branches as the plugin would be named "dokuwiki-plugin-foobar" or "master".

This implements looking for known plugin type php files, parsing them with PHP's parser and extracting the class name. The base name is in that class name.

Seems to work fine in my unit and manual tests.