### PR TITLE
Handle array EXIF date values

### DIFF
--- a/_test/tests/inc/JpegMetaTest.php
+++ b/_test/tests/inc/JpegMetaTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class JpegMetaTest extends DokuWikiTest
+{
+    public function testGetDatesHandlesExifDateTimeArrays()
+    {
+        $meta = new JpegMeta('');
+        $meta->_markers = array(array('marker' => 0));
+        $meta->_info = array(
+            'file' => array(),
+            'jfif' => false,
+            'jpeg' => false,
+            'exif' => array(
+                'DateTime' => array(
+                    '2005:02:03 11:25:29',
+                    '2005:02:04 09:44:46',
+                ),
+            ),
+            'xmp' => false,
+            'adobe' => false,
+        );
+
+        $dates = $meta->getDates();
+
+        $this->assertSame(strtotime('2005-02-03 11:25:29'), $dates['EarliestTime']);
+        $this->assertSame('ExifDateTime', $dates['EarliestTimeSource']);
+        $this->assertSame(strtotime('2005-02-04 09:44:46'), $dates['LatestTime']);
+        $this->assertSame('ExifDateTime', $dates['LatestTimeSource']);
+    }
+}

--- a/inc/JpegMeta.php
+++ b/inc/JpegMeta.php
@@ -660,60 +660,29 @@ class JpegMeta {
         $earliestTime = time();
         $earliestTimeSource = "";
 
-        if (@isset($this->_info['exif']['DateTime'])) {
-            $dates['ExifDateTime'] = $this->_info['exif']['DateTime'];
+        $exifDateFields = array(
+            'DateTime' => 'ExifDateTime',
+            'DateTimeOriginal' => 'ExifDateTimeOriginal',
+            'DateTimeDigitized' => 'ExifDateTimeDigitized',
+        );
 
-            $aux = $this->_info['exif']['DateTime'];
-            $aux[4] = "-";
-            $aux[7] = "-";
-            $t = strtotime($aux);
-
-            if ($t && $t > $latestTime) {
-                $latestTime = $t;
-                $latestTimeSource = "ExifDateTime";
+        foreach ($exifDateFields as $field => $source) {
+            if (!@isset($this->_info['exif'][$field])) {
+                continue;
             }
 
-            if ($t && $t < $earliestTime) {
-                $earliestTime = $t;
-                $earliestTimeSource = "ExifDateTime";
-            }
-        }
+            $dates[$source] = $this->_info['exif'][$field];
 
-        if (@isset($this->_info['exif']['DateTimeOriginal'])) {
-            $dates['ExifDateTimeOriginal'] = $this->_info['exif']['DateTimeOriginal'];
+            foreach ($this->_parseExifDateTime($this->_info['exif'][$field]) as $t) {
+                if ($t && $t > $latestTime) {
+                    $latestTime = $t;
+                    $latestTimeSource = $source;
+                }
 
-            $aux = $this->_info['exif']['DateTimeOriginal'];
-            $aux[4] = "-";
-            $aux[7] = "-";
-            $t = strtotime($aux);
-
-            if ($t && $t > $latestTime) {
-                $latestTime = $t;
-                $latestTimeSource = "ExifDateTimeOriginal";
-            }
-
-            if ($t && $t < $earliestTime) {
-                $earliestTime = $t;
-                $earliestTimeSource = "ExifDateTimeOriginal";
-            }
-        }
-
-        if (@isset($this->_info['exif']['DateTimeDigitized'])) {
-            $dates['ExifDateTimeDigitized'] = $this->_info['exif']['DateTimeDigitized'];
-
-            $aux = $this->_info['exif']['DateTimeDigitized'];
-            $aux[4] = "-";
-            $aux[7] = "-";
-            $t = strtotime($aux);
-
-            if ($t && $t > $latestTime) {
-                $latestTime = $t;
-                $latestTimeSource = "ExifDateTimeDigitized";
-            }
-
-            if ($t && $t < $earliestTime) {
-                $earliestTime = $t;
-                $earliestTimeSource = "ExifDateTimeDigitized";
+                if ($t && $t < $earliestTime) {
+                    $earliestTime = $t;
+                    $earliestTimeSource = $source;
+                }
             }
         }
 
@@ -762,6 +731,41 @@ class JpegMeta {
         $dates['LatestTimeStr'] = date("Y-m-d H:i:s", $latestTime);
 
         return $dates;
+    }
+
+    /**
+     * Parse one or more EXIF date strings to unix timestamps
+     *
+     * EXIF tags can occur multiple times in different IFDs. In that case the
+     * metadata parser stores the field as an array of values.
+     *
+     * @param string|array $value
+     * @return int[]
+     */
+    function _parseExifDateTime($value) {
+        if (!is_array($value)) {
+            $value = array($value);
+        }
+
+        $timestamps = array();
+        foreach ($value as $date) {
+            if (is_array($date) && isset($date['val'])) {
+                $date = $date['val'];
+            }
+
+            if (!is_string($date) || strlen($date) < 10) {
+                continue;
+            }
+
+            $date[4] = "-";
+            $date[7] = "-";
+            $timestamp = strtotime($date);
+            if ($timestamp) {
+                $timestamps[] = $timestamp;
+            }
+        }
+
+        return $timestamps;
     }
 
     /**


### PR DESCRIPTION
## Summary
- handle duplicated EXIF DateTime fields stored as arrays
- share EXIF date parsing across DateTime, DateTimeOriginal, and DateTimeDigitized
- add a regression test for array DateTime metadata

Fixes #4628

## Tests
- _test/vendor/bin/phpunit --configuration _test/phpunit.xml _test/tests/inc/JpegMetaTest.php --stderr