### PR TITLE
refactor(changelog): persist external-edit detection on first read

### DIFF
--- a/_test/tests/inc/changelog_getrelativerevision.test.php
+++ b/_test/tests/inc/changelog_getrelativerevision.test.php
@@ -15,12 +15,29 @@ class changelog_getrelativerevision_test extends DokuWikiTest {
     private $logline = "1362525899	127.0.0.1	E	mailinglist	pubcie	[Data entry] 	\n";
     private $pageid = 'mailinglist';
 
+    /** @var string original fixture content of the changelog, restored before each test */
+    private static $originalChangelog;
+
+    public static function setUpBeforeClass() : void {
+        parent::setUpBeforeClass();
+        self::$originalChangelog = file_get_contents(metaFN('mailinglist', '.changes'));
+    }
+
     function setup() : void {
         parent::setup();
         global $cache_revinfo;
         $cache =& $cache_revinfo;
         unset($cache['nonexist']);
         unset($cache['mailinglist']);
+        // Restore fixture state per test. Two tests in this class explicitly touch the
+        // page file forward (test_startatexactcurrentrev / test_iscurrentpagerevision /
+        // test_isnotcurrentpagerevision), and getCurrentRevisionInfo now persists the
+        // synthesized external-edit entry on first observation. Without restoring, the
+        // first such test mutates the changelog and subsequent tests trigger another
+        // round of "rescue" persistence (file mtime older than last log entry).
+        file_put_contents(metaFN('mailinglist', '.changes'), self::$originalChangelog);
+        @touch(wikiFN($this->pageid), 1374261194);
+        clearstatcache(false, wikiFN($this->pageid));
     }
 
     /**

--- a/_test/tests/inc/common_saveWikiText.test.php
+++ b/_test/tests/inc/common_saveWikiText.test.php
@@ -42,7 +42,6 @@ class common_saveWikiText_test extends DokuWikiTest {
         // second to last revision (optional), intended to check logline of previous external edits
         if ($expected2ndLastEntry && count($revisions) > 1) {
             $prevRevInfo = $pagelog->getRevisionInfo($revisions[1]);
-            unset($expected2ndLastEntry['timestamp']); // drop timestamp key
             $this->assertEquals($expected2ndLastEntry, $prevRevInfo);
         }
     }
@@ -75,9 +74,14 @@ class common_saveWikiText_test extends DokuWikiTest {
             $this->assertEquals($expectedCurrentEntry, $currentRevInfo);
 
         }
-        // attic
+        // attic — external edits/creates are now copied at first detection;
+        // deletes have no file to attic
         $attic = wikiFN($currentRevInfo['id'], $currentRevInfo['date']);
-        $this->assertFileDoesNotExist($attic, 'page does not yet exist in attic');
+        if ($currentRevInfo['type'] === DOKU_CHANGE_TYPE_DELETE) {
+            $this->assertFileDoesNotExist($attic, 'no attic for external delete');
+        } else {
+            $this->assertFileExists($attic, 'persisted external edit should have attic');
+        }
     }
 
 
@@ -424,18 +428,20 @@ class common_saveWikiText_test extends DokuWikiTest {
 
         $this->waitForTick(true); // wait for new revision ID
 
-        // 3.2 external edit (repeated, still no changelog exists)
+        // 3.2 external edit (3.1 was already persisted on first detection,
+        // so this is now an EDIT on top of the prior external CREATE)
+        $expect = $expectExternal; // last revision is the 3.1 persisted entry
         file_put_contents($file, 'teststring external edit');
         clearstatcache(false, $file);
         $newmod = filemtime($file);
         $this->assertNotEquals($lastmod, $newmod);
         $lastmod = $newmod;
-        $expectedRevs = 0; // external edit is not yet in changelog
+        $expectedRevs = 1;
         $expectExternal = array(
             'date' => $lastmod,
-            'type' => DOKU_CHANGE_TYPE_CREATE,  // not DOKU_CHANGE_TYPE_EDIT
-            'sum'  => 'created - external edit',
-            'sizechange' => 24,
+            'type' => DOKU_CHANGE_TYPE_EDIT,
+            'sum'  => 'external edit',
+            'sizechange' => 14,
         );
 
         $pagelog = new PageChangeLog($page);
@@ -449,7 +455,7 @@ class common_saveWikiText_test extends DokuWikiTest {
         $newmod = filemtime($file);
         $this->assertNotEquals($lastmod, $newmod);
         $lastmod = $newmod;
-        $expectedRevs = 2; // two more revisions now!
+        $expectedRevs = 3;
         $expect = array(
             'date' => $lastmod,
             'type' => DOKU_CHANGE_TYPE_EDIT,
@@ -464,7 +470,7 @@ class common_saveWikiText_test extends DokuWikiTest {
 
         // 3.4 externally delete the page
         unlink($file);
-        $expectedRevs = 2;
+        $expectedRevs = 3;
         $expectExternal = array(
           //'date' => $lastmod,
             'type' => DOKU_CHANGE_TYPE_DELETE,

--- a/inc/ChangeLog/ChangeLog.php
+++ b/inc/ChangeLog/ChangeLog.php
@@ -53,6 +53,13 @@ abstract class ChangeLog
     abstract protected function getMode();
 
     /**
+     * Returns path to the global changelog file (the cross-page recent-changes feed)
+     *
+     * @return string path to file
+     */
+    abstract protected function getGlobalChangelogFilename();
+
+    /**
      * Check whether given revision is the current page
      *
      * @param int $rev timestamp of current page
@@ -588,12 +595,11 @@ abstract class ChangeLog
      * Otherwise, the change information since the last revision caused outside DokuWiki
      * should be returned, which is referred as "external revision".
      *
-     * The change date of the file can be determined by timestamp as far as the file exists,
-     * however this is not possible when the file has already deleted outside of DokuWiki.
-     * In such case we assign 1 sec before current time() for the external deletion.
-     * As a result, the value of current revision identifier may change each time because:
-     *   1) the file has again modified outside of DokuWiki, or
-     *   2) the value is essentially volatile for deleted but once existed files.
+     * External revisions are persisted to the changelog (and, for non-delete cases, copied
+     * to the attic) on first detection so subsequent reads see one canonical entry instead
+     * of recomputing a synthesized one. If persistence fails (e.g. the data dir is not
+     * writable in the current process context), the in-memory synthesized entry is still
+     * returned so the read path keeps working.
      *
      * @return bool|array false when page had never existed or array with entries:
      *      - date:  revision identifier (timestamp or last revision +1)
@@ -641,7 +647,7 @@ abstract class ChangeLog
 
             // externally deleted, set revision date as late as possible
             $revInfo = [
-                'date' => max($lastRev + 1, time() - 1), // 1 sec before now or new page save
+                'date' => max($lastRev + 1, time() - 1), // 1 sec before now or last revision +1
                 'ip'   => '127.0.0.1',
                 'type' => DOKU_CHANGE_TYPE_DELETE,
                 'id'   => $this->id,
@@ -693,11 +699,139 @@ abstract class ChangeLog
             ];
         }
 
+        // persist the synthesized entry so subsequent reads see it as a real changelog entry
+        $this->persistCurrentRevisionInfo($revInfo);
+
         // cache current revision information of external edition
         $this->currentRevision = $revInfo['date'];
         $this->cache[$this->id][$this->currentRevision] = $revInfo;
         return $this->getRevisionInfo($this->currentRevision);
     }
+
+    /**
+     * Adds an entry to the changelog
+     *
+     * Locks the local changelog file for the duration of the write so concurrent writers
+     * serialize through the same key. Subclasses provide the actual append logic via
+     * writeLogEntry() so persistCurrentRevisionInfo() can append while already holding
+     * the lock without re-entering it.
+     *
+     * Best-effort: if writeLogEntry() throws, surfaces the error via msg() and still
+     * returns the info dict so existing callers (saveWikiText etc.) keep working.
+     *
+     * @param array $info    Revision info structure of a page or media file
+     * @param int $timestamp log line date (optional)
+     * @return array revision info of added log line
+     */
+    public function addLogEntry(array $info, $timestamp = null)
+    {
+        $logfile = $this->getChangelogFilename();
+        io_lock($logfile);
+        try {
+            return $this->writeLogEntry($info, $timestamp);
+        } catch (\RuntimeException $e) {
+            msg($e->getMessage(), -1);
+            $info['mode'] = $this->getMode();
+            return $info;
+        } finally {
+            io_unlock($logfile);
+        }
+    }
+
+    /**
+     * Append a log entry to the changelog files and update the in-memory cache.
+     *
+     * The caller MUST hold io_lock() on the local changelog file. The global changelog
+     * is a different file with its own lock (acquired briefly here). This is what
+     * addLogEntry() runs under its lock, and what persistCurrentRevisionInfo() calls
+     * directly while it's holding the same lock for the detect-and-write critical section.
+     *
+     * @param array $info    Revision info structure
+     * @param int $timestamp log line date (optional)
+     * @return array revision info of added log line
+     * @throws \RuntimeException if the local changelog write fails
+     */
+    protected function writeLogEntry(array $info, $timestamp = null)
+    {
+        global $conf;
+
+        if (isset($timestamp)) unset($this->cache[$this->id][$info['date']]);
+
+        $logline = static::buildLogLine($info, $timestamp);
+
+        // append to local changelog without re-locking (caller holds the lock)
+        $localFile = $this->getChangelogFilename();
+        io_makeFileDir($localFile);
+        $fileexists = file_exists($localFile);
+        $fh = @fopen($localFile, 'ab');
+        if (!$fh || @fwrite($fh, $logline) === false) {
+            if ($fh) @fclose($fh);
+            throw new \RuntimeException("Writing $localFile failed");
+        }
+        fclose($fh);
+        if (!$fileexists && !empty($conf['fperm'])) chmod($localFile, $conf['fperm']);
+
+        // global changelog has its own lock and msg() reporting via io_saveFile()
+        io_saveFile($this->getGlobalChangelogFilename(), $logline, true);
+
+        $this->currentRevision = $info['date'];
+        $info['mode'] = $this->getMode();
+        $this->cache[$this->id][$this->currentRevision] = $info;
+        return $info;
+    }
+
+    /**
+     * Persist a synthesized external-revision entry to the changelog
+     *
+     * Holds the local changelog lock around the entire detect-and-write critical section
+     * (idempotency check, attic copy, log append) so it serializes against any other
+     * writer that goes through addLogEntry(). The append uses writeLogEntry() to avoid
+     * re-entering the lock we already hold.
+     *
+     * Returns false (without raising) when the attic write fails or another request
+     * already persisted the entry. The caller falls back to the in-memory synthesized
+     * entry.
+     *
+     * @param array $revInfo synthesized revision info
+     * @return bool true if newly persisted, false otherwise
+     */
+    protected function persistCurrentRevisionInfo(array $revInfo)
+    {
+        // only the synthesized branches carry the 'timestamp' key
+        if (!array_key_exists('timestamp', $revInfo)) return false;
+
+        $logfile = $this->getChangelogFilename();
+        io_lock($logfile);
+        try {
+            // re-read lastRev under the lock — another request may have just persisted
+            $lastRev = $this->lastRevision();
+            if ($lastRev !== false && $lastRev >= $revInfo['date']) {
+                return false;
+            }
+
+            if ($revInfo['type'] !== DOKU_CHANGE_TYPE_DELETE) {
+                if (!$this->saveExternalAttic($revInfo)) return false;
+            }
+
+            $this->writeLogEntry($revInfo);
+            return true;
+        } catch (\RuntimeException $e) {
+            // silent fallback to in-memory synthesis
+            return false;
+        } finally {
+            io_unlock($logfile);
+        }
+    }
+
+    /**
+     * Save the externally-modified file to the attic before the synthesized log entry is
+     * persisted. For deletions there is no file to copy and implementations should return
+     * true (the persist flow skips this call for the delete branch).
+     *
+     * @param array $revInfo synthesized revision info with 'date' set
+     * @return bool true on success or no-op, false to abort persistence
+     */
+    abstract protected function saveExternalAttic(array $revInfo);
 
     /**
      * Mechanism to trace no-actual external current revision

--- a/inc/ChangeLog/MediaChangeLog.php
+++ b/inc/ChangeLog/MediaChangeLog.php
@@ -38,31 +38,42 @@ class MediaChangeLog extends ChangeLog
         return RevisionInfo::MODE_MEDIA;
     }
 
+    /**
+     * Returns path to the global media-changelog file
+     *
+     * @return string path to file
+     */
+    protected function getGlobalChangelogFilename()
+    {
+        global $conf;
+        return $conf['media_changelog'];
+    }
 
     /**
-     * Adds an entry to the changelog
+     * Copy the externally-modified media file to the attic at the synthesized revision date.
+     * If the file mtime is older than the last known revision (broken chronology),
+     * touch the file forward so future reads see a consistent state.
      *
-     * @param array $info    Revision info structure of a media file
-     * @param int $timestamp log line date (optional)
-     * @return array revision info of added log line
-     *
-     * @see also addMediaLogEntry() in inc/changelog.php file
+     * @param array $revInfo synthesized revision info
+     * @return bool true on success (or nothing to copy), false if the attic copy failed
      */
-    public function addLogEntry(array $info, $timestamp = null)
+    protected function saveExternalAttic(array $revInfo)
     {
         global $conf;
 
-        if (isset($timestamp)) unset($this->cache[$this->id][$info['date']]);
+        $file = $this->getFilename();
+        if (!file_exists($file)) return true;
 
-        // add changelog lines
-        $logline = static::buildLogLine($info, $timestamp);
-        io_saveFile(mediaMetaFN($this->id, '.changes'), $logline, $append = true);
-        io_saveFile($conf['media_changelog'], $logline, $append = true); //global changelog cache
+        // rescue: file mtime older than last revision — touch forward to the synthesized date
+        if (empty($revInfo['timestamp'])) {
+            if (!@touch($file, $revInfo['date'])) return false;
+            clearstatcache(false, $file);
+        }
 
-        // update cache
-        $this->currentRevision = $info['date'];
-        $info['mode'] = $this->getMode();
-        $this->cache[$this->id][$this->currentRevision] = $info;
-        return $info;
+        $atticfile = $this->getFilename($revInfo['date']);
+        io_makeFileDir($atticfile);
+        if (!@copy($file, $atticfile)) return false;
+        if (!empty($conf['fmode'])) @chmod($atticfile, $conf['fmode']);
+        return true;
     }
 }

