### PR TITLE
Limit namespace depth in io_createNamespace() #4613

### DIFF
--- a/_test/tests/inc/io_createnamespace.test.php
+++ b/_test/tests/inc/io_createnamespace.test.php
@@ -1,0 +1,32 @@
+<?php
+
+class io_createnamespace_test extends DokuWikiTest
+{
+    /**
+     * Test that io_createNamespace throws on excessively deep hierarchies
+     */
+    public function test_depth_limit()
+    {
+        $this->expectException(RuntimeException::class);
+
+        // build an ID with 200 segments — well above the 128 limit
+        $segments = array_fill(0, 200, 'ns');
+        $segments[] = 'file.txt';
+        $deep_id = implode(':', $segments);
+
+        io_createNamespace($deep_id, 'media');
+    }
+
+    /**
+     * Test that io_createNamespace still works for reasonable depths
+     */
+    public function test_normal_depth()
+    {
+        global $conf;
+
+        io_createNamespace('a:b:c:file.txt', 'media');
+
+        $path = $conf['mediadir'] . '/a/b/c';
+        $this->assertDirectoryExists($path, 'Normal namespace depth should be created');
+    }
+}

--- a/inc/io.php
+++ b/inc/io.php
@@ -538,9 +538,13 @@ function io_createNamespace($id, $ns_type = 'pages')
     // verify ns_type
     $types = ['pages' => 'wikiFN', 'media' => 'mediaFN'];
     if (!isset($types[$ns_type])) {
-        trigger_error('Bad $ns_type parameter for io_createNamespace().');
-        return;
+        throw new RuntimeException('Bad $ns_type parameter for io_createNamespace().');
     }
+    // refuse to create excessively deep hierarchies #4613
+    if (substr_count($id, ':') >= 128) {
+        throw new RuntimeException('Refusing to create nested namespace hierarchy deeper than 128 levels');
+    }
+
     // make event list
     $missing = [];
     $ns_stack = explode(':', $id);


### PR DESCRIPTION
Throw a RuntimeException when the given ID contains 128 or more colon-separated segments, preventing creation of excessively deep directory hierarchies.