### PR TITLE
test: add tests to catch #4637

### DIFF
--- a/_test/tests/Parsing/HandlerTest.php
+++ b/_test/tests/Parsing/HandlerTest.php
@@ -51,4 +51,37 @@ class HandlerTest extends \DokuWikiTest
 
         $this->assertSame('mymode', $mode->receivedModeName);
     }
+
+    /**
+     * Regression test for #4637
+     *
+     * handleToken() must route plugin_* modes through plugin() even when
+     * the same name is also registered as a mode object.
+     *
+     * Before the fix, modeObjects was consulted first, which called
+     * SyntaxPlugin::handle() directly. That returns data but never
+     * emits an instruction via addPluginCall(), so the plugin's rendered
+     * output silently disappeared.
+     */
+    function testPluginModeIsRoutedThroughPluginHandler()
+    {
+        $handler = new Handler();
+
+        // Plugins register themselves as mode objects under their plugin_* name.
+        // This reproduces the conflict the bug depended on.
+        $info = plugin_load('syntax', 'info');
+        $this->assertNotNull($info, 'info plugin must be available for this test');
+        $handler->registerModeObject('plugin_info', $info);
+
+        $handler->handleToken('plugin_info', '~~INFO:datetime~~', DOKU_LEXER_SPECIAL, 0);
+
+        // After the fix, plugin() runs and emits a plugin instruction.
+        // With the bug, modeObjects['plugin_info']->handle() ran and emitted nothing.
+        $this->assertCount(1, $handler->calls, 'plugin mode must emit exactly one instruction');
+        [$name, $args] = $handler->calls[0];
+        $this->assertSame('plugin', $name);
+        $this->assertSame('info', $args[0]);
+        $this->assertSame(['datetime'], $args[1]);
+        $this->assertSame('~~INFO:datetime~~', $args[3]);
+    }
 }

--- a/_test/tests/inc/parser/renderer_pipeline.test.php
+++ b/_test/tests/inc/parser/renderer_pipeline.test.php
@@ -1,0 +1,66 @@
+<?php
+
+use DOMWrap\Document;
+
+/**
+ * End-to-end test for the parse + render pipeline.
+ *
+ * Renders the syntax wiki page and inspects the resulting XHTML to catch
+ * wholesale regressions in parsing, the call list, or the XHTML renderer.
+ */
+class renderer_pipeline_test extends DokuWikiTest
+{
+    public function testWikiSyntaxPageRendersExpectedStructure()
+    {
+        global $ID;
+        $ID = 'wiki:syntax';
+
+        $html = p_wiki_xhtml('wiki:syntax');
+        $this->assertNotEmpty($html, 'wiki:syntax must render to non-empty HTML');
+
+        // DOMWrap needs a single root; wrap in a container.
+        $doc = (new Document())->html('<div id="root">' . $html . '</div>');
+
+        // Top-level heading from the page source: "====== Formatting Syntax ======"
+        $h1 = $doc->find('h1');
+        $this->assertSame(1, $h1->count(), 'page must have exactly one h1');
+        $this->assertSame('Formatting Syntax', trim($h1->text()));
+
+        // Headers of various levels — page has dozens of sections.
+        $this->assertGreaterThan(10, $doc->find('h2')->count(), 'page must have many h2 sections');
+        $this->assertGreaterThan(0, $doc->find('h3')->count());
+        $this->assertGreaterThan(0, $doc->find('h4')->count());
+
+        // Section edit markers — verifies finalize/Block ran.
+        $this->assertGreaterThan(
+            5,
+            substr_count($html, '<!-- EDIT{'),
+            'expected multiple section edit markers'
+        );
+
+        // Internal wiki links and external links from the page.
+        $this->assertGreaterThan(0, $doc->find('a.wikilink1, a.wikilink2')->count());
+        $this->assertGreaterThan(0, $doc->find('a.urlextern')->count());
+        $this->assertGreaterThan(0, $doc->find('a.interwiki')->count());
+
+        // Inline formatting.
+        $this->assertGreaterThan(0, $doc->find('em')->count());
+        $this->assertGreaterThan(0, $doc->find('strong')->count());
+        $this->assertGreaterThan(0, $doc->find('code')->count());
+
+        // A table is rendered by the page.
+        $this->assertGreaterThan(0, $doc->find('table.inline')->count());
+
+        // Footnote block (the page uses ((...)) footnotes).
+        $this->assertSame(1, $doc->find('div.footnotes')->count());
+
+        // The info plugin produces the syntax-plugin list.
+        $pluginSection = $doc->find('h2#syntax_plugins')->following('div.level2');
+        $this->assertSame(1, $pluginSection->find('ul')->count(), 'info plugin must emit a <ul>');
+        $this->assertGreaterThan(
+            0,
+            $pluginSection->find('ul li.level1 a.urlextern')->count(),
+            'info plugin must list at least one syntax plugin entry'
+        );
+    }
+}


### PR DESCRIPTION
Issue #4637 was fixed in 7686f2030b19f948d2e50df1613ef6592fa44b46 but I didn't like that no test had caught the issue.

This adds a specific test for the issue as a HandlerTest. Additionally a simple smoke test is added that renders the wiki:syntax page and inspects the created DOM. It's not comprehensive but might help flagging similar issue in the future.

cc @annda 