### PR TITLE
feat: add diff to disableactions config option

### DIFF
--- a/inc/ChangeLog/RevisionInfo.php
+++ b/inc/ChangeLog/RevisionInfo.php
@@ -261,6 +261,11 @@ class RevisionInfo
     public function showIconCompareWithPrevious()
     {
         global $lang;
+
+        if (!actionOK('diff')) {
+            return '<img src="' . DOKU_BASE . 'lib/images/blank.gif" width="15" height="11" alt="" />';
+        }
+
         $id = $this->val('id');
 
         $href = '';
@@ -303,6 +308,11 @@ class RevisionInfo
     public function showIconCompareWithCurrent()
     {
         global $lang;
+
+        if (!actionOK('diff')) {
+            return '<img src="' . DOKU_BASE . 'lib/images/blank.gif" width="15" height="11" alt="" />';
+        }
+
         $id = $this->val('id');
         $rev = $this->isCurrent() ? '' : $this->val('date');
 

--- a/inc/Ui/MediaRevisions.php
+++ b/inc/Ui/MediaRevisions.php
@@ -105,7 +105,9 @@ class MediaRevisions extends Revisions
         $form->addTagClose('ul');  // end of revision list
 
         // show button for diff view
-        $form->addButton('do[diff]', $lang['diff2'])->attr('type', 'submit');
+        if (actionOK('diff')) {
+            $form->addButton('do[diff]', $lang['diff2'])->attr('type', 'submit');
+        }
 
         $form->addTagClose('div'); // close div class=no
 

--- a/inc/Ui/PageRevisions.php
+++ b/inc/Ui/PageRevisions.php
@@ -104,7 +104,9 @@ class PageRevisions extends Revisions
         $form->addTagClose('ul');  // end of revision list
 
         // show button for diff view
-        $form->addButton('do[diff]', $lang['diff2'])->attr('type', 'submit');
+        if (actionOK('diff')) {
+            $form->addButton('do[diff]', $lang['diff2'])->attr('type', 'submit');
+        }
 
         $form->addTagClose('div'); // close div class=no
 

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -153,6 +153,7 @@ $meta['rememberme'] = ['onoff'];
 $meta['disableactions'] = ['disableactions',
     '_choices' => [
         'backlink',
+        'diff',
         'index',
         'recent',
         'revisions',


### PR DESCRIPTION
## Summary

Adds `diff` as a checkbox in the `disableactions` config setting so admins can disable the diff action independently of other actions like revisions or edit.

## Why this matters

Admins running CMS-style DokuWiki sites may want to hide diff functionality from users while keeping revision history accessible. Currently there's no way to disable diff through the config manager UI - it requires manual config editing and diff links still appear in revision lists.

## Changes

- `lib/plugins/config/settings/config.metadata.php`: Add `'diff'` to the `_choices` array (in alphabetical order)
- `inc/ChangeLog/RevisionInfo.php`: Add `actionOK('diff')` early return in `showIconCompareWithPrevious()` and `showIconCompareWithCurrent()` to hide diff icons when disabled
- `inc/Ui/PageRevisions.php`: Guard the "Compare" submit button with `actionOK('diff')`
- `inc/Ui/MediaRevisions.php`: Same guard for media revision comparisons

The `ActionRouter` (line 209) already handles disabled actions generically, so navigating to `?do=diff` when diff is disabled will show the appropriate error. These changes ensure the UI is consistent by hiding diff-related links and buttons.

## Testing

- Verified the `_choices` array stays in alphabetical order
- The `actionOK()` function is the standard pattern used throughout the codebase (`RevisionInfo.php:343`, `Ui/Login.php:71`, `Ui/UserProfile.php:42`, etc.)

Fixes #4504

This contribution was developed with AI assistance (Claude Code).