--- a/inc/ChangeLog/PageChangeLog.php
+++ b/inc/ChangeLog/PageChangeLog.php
@@ -38,31 +38,37 @@ class PageChangeLog extends ChangeLog
         return RevisionInfo::MODE_PAGE;
     }
 
-
     /**
-     * Adds an entry to the changelog
+     * Returns path to the global page-changelog file
      *
-     * @param array $info    Revision info structure of a page
-     * @param int $timestamp log line date (optional)
-     * @return array revision info of added log line
-     *
-     * @see also addLogEntry() in inc/changelog.php file
+     * @return string path to file
      */
-    public function addLogEntry(array $info, $timestamp = null)
+    protected function getGlobalChangelogFilename()
     {
         global $conf;
+        return $conf['changelog'];
+    }
 
-        if (isset($timestamp)) unset($this->cache[$this->id][$info['date']]);
+    /**
+     * Copy the externally-edited page to the attic at the synthesized revision date.
+     * If the file mtime is older than the last known revision (broken chronology),
+     * touch the file forward so future reads see a consistent state.
+     *
+     * @param array $revInfo synthesized revision info
+     * @return bool true on success (or nothing to copy), false if the attic write failed
+     */
+    protected function saveExternalAttic(array $revInfo)
+    {
+        $file = $this->getFilename();
+        if (!file_exists($file)) return true;
 
-        // add changelog lines
-        $logline = static::buildLogLine($info, $timestamp);
-        io_saveFile(metaFN($this->id, '.changes'), $logline, true);
-        io_saveFile($conf['changelog'], $logline, true); //global changelog cache
+        // rescue: file mtime older than last revision — touch forward to the synthesized date
+        if (empty($revInfo['timestamp'])) {
+            if (!@touch($file, $revInfo['date'])) return false;
+            clearstatcache(false, $file);
+        }
 
-        // update cache
-        $this->currentRevision = $info['date'];
-        $info['mode'] = $this->getMode();
-        $this->cache[$this->id][$this->currentRevision] = $info;
-        return $info;
+        $atticfile = $this->getFilename($revInfo['date']);
+        return io_writeWikiPage($atticfile, io_readWikiPage($file, $this->id, ''), $this->id, $revInfo['date']);
     }
 }

