### PR TITLE
refactor preference cookie handling. fixes #4544

### DIFF
--- a/_test/tests/inc/common_dokupref.test.php
+++ b/_test/tests/inc/common_dokupref.test.php
@@ -81,6 +81,20 @@ class common_dokupref_test extends DokuWikiTest {
         $this->assertEquals('nil', get_doku_pref('foo2', 'nil'));
     }
 
+    // #4544
+    function test_set_same() {
+        set_doku_pref('foo1', 'bar1');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'), 'first set');
+
+        set_doku_pref('foo2', 'bar2');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'), 'second set');
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'), 'second set');
+
+        // setting the same value for foo2 should not destroy the cookie
+        set_doku_pref('foo2', 'bar2');
+        $this->assertEquals('bar1', get_doku_pref('foo1', 'nil'), 'third set');
+        $this->assertEquals('bar2', get_doku_pref('foo2', 'nil'), 'third set');
+    }
 }
 
 //Setup VIM: ex: et ts=4 :

--- a/inc/PrefCookie.php
+++ b/inc/PrefCookie.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace dokuwiki;
+
+/**
+ * The preference cookie is used to store small user preference data
+ *
+ * The cookie is written from PHP (using this class) and from JavaScript (using the DokuCookie object).
+ *
+ * Data is stored as key#value#key#value string, with all keys and values being urlencoded
+ */
+class PrefCookie
+{
+    const COOKIENAME = 'DOKU_PREFS';
+
+    /** @var string[] */
+    protected array $data = [];
+
+    /**
+     * Initialize the class from the cookie data
+     */
+    public function __construct()
+    {
+        $this->data = $this->decodeData($_COOKIE[self::COOKIENAME] ?? '');
+    }
+
+    /**
+     * Get a preference from the cookie
+     *
+     * @param string $pref The preference to read
+     * @param mixed $default The default to return if no preference is set
+     * @return mixed
+     */
+    public function get(string $pref, $default = null)
+    {
+        return $this->data[$pref] ?? $default;
+    }
+
+    /**
+     * Set a preference
+     *
+     * This will trigger a setCookie header and needs to be called before any output is sent
+     *
+     * @param string $pref The preference to set
+     * @param string|null $value The value to set. Null to delete a value
+     * @return void
+     */
+    public function set(string $pref, ?string $value): void
+    {
+        if ($value === null) {
+            if (isset($this->data[$pref])) {
+                unset($this->data[$pref]);
+            }
+        } else {
+            $this->data[$pref] = $value;
+        }
+
+        $this->sendCookie();
+    }
+
+    /**
+     * Set the cookie header
+     *
+     * @return void
+     */
+    protected function sendCookie(): void
+    {
+        global $conf;
+
+        ksort($this->data); // sort by key
+        $olddata = $_COOKIE[self::COOKIENAME] ?? '';
+        $newdata = self::encodeData($this->data);
+
+        // no need to set a cookie when it's the same as before
+        if ($olddata == $newdata) return;
+
+        // update the cookie data for the current request
+        $_COOKIE[self::COOKIENAME] = $newdata;
+
+        // no cookies to set when running on CLI
+        if (PHP_SAPI === 'cli') return;
+
+        // set the cookie header
+        setcookie(self::COOKIENAME, $newdata, [
+            'expires' => time() + 365 * 24 * 3600,
+            'path' => empty($conf['cookiedir']) ? DOKU_REL : $conf['cookiedir'],
+            'secure' => ($conf['securecookie'] && Ip::isSsl()),
+            'samesite' => 'Lax'
+        ]);
+    }
+
+    /**
+     * Decode the cookie data (if any)
+     *
+     * @return array the cookie data as associative array
+     */
+    protected function decodeData(string $rawdata): array
+    {
+        $data = [];
+        if($rawdata === '') return $data;
+        $parts = explode('#', $rawdata);
+        $count = count($parts);
+
+        for ($i = 0; $i < $count; $i += 2) {
+            if (!isset($parts[$i + 1])) {
+                Logger::error('Odd entries in user\'s pref cookie', $rawdata);
+                continue;
+            }
+
+            // if the entry was duplicated, it will be overwritten. Takes care of #2721
+            $data[urldecode($parts[$i])] = urldecode($parts[$i + 1]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Encode the given cookie data
+     *
+     * @param array $data the cookie data as associative array
+     * @return string the raw string to save in the cookie
+     */
+    protected function encodeData(array $data): string
+    {
+        $parts = [];
+
+        foreach ($data as $key => $val) {
+            $val = (string)$val; // we only store strings
+            $parts[] = join('#', [rawurlencode($key), rawurlencode($val)]);
+        }
+
+        return join('#', $parts);
+    }
+}


### PR DESCRIPTION
This refactors the DOKU_PREF cookie handling on the PHP side into a class. It makes encoding/decoding more explicit and easier to understand.

The new class is used in set_doku_pref() and get_doku_pref() which have not been deprecated for now.