### PR TITLE
fix(locktimer): reset lock timer on paste and other input events

### DIFF
--- a/lib/scripts/locktimer.js
+++ b/lib/scripts/locktimer.js
@@ -44,7 +44,9 @@ var dw_locktimer = {
         }
 
         // register refresh event
-        $edit.keypress(dw_locktimer.refresh);
+        // 'input' fires on any value change (typing, paste, cut, drag-drop), unlike 'keypress'
+        // which misses mouse-driven paste — see issue #3714
+        $edit.on('input', dw_locktimer.refresh);
         // start timer
         dw_locktimer.reset();
     },
@@ -98,7 +100,7 @@ var dw_locktimer = {
     /**
      * Refresh the lock via AJAX
      *
-     * Called on keypresses in the edit area
+     * Called on input events (typing, paste, cut, drag-drop) in the edit area
      */
     refresh: function(){
         var now = new Date(),


### PR DESCRIPTION
The lock-timer handler was bound only to `keypress`, which fires for character key presses but not for paste via right-click menu, drag-and-drop, or other non-keyboard input methods. Users editing a page solely by pasting could therefore lose their page lock after the configured timeout despite active editing.

Switch the binding to the `input` event, which fires on every value change of the textarea regardless of source (typing, paste via any method, cut, drag-drop, undo/redo). This is a superset of the previous behaviour, so no editing action regresses.

Fixes #3714