### PR TITLE
Fix syntax plugin rendering

### DIFF
--- a/inc/Parsing/Handler.php
+++ b/inc/Parsing/Handler.php
@@ -90,15 +90,16 @@ class Handler
     {
         $this->currentModeName = $originalModeName ?: $modeName;
 
-        // core modes: dispatch through the mode object's handle() method
-        if (isset($this->modeObjects[$modeName])) {
-            return $this->modeObjects[$modeName]->handle($match, $state, $pos, $this);
-        }
-
-        // plugin modes: extract plugin name and call plugin()
+        // check plugin modes first: they must go through plugin() so addPluginCall() emits an instruction.
+        // SyntaxPlugin::handle() only returns data but in contrast to core modes, it does not write to the call list.
         if (str_starts_with($modeName, 'plugin_')) {
             [, $plugin] = sexplode('_', $modeName, 2, '');
             return $this->plugin($match, $state, $pos, $plugin);
+        }
+
+        // core modes: dispatch through the mode object's handle() method
+        if (isset($this->modeObjects[$modeName])) {
+            return $this->modeObjects[$modeName]->handle($match, $state, $pos, $this);
         }
 
         // should not be reached — all modes should have registered objects


### PR DESCRIPTION
Reverse the order in which core modes and plugin modes are handled by the `\dokuwiki\Parsing\Handler`. Otherwise only the handle() method of the plugin is called, which is fine for core modes. Syntax plugins need to go through `plugin()` to actually add their own calls.

Fixes #4637 