### PR TITLE
minor typo in install.html

### DIFF
--- a/inc/lang/en/install.html
+++ b/inc/lang/en/install.html
@@ -1,4 +1,4 @@
-<p>This page assists in the first time installation and configuration of <a href="http://dokuwiki.org">Dokuwiki</a>. More info on this installer is available on it's own <a href="http://dokuwiki.org/installer">documentation page</a>.</p>
+<p>This page assists in the first time installation and configuration of <a href="http://dokuwiki.org">Dokuwiki</a>. More info on this installer is available on its own <a href="http://dokuwiki.org/installer">documentation page</a>.</p>
 
 <p>DokuWiki uses ordinary files for the storage of wiki pages and other information associated with those pages (e.g. images, search indexes, old revisions, etc).  In order to operate successfully DokuWiki <strong>must</strong> have write access to the directories that hold those files.  This installer is not capable of setting up directory permissions. That normally needs to be done directly on a command shell or if you are using hosting, through FTP or your hosting control panel (e.g. cPanel).</p>
 


### PR DESCRIPTION
Minor typo in install.html, changed "info available on it's own page" to "info available on its own page".