### PR TITLE
Remove HTML entities from manifest

### DIFF
--- a/inc/Manifest.php
+++ b/inc/Manifest.php
@@ -15,15 +15,15 @@ class Manifest
         $manifest['scope'] = DOKU_REL;
 
         if (empty($manifest['name'])) {
-            $manifest['name'] = strip_tags($conf['title']);
+            $manifest['name'] = html_entity_decode(strip_tags($conf['title']));
         }
 
         if (empty($manifest['short_name'])) {
-            $manifest['short_name'] = strip_tags($conf['title']);
+            $manifest['short_name'] = html_entity_decode(strip_tags($conf['title']));
         }
 
         if (empty($manifest['description'])) {
-            $manifest['description'] = strip_tags($conf['tagline']);
+            $manifest['description'] = html_entity_decode(strip_tags($conf['tagline']));
         }
 
         if (empty($manifest['start_url'])) {


### PR DESCRIPTION
This is related to #4513. It adds the removal of HTML entities from the strings.

It may depend on the PHP INI setting `default_charset` to be `'UTF-8'` (default) to work correctly in all situations. I suspect this would be the normal case, but there may be exceptions in some installations which might then yield weird results.

But the worst case should be no worse than leaving the HTML entities in the strings unchanged. So I think this might be an improvement.

Thanks go to @Michaelsy for suggesting this in the [Forum](https://forum.dokuwiki.org/d/23450-htm-in-tagline-vs-manifest-description/9).

fiwswe