### PR TITLE
improve toolbar picker accessibility

### DIFF
--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -280,4 +280,15 @@ function fixtxt(str){
 jQuery(function () {
     initToolbar('tool__bar','wiki__text',toolbar);
     jQuery('#tool__bar').attr('role', 'toolbar');
+
+    jQuery(document).on('focusout', function(event) {
+        if (!event.relatedTarget || !event.relatedTarget.closest('.picker')) {
+            pickerClose();
+        }
+    });
+    jQuery(document).on('keydown', function(event) {
+        if (event.key === 'Escape') {
+            pickerClose();
+        }
+    });
 });

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -56,10 +56,7 @@ function initToolbar(tbid,edid,tb, allowblock){
             if(pickerid !== ''){
                 $toolbar.append($btn);
                 $toolbar.append(jQuery('#'+pickerid));
-                $btn.attr('aria-controls', pickerid);
-                if (actionFunc === 'addBtnActionPicker') {
-                    $btn.attr('aria-haspopup', 'true');
-                }
+                $btn.attr('aria-expanded', 'false');
             }
             return;
         }
@@ -241,8 +238,10 @@ function pickerToggle(pickerid,$btn){
         pos = $btn.offset();
     if ($picker.hasClass('a11y')) {
         $picker.removeClass('a11y').attr('aria-hidden', 'false');
+        $btn.attr('aria-expanded', 'true');
     } else {
         $picker.addClass('a11y').attr('aria-hidden', 'true');
+        $btn.attr('aria-expanded', 'false');
     }
     var picker_left = pos.left + 3,
         picker_width = $picker.width(),
@@ -267,6 +266,7 @@ function pickerToggle(pickerid,$btn){
  */
 function pickerClose(){
     jQuery('.picker').addClass('a11y').attr('aria-hidden', 'true');
+    jQuery('.picker').prev().attr('aria-expanded', 'false');
 }
 
 

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -55,6 +55,7 @@ function initToolbar(tbid,edid,tb, allowblock){
             var pickerid = window[actionFunc]($btn, val, edid);
             if(pickerid !== ''){
                 $toolbar.append($btn);
+                $toolbar.append(jQuery('#'+pickerid));
                 $btn.attr('aria-controls', pickerid);
                 if (actionFunc === 'addBtnActionPicker') {
                     $btn.attr('aria-haspopup', 'true');

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -265,7 +265,7 @@ function pickerToggle(pickerid,$btn){
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function pickerClose(){
-    jQuery('.picker').addClass('a11y');
+    jQuery('.picker').addClass('a11y').attr('aria-hidden', 'true');
 }
 
 

--- a/lib/scripts/toolbar.js
+++ b/lib/scripts/toolbar.js
@@ -194,7 +194,7 @@ function tb_autohead(btn, props, edid){
 function addBtnActionPicker($btn, props, edid) {
     var pickerid = 'picker'+(pickercounter++);
     var picker = createPicker(pickerid, props, edid);
-    jQuery(picker).attr('aria-hidden', 'true');
+    jQuery(picker).prop('hidden', true);
 
     $btn.click(
         function(e) {
@@ -237,10 +237,10 @@ function pickerToggle(pickerid,$btn){
     var $picker = jQuery('#' + pickerid),
         pos = $btn.offset();
     if ($picker.hasClass('a11y')) {
-        $picker.removeClass('a11y').attr('aria-hidden', 'false');
+        $picker.removeClass('a11y').prop('hidden', false);
         $btn.attr('aria-expanded', 'true');
     } else {
-        $picker.addClass('a11y').attr('aria-hidden', 'true');
+        $picker.addClass('a11y').prop('hidden', true);
         $btn.attr('aria-expanded', 'false');
     }
     var picker_left = pos.left + 3,
@@ -265,7 +265,7 @@ function pickerToggle(pickerid,$btn){
  * @author Andreas Gohr <andi@splitbrain.org>
  */
 function pickerClose(){
-    jQuery('.picker').addClass('a11y').attr('aria-hidden', 'true');
+    jQuery('.picker').addClass('a11y').prop('hidden', true);
     jQuery('.picker').prev().attr('aria-expanded', 'false');
 }
 


### PR DESCRIPTION
This fixes the picker-related items from #3449 and #3450.

I tried to make the changes minimally invasive. For example, the pickers are still *created* at the end of the page, but then they are moved to come immediately after the button that triggers them.

I took some inspiration from [dropdowns in bootstrap](https://getbootstrap.com/docs/5.3/components/dropdowns/), notably that they are modeled as generic disclosure elements and that focusout/escape close the picker.

The picker for headings contains buttons with access keys. I am not entirely sure what effect this change has on those access keys. I tested Chrome and Firefox. In Firefox the access keys worked fine. In Chrome the access keys for headings didn't work even before this change.