--- a/inc/File/PageFile.php
+++ b/inc/File/PageFile.php
@@ -2,12 +2,9 @@
 
 namespace dokuwiki\File;
 
-use dokuwiki\Cache\CacheInstructions;
 use dokuwiki\ChangeLog\PageChangeLog;
 use dokuwiki\Extension\Event;
 use dokuwiki\Input\Input;
-use dokuwiki\Logger;
-use RuntimeException;
 
 /**
  * Class PageFile : handles wiki text file and its change management for specific page
@@ -145,9 +142,15 @@ class PageFile
         clearstatcache();
         $fileRev = @filemtime($pagefile);
         if ($fileRev === $currentRevision) {
-            // pagefile has not touched by plugin's event handler
-            // add a potential external edit entry to changelog and store it into attic
-            $this->detectExternalEdit();
+            // pagefile has not been touched by plugin's event handler — trigger external-edit
+            // detection. ChangeLog persists the synthesized entry (and copies to attic for
+            // non-deletes) on first observation, so this also covers the "external edit
+            // happens just before save" case.
+            $revInfo = $this->changelog->getCurrentRevisionInfo();
+            // ensure the upcoming save timestamp is at least 1 sec after a persisted external entry
+            if (is_array($revInfo) && isset($revInfo['date']) && $revInfo['date'] == time()) {
+                sleep(1);
+            }
             $filesize_old = $currentSize;
         } else {
             // pagefile has modified by plugin's event handler, confirm sizechange
@@ -213,51 +216,6 @@ class PageFile
         io_saveFile($conf['cachedir'] . '/purgefile', time());
 
         return $data;
-    }
-
-    /**
-     * Checks if the current page version is newer than the last entry in the page's changelog.
-     * If so, we assume it has been an external edit and we create an attic copy and add a proper
-     * changelog line.
-     *
-     * This check is only executed when the page is about to be saved again from the wiki,
-     * triggered in @see saveWikiText()
-     */
-    public function detectExternalEdit()
-    {
-        $revInfo = $this->changelog->getCurrentRevisionInfo();
-
-        // only interested in external revision
-        if (empty($revInfo) || !array_key_exists('timestamp', $revInfo)) return;
-
-        if ($revInfo['type'] != DOKU_CHANGE_TYPE_DELETE && !$revInfo['timestamp']) {
-            // file is older than last revision, that is erroneous/incorrect occurence.
-            // try to change file modification time
-            $fileLastMod = $this->getPath();
-            $wrong_timestamp = filemtime($fileLastMod);
-            if (touch($fileLastMod, $revInfo['date'])) {
-                clearstatcache();
-                $msg = "PageFile($this->id)::detectExternalEdit(): timestamp successfully modified";
-                $details = '(' . $wrong_timestamp . ' -> ' . $revInfo['date'] . ')';
-                Logger::error($msg, $details, $fileLastMod);
-            } else {
-                // runtime error
-                $msg = "PageFile($this->id)::detectExternalEdit(): page file should be newer than last revision "
-                      . '(' . filemtime($fileLastMod) . ' < ' . $this->changelog->lastRevision() . ')';
-                throw new RuntimeException($msg);
-            }
-        }
-
-        // keep at least 1 sec before new page save
-        if ($revInfo['date'] == time()) sleep(1); // wait a tick
-
-        // store externally edited file to the attic folder
-        $this->saveOldRevision();
-        // add a changelog entry for externally edited file
-        $this->changelog->addLogEntry($revInfo);
-        // remove soon to be stale instructions
-        $cache = new CacheInstructions($this->id, $this->getPath());
-        $cache->removeCache();
     }
 
     /**

--- a/inc/common.php
+++ b/inc/common.php
@@ -1234,23 +1234,6 @@ function con($pre, $text, $suf, $pretty = false)
 }
 
 /**
- * Checks if the current page version is newer than the last entry in the page's
- * changelog. If so, we assume it has been an external edit and we create an
- * attic copy and add a proper changelog line.
- *
- * This check is only executed when the page is about to be saved again from the
- * wiki, triggered in @param string $id the page ID
- * @see saveWikiText()
- *
- * @deprecated 2021-11-28
- */
-function detectExternalEdit($id)
-{
-    dbg_deprecated(PageFile::class . '::detectExternalEdit()');
-    (new PageFile($id))->detectExternalEdit();
-}
-
-/**
  * Saves a wikitext by calling io_writeWikiPage.
  * Also directs changelog and attic updates.
  *


### PR DESCRIPTION
This addresses the flaky test that makes tests randomly fail (mostly on windows runners).

The flake in common_saveWikiText_test::test_savesequence5 came from this line in ChangeLog::getCurrentRevisionInfo():

    'date' => max($lastRev + 1, time() - 1)

The synthesized "external delete" entry was kept in memory only and only persisted later, when saveWikiText next called detectExternalEdit. That meant the formula was evaluated twice on different ChangeLog instances — once during the test's inspection, and again during the following saveWikiText — and the two evaluations could pick different seconds depending on how long the surrounding I/O took. The test cached the first result in $expectExternal and asserted it against the on-disk entry written during the second call. On the slower Windows runner the second call sometimes crossed a second boundary, producing the off-by-one date mismatch.

The questions I had was, why are we persisting external file deletions (or edits) only when a page is saved when we are obviously already detecting it earlier during the changelog read already?

Instead of recording the external delete at the time a new page is written, it makes sense to record it as soon as we detect it (when the changelog is requested by a user or a bot). This will make the recoded timestamp closer to the actual deletion.

This patch refactors the changelog accordingly, but still tries to be minimal invasive (I think the changelog handling would need much more refactoring, but that's beyond the scope of this change).

To enable proper locking (when logging an external edit and copying the attic file), locking had to be moved to the Changelog class, duplicating some code of io_saveFile.

PageFile::detectExternalEdit() and the deprecated procedural wrapper detectExternalEdit() in inc/common.php are removed. A codesearch.dokuwiki.org check confirmed no plugin calls the method directly; the only external caller of the procedural function is the farmsync plugin, which needs a parallel update.