### PR TITLE
build action: improve export-ignore handling. fixes #4555

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -56,9 +56,13 @@ jobs:
 
       - name: Build Archives
         run: |
-          for F in $(awk '/export-ignore/{print $1}' .gitattributes); do
-            rm -rf $F
+          git ls-files | while read path; do
+            if git check-attr export-ignore -- "$path" | grep -q 'export-ignore: set'; then
+              echo "Deleting $path"
+              rm -f "$path"
+            fi
           done
+          find . -type d -empty -delete
           mkdir -p data/pages/playground
           echo "====== PlayGround ======" > data/pages/playground/playground.txt
           cd ..


### PR DESCRIPTION
Insted of parsing the .gitattributes ourselves, we let git do it. All ignored files are then deleted. Afterwards a find removes any dangling directories.

Hard to test without building a release. I did test the individual parts though.