### PR TITLE
set explicit referrer-policy

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -18,7 +18,10 @@ function act_dispatch()
     // always initialize on first dispatch (test request may dispatch mutliple times on one request)
     $router = ActionRouter::getInstance(true);
 
-    $headers = ['Content-Type: text/html; charset=utf-8'];
+    $headers = [
+        'Content-Type: text/html; charset=utf-8',
+        'Referrer-Policy: strict-origin-when-cross-origin',
+    ];
     Event::createAndTrigger('ACTION_HEADERS_SEND', $headers, 'act_sendheaders');
 
     // clear internal variables


### PR DESCRIPTION
This emits a referrer policy header. It will instruct browsers to send an abbreviated (host name only) referrer header on cross-origin requests.

This fixes issues with YouTube embeds reported at
splitbrain/dokuwiki-plugin-vshare#154

This setting is the default in many browsers, so it doesn't change behavior for most people.

More info at:

* https://github.com/splitbrain/dokuwiki-plugin-vshare/issues/154
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy