### PR TITLE
Less ubiquitous feed caching. addresses #4574

### DIFF
--- a/_test/tests/Feed/FeedCreatorOptionsTest.php
+++ b/_test/tests/Feed/FeedCreatorOptionsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace dokuwiki\test\Feed;
+
+use dokuwiki\Feed\FeedCreatorOptions;
+
+class FeedCreatorOptionsTest extends \DokuWikiTest
+{
+    // region getCacheKey mode behavior
+
+    public function testRecentModeIsCacheable()
+    {
+        $options = new FeedCreatorOptions(['feed_mode' => 'recent']);
+        $this->assertNotNull($options->getCacheKey());
+    }
+
+    public function testListModeIsNotCacheable()
+    {
+        $options = new FeedCreatorOptions(['feed_mode' => 'list', 'namespace' => 'wiki']);
+        $this->assertNull($options->getCacheKey());
+    }
+
+    public function testSearchModeIsNotCacheable()
+    {
+        $options = new FeedCreatorOptions(['feed_mode' => 'search', 'search_query' => 'test']);
+        $this->assertNull($options->getCacheKey());
+    }
+
+    public function testUnknownModeIsNotCacheable()
+    {
+        $options = new FeedCreatorOptions(['feed_mode' => 'foobar']);
+        $this->assertNull($options->getCacheKey());
+    }
+
+    // endregion
+
+    // region irrelevant params don't affect recent key
+
+    public function testSortDoesNotAffectRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent', 'sort' => 'natural']);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'sort' => 'date']);
+        $this->assertSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    public function testSearchQueryDoesNotAffectRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent']);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'search_query' => 'anything']);
+        $this->assertSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    // endregion
+
+    // region relevant params DO affect recent key
+
+    public function testNamespaceAffectsRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent', 'namespace' => '']);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'namespace' => 'wiki']);
+        $this->assertNotSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    public function testItemsAffectsRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent', 'items' => 10]);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'items' => 20]);
+        $this->assertNotSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    public function testShowMinorAffectsRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent', 'show_minor' => false]);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'show_minor' => true]);
+        $this->assertNotSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    public function testContentTypeAffectsRecentKey()
+    {
+        $a = new FeedCreatorOptions(['feed_mode' => 'recent', 'content_type' => 'pages']);
+        $b = new FeedCreatorOptions(['feed_mode' => 'recent', 'content_type' => 'both']);
+        $this->assertNotSame($a->getCacheKey(), $b->getCacheKey());
+    }
+
+    // endregion
+
+    // region items clamping
+
+    public function testItemsClampedToMinimumOne()
+    {
+        $options = new FeedCreatorOptions(['items' => 0]);
+        $this->assertSame(1, $options->options['items']);
+    }
+
+    public function testItemsClampedToMaximum()
+    {
+        global $conf;
+        $options = new FeedCreatorOptions(['items' => 999999]);
+        $this->assertSame($conf['recent'] * 5, $options->options['items']);
+    }
+
+    public function testItemsValidValuePassesThrough()
+    {
+        $options = new FeedCreatorOptions(['items' => 10]);
+        $this->assertSame(10, $options->options['items']);
+    }
+
+    // endregion
+}

--- a/feed.php
+++ b/feed.php
@@ -33,20 +33,22 @@ if (!actionOK('rss')) {
 
 $options = new FeedCreatorOptions();
 
-// the feed is dynamic - we need a cache for each combo
-// (but most people just use the default feed so it's still effective)
-$key = implode('$', [
-    $options->getCacheKey(),
+// we only cache the recent cache, but do so based on dynamic parameters
+// other modes are never cached and always created on the fly
+$cache = null;
+$cacheKey = $options->getCacheKey([
     $INPUT->server->str('REMOTE_USER'),
     $INPUT->server->str('HTTP_HOST'),
-    $INPUT->server->str('SERVER_PORT')
+    $INPUT->server->str('SERVER_PORT'),
 ]);
-$cache = new Cache($key, '.feed');
+if ($cacheKey !== null) {
+    $cache = new Cache($cacheKey, '.feed');
 
-// prepare cache depends
-$depends['files'] = getConfigFiles('main');
-$depends['age'] = $conf['rss_update'];
-$depends['purge'] = $INPUT->bool('purge');
+    // prepare cache depends
+    $depends['files'] = getConfigFiles('main');
+    $depends['age'] = $conf['rss_update'];
+    $depends['purge'] = $INPUT->bool('purge');
+}
 
 // check cacheage and deliver if nothing has changed since last
 // time or the update interval has not passed, also handles conditional requests
@@ -54,7 +56,7 @@ header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Pragma: public');
 header('Content-Type: ' . $options->getMimeType());
 header('X-Robots-Tag: noindex');
-if ($cache->useCache($depends)) {
+if ($cache?->useCache($depends)) {
     http_conditionalRequest($cache->getTime());
     if ($conf['allowdebug']) header("X-CacheUsed: $cache->cache");
     echo $cache->retrieveCache();
@@ -66,7 +68,7 @@ if ($cache->useCache($depends)) {
 // create new feed
 try {
     $feed = (new FeedCreator($options))->build();
-    $cache->storeCache($feed);
+    $cache?->storeCache($feed);
     echo $feed;
 } catch (Exception $e) {
     http_status(500);

--- a/inc/Feed/FeedCreatorOptions.php
+++ b/inc/Feed/FeedCreatorOptions.php
@@ -50,6 +50,8 @@ class FeedCreatorOptions
         'content_type' => 'pages',
         'guardmail' => 'none',
         'title' => '',
+        'cache_allow' => false,
+        'cache_key' => '',
     ];
 
     /**
@@ -81,7 +83,7 @@ class FeedCreatorOptions
             $conf['rss_content']
         );
         $this->options['namespace'] = $INPUT->filter('cleanID')->str('ns');
-        $this->options['items'] = max(0, $INPUT->int('num', $conf['recent']));
+        $this->options['items'] = $INPUT->int('num', $conf['recent']);
         $this->options['show_minor'] = $INPUT->bool('minor');
         $this->options['show_deleted'] = $conf['rss_show_deleted'];
         $this->options['show_summary'] = $conf['rss_show_summary'];
@@ -105,6 +107,11 @@ class FeedCreatorOptions
         $this->options['subtitle'] = $conf['tagline'];
 
         $this->options = array_merge($this->options, $options);
+        // clamp items to a reasonable range to prevent cache DoS via arbitrary num values
+        $this->options['items'] = min(max(1, (int)$this->options['items']), $conf['recent'] * 5);
+        // only the recent mode is cached by default to prevent cache DoS;
+        // plugins can enable caching for their modes via FEED_OPTS_POSTPROCESS
+        $this->options['cache_allow'] = ($this->options['feed_mode'] === 'recent');
 
         // initialization finished, let plugins know
         $eventData = [
@@ -116,13 +123,32 @@ class FeedCreatorOptions
     /**
      * The cache key to use for a feed with these options
      *
-     * Does not contain user or host specific information yet
+     * Only includes options that affect the current mode's output.
      *
-     * @return string
+     * @param string[] $additional additional key parts (e.g. user, host, port)
+     * @return string|null null if the feed should not be cached
      */
-    public function getCacheKey()
+    public function getCacheKey(array $additional = []): ?string
     {
-        return implode('', array_values($this->options));
+        if (!$this->options['cache_allow']) {
+            return null;
+        }
+
+        return implode('$', array_merge([
+            $this->options['feed_mode'],
+            $this->options['type'],
+            $this->options['link_to'],
+            $this->options['item_content'],
+            $this->options['show_summary'],
+            $this->options['guardmail'],
+            $this->options['namespace'],
+            $this->options['items'],
+            $this->options['show_minor'],
+            $this->options['show_deleted'],
+            $this->options['only_new'],
+            $this->options['content_type'],
+            $this->options['cache_key'],
+        ], $additional));
     }
 
     /**

--- a/inc/template.php
+++ b/inc/template.php
@@ -292,12 +292,6 @@ function tpl_metaheaders($alt = true)
                 'title' => $lang['btn_recent'],
                 'href' => DOKU_BASE . 'feed.php'
             ];
-            $head['link'][] = [
-                'rel' => 'alternate',
-                'type' => 'application/rss+xml',
-                'title' => $lang['currentns'],
-                'href' => DOKU_BASE . 'feed.php?mode=list&ns=' . (isset($INFO) ? $INFO['namespace'] : '')
-            ];
         }
         if (($ACT == 'show' || $ACT == 'search') && $INFO['writable']) {
             $head['link'][] = [


### PR DESCRIPTION
Instead of creating caches for each and every requested feed, only the recent feed is still cached.

The number of items is clamped to conf[recent]*5.

Plugins can influence the caching behavior via the existing FEED_OPTS_POSTPROCESS event by setting cache_allow to true and optionally adding their own cache key in cache_key

Additionally the per-namespace feed autodiscovery link from <head> pointing to list-mode feeds has been removed.