### PR TITLE
Feat(openapi): support union and typed associative array typehints

### DIFF
--- a/_test/tests/Remote/OpenApiDoc/TypeTest.php
+++ b/_test/tests/Remote/OpenApiDoc/TypeTest.php
@@ -101,4 +101,68 @@ class TypeTest extends \DokuWikiTest
         $this->assertEquals($expected, $result);
     }
 
+    public function provideUnionTypes()
+    {
+        return [
+            // [hint, isUnion, isNullable, nonNullMembersAsStrings]
+            ['int|bool', true, false, ['int', 'bool']],
+            ['string|null', true, true, ['string']],
+            ['null|string', true, true, ['string']],
+            ['Page|null', true, true, ['Page']],
+            ['int|bool|string', true, false, ['int', 'bool', 'string']],
+            ['int|bool|null', true, true, ['int', 'bool']],
+            // Malformed inputs degrade to non-union without throwing
+            ['int|', false, false, ['int|']],
+            ['|int', false, false, ['|int']],
+            // Non-union types remain non-union
+            ['int', false, false, ['int']],
+            ['Foo[]', false, false, ['Foo[]']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUnionTypes
+     */
+    public function testUnionTypes($typehint, $isUnion, $isNullable, $expectedNonNull)
+    {
+        $type = new Type($typehint);
+        $this->assertSame($isUnion, $type->isUnion(), 'isUnion');
+        $this->assertSame($isNullable, $type->isNullable(), 'isNullable');
+        $nonNull = array_map(fn(Type $t) => (string) $t, $type->getNonNullMembers());
+        $this->assertEquals($expectedNonNull, $nonNull, 'non-null members');
+    }
+
+    public function provideMapTypes()
+    {
+        return [
+            // [hint, isMap, expectedKey, expectedValue]
+            ['array<string, Page>', true, 'string', 'Page'],
+            ['array<int, string>', true, 'int', 'string'],
+            ['array<string, int[]>', true, 'string', 'int[]'],
+            ['array<string, array<int, Page>>', true, 'string', 'array<int, Page>'],
+            // Non-maps
+            ['array', false, null, null],
+            ['array<>', false, null, null],
+            ['array<int>', false, null, null],
+            ['int[]', false, null, null],
+            ['Page', false, null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMapTypes
+     */
+    public function testMapTypes($typehint, $isMap, $expectedKey, $expectedValue)
+    {
+        $type = new Type($typehint);
+        $this->assertSame($isMap, $type->isMap(), 'isMap');
+        if ($isMap) {
+            $this->assertEquals($expectedKey, (string) $type->getMapKeyType());
+            $this->assertEquals($expectedValue, (string) $type->getMapValueType());
+        } else {
+            $this->assertNull($type->getMapKeyType());
+            $this->assertNull($type->getMapValueType());
+        }
+    }
+
 }

--- a/inc/Remote/OpenApiDoc/OpenAPIGenerator.php
+++ b/inc/Remote/OpenApiDoc/OpenAPIGenerator.php
@@ -349,6 +349,46 @@ class OpenAPIGenerator
      */
     public function typeToSchema(Type $type)
     {
+        // Union types — `T|null` becomes a nullable schema (OpenAPI 3.1 array-of-types form),
+        // wider unions become `oneOf`. We do this before falling into the scalar path because
+        // `getOpenApiType()` returns `object` for any raw union string.
+        if ($type->isUnion()) {
+            $nonNull = $type->getNonNullMembers();
+            if (count($nonNull) === 1) {
+                $schema = $this->typeToSchema($nonNull[0]);
+                // Wrap the single concrete type with null. If something upstream already
+                // emitted an array-typed `type` (shouldn't currently happen), append.
+                $existing = $schema['type'] ?? null;
+                if (is_array($existing)) {
+                    if (!in_array('null', $existing, true)) {
+                        $existing[] = 'null';
+                    }
+                    $schema['type'] = $existing;
+                } elseif (is_string($existing)) {
+                    $schema['type'] = [$existing, 'null'];
+                }
+                return $schema;
+            }
+            $oneOf = [];
+            foreach ($nonNull as $member) {
+                $oneOf[] = $this->typeToSchema($member);
+            }
+            if ($type->isNullable()) {
+                $oneOf[] = ['type' => 'null'];
+            }
+            return ['oneOf' => $oneOf];
+        }
+
+        // Typed associative array — `array<K, V>` becomes an object with typed
+        // additionalProperties. JSON Schema only models string-keyed maps, so the
+        // key type is captured in the model but not emitted to the spec.
+        if ($type->isMap()) {
+            return [
+                'type' => 'object',
+                'additionalProperties' => $this->typeToSchema($type->getMapValueType()),
+            ];
+        }
+
         $schema = [
             'type' => $type->getOpenApiType(),
         ];

--- a/inc/Remote/OpenApiDoc/Type.php
+++ b/inc/Remote/OpenApiDoc/Type.php
@@ -7,6 +7,16 @@ class Type implements \Stringable
     protected $typehint;
     protected $context;
 
+    /** @var Type[]|null Lazily populated. Single-element [$this] when not a union. */
+    protected ?array $unionMembers = null;
+    protected bool $unionParsed = false;
+
+    /** @var Type|null Key type for array<K, V>; null when not a map. */
+    protected ?Type $mapKeyType = null;
+    /** @var Type|null Value type for array<K, V>; null when not a map. */
+    protected ?Type $mapValueType = null;
+    protected bool $mapParsed = false;
+
     /**
      * @param string $typehint The typehint as read from the docblock
      * @param string $context A fully qualified class name in which context the typehint is used
@@ -137,5 +147,167 @@ class Type implements \Stringable
 
         // everything else is an object
         return 'object'; //should this return 'struct'?
+    }
+
+    /**
+     * Is this a union type like `int|bool` or `string|null`?
+     *
+     * @return bool
+     */
+    public function isUnion(): bool
+    {
+        return count($this->getUnionMembers()) > 1;
+    }
+
+    /**
+     * Return the members of a union type, each as its own Type.
+     *
+     * For non-union types this returns a single-element array containing $this,
+     * so callers can iterate uniformly without a separate isUnion check.
+     *
+     * @return Type[]
+     */
+    public function getUnionMembers(): array
+    {
+        if (!$this->unionParsed) {
+            $this->parseUnion();
+            $this->unionParsed = true;
+        }
+        return $this->unionMembers;
+    }
+
+    /**
+     * Does this union include `null`?
+     *
+     * @return bool
+     */
+    public function isNullable(): bool
+    {
+        foreach ($this->getUnionMembers() as $member) {
+            if ((string) $member === 'null') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return the union members excluding `null`. For non-nullable types this is the same as getUnionMembers().
+     *
+     * @return Type[]
+     */
+    public function getNonNullMembers(): array
+    {
+        $result = [];
+        foreach ($this->getUnionMembers() as $member) {
+            if ((string) $member !== 'null') {
+                $result[] = $member;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Is this a typed associative-array hint like `array<string, Page>`?
+     *
+     * Only the two-arg form is recognised. `array<T>` (list shorthand) is not a map.
+     *
+     * @return bool
+     */
+    public function isMap(): bool
+    {
+        $this->ensureMapParsed();
+        return $this->mapKeyType !== null;
+    }
+
+    /**
+     * Key type of an `array<K, V>` hint, or null if not a map.
+     *
+     * @return Type|null
+     */
+    public function getMapKeyType(): ?Type
+    {
+        $this->ensureMapParsed();
+        return $this->mapKeyType;
+    }
+
+    /**
+     * Value type of an `array<K, V>` hint, or null if not a map.
+     *
+     * @return Type|null
+     */
+    public function getMapValueType(): ?Type
+    {
+        $this->ensureMapParsed();
+        return $this->mapValueType;
+    }
+
+    private function parseUnion(): void
+    {
+        $hint = trim($this->typehint);
+        if (str_contains($hint, '|')) {
+            $parts = $this->splitTopLevel($hint, '|');
+            // Drop empty parts from malformed input like `int|` or `|int`
+            $parts = array_values(array_filter(array_map('trim', $parts), fn($p) => $p !== ''));
+            if (count($parts) > 1) {
+                $this->unionMembers = [];
+                foreach ($parts as $p) {
+                    $this->unionMembers[] = new Type($p, $this->context);
+                }
+                return;
+            }
+        }
+        $this->unionMembers = [$this];
+    }
+
+    private function ensureMapParsed(): void
+    {
+        if ($this->mapParsed) {
+            return;
+        }
+        $this->mapParsed = true;
+        $hint = trim($this->typehint);
+        if (!preg_match('/^array<(.+)>$/i', $hint, $m)) {
+            return;
+        }
+        $parts = $this->splitTopLevel($m[1], ',');
+        if (count($parts) !== 2) {
+            return;
+        }
+        $key = trim($parts[0]);
+        $value = trim($parts[1]);
+        if ($key === '' || $value === '') {
+            return;
+        }
+        $this->mapKeyType = new Type($key, $this->context);
+        $this->mapValueType = new Type($value, $this->context);
+    }
+
+    /**
+     * Split a string on $sep, ignoring separators inside angle brackets.
+     *
+     * @return string[]
+     */
+    private function splitTopLevel(string $str, string $sep): array
+    {
+        $depth = 0;
+        $parts = [];
+        $current = '';
+        $len = strlen($str);
+        for ($i = 0; $i < $len; $i++) {
+            $ch = $str[$i];
+            if ($ch === '<') {
+                $depth++;
+            } elseif ($ch === '>') {
+                $depth--;
+            } elseif ($ch === $sep && $depth === 0) {
+                $parts[] = $current;
+                $current = '';
+                continue;
+            }
+            $current .= $ch;
+        }
+        $parts[] = $current;
+        return $parts;
     }
 }


### PR DESCRIPTION
# Feat(openapi): support union and typed associative array typehints

Closes #4146

## Summary

`Type` currently parses only single typehints (`string`, `int`, `Page`, `Page[]`). docblock hints with **unions** (`int|bool`, `string|null`) or **typed associative arrays** (`array<string, Page>`) fall through to a generic `object` schema, losing the type info that the docblock already provides.

this adds lazy parsing for both shapes in `Type`, and teaches `OpenAPIGenerator::typeToSchema` to emit the right JSON Schema for each.

OpenAPI version stays at 3.1 (already set in `OpenAPIGenerator.php:40`), which natively supports both `oneOf` and array-typed `type` fields.

## What Changed

- `inc/Remote/OpenApiDoc/Type.php` — add `isUnion()`, `getUnionMembers()`, `isNullable()`, `getNonNullMembers()`, `isMap()`, `getMapKeyType()`, `getMapValueType()`. parsing is lazy and bracket-aware (won't split `array<string, int|null>` on the inner `|`). existing methods (`getBaseType`, `getOpenApiType`, `getSubType`, etc.) are unchanged for backwards-compat — callers that didn't ask for unions/maps see exactly the same behavior.
- `inc/Remote/OpenApiDoc/OpenAPIGenerator.php` — `typeToSchema()` now branches on `isUnion()` and `isMap()` before the existing scalar/array/object path. `T|null` collapses to the nullable array form; wider unions emit `oneOf`. maps emit `additionalProperties`.
- `_test/tests/Remote/OpenApiDoc/TypeTest.php` — 19 new data-provider rows across `testUnionTypes` and `testMapTypes` covering happy-path + malformed input (`int|`, `|int`, `array<>`, `array<int>` single-arg form).

## Reproduction

a small standalone script (not committed) calls `OpenAPIGenerator::typeToSchema` on the broken shapes. before the fix every union and every `array<K, V>` collapses to a flat `object`. after the fix the schema retains the type info:

```
--- BEFORE (HEAD^): schema output for the broken types ---
int                          → {"type":"integer"}
int|bool                     → {"type":"object"}
string|null                  → {"type":"object"}
Page|null                    → {"type":"object"}
int|bool|null                → {"type":"object"}
array<string, Page>          → {"type":"object"}
array<int, string>           → {"type":"object"}
array<string, int[]>         → {"type":"object"}
Foo[]                        → {"type":"array","items":{"type":"object"}}

--- AFTER (HEAD): schema output with the fix ---
int                          → {"type":"integer"}
int|bool                     → {"oneOf":[{"type":"integer"},{"type":"boolean"}]}
string|null                  → {"type":["string","null"]}
Page|null                    → {"type":["object","null"]}
int|bool|null                → {"oneOf":[{"type":"integer"},{"type":"boolean"},{"type":"null"}]}
array<string, Page>          → {"type":"object","additionalProperties":{"type":"object"}}
array<int, string>           → {"type":"object","additionalProperties":{"type":"string"}}
array<string, int[]>         → {"type":"object","additionalProperties":{"type":"array","items":{"type":"integer"}}}
Foo[]                        → {"type":"array","items":{"type":"object"}}
```

`Foo[]` is unchanged on purpose — the existing array path was already correct.

## Design Decisions

1. **`T|null` → nullable array** rather than always-`oneOf`. cleaner for downstream client tooling; OpenAPI 3.1 supports both but the array form is the recommended encoding.
2. **`array<K, V>` only**, not `list<T>` / `iterable<T>` / other PHPStan generic shapes. scope creep otherwise; can land as follow-ups if asked.
3. **lazy parsing**, not eager-in-constructor. keeps existing call sites cheap and avoids gratuitously instantiating sub-`Type`s when only the raw hint is consulted.
4. **JSON Schema only models string-keyed maps**, so `K` is captured in the model (via `getMapKeyType()`) but not emitted to the spec. `K=int` is accepted and parsed but the emitted schema's `additionalProperties` still applies to string keys — same as how every other tool handles this.
5. **malformed inputs degrade gracefully** rather than throw — `int|` stays a single type with the raw hint, `array<>` is treated as a non-map. matches the project's existing tolerance for weird docblocks.

## Tests

```
$ cd _test && ./vendor/bin/phpunit --no-coverage tests/Remote/OpenApiDoc/TypeTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

................................................................. 65 / 81 ( 80%)
................                                                  81 / 81 (100%)

Time: 00:10.982, Memory: 10.00 MB

OK (81 tests, 119 assertions)
```

baseline was 62/62 before the change; +19 new rows across `testUnionTypes` and `testMapTypes`.

```
$ cd _test && ./vendor/bin/phpunit --no-coverage tests/Remote/
...
OK, but incomplete, skipped, or risky tests!
Tests: 146, Assertions: 327, Incomplete: 3.
```

3 pre-existing incomplete tests, unrelated.

## Notes For Review

- `Type::getOpenApiType()` still returns `object` for union/map raw strings — intentional, callers other than the schema generator may rely on that. happy to refactor if you'd rather all consumers route through the new accessors.
- the parser uses a simple depth-tracking split (`splitTopLevel`) rather than a real tokenizer. fine for one level of nesting (which is all PHPStan supports for `array<K, V>` either); if you want full grammar coverage later, that's a separate change.
- no changes to `DocBlockClass` / `DocBlockMethod` / `DocBlock` — they consume `Type` only through the unchanged existing methods.
