### PR TITLE
LegacyIndexer for search index backwards compatibility

### DIFF
--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -4,7 +4,6 @@ namespace dokuwiki\Search;
 
 use dokuwiki\Debug\DebugHelper;
 use dokuwiki\Extension\Event;
-use dokuwiki\Search\Collection\CollectionSearch;
 use dokuwiki\Search\Collection\PageFulltextCollection;
 use dokuwiki\Search\Collection\PageMetaCollection;
 use dokuwiki\Search\Collection\PageTitleCollection;
@@ -12,11 +11,9 @@ use dokuwiki\Search\Exception\IndexAccessException;
 use dokuwiki\Search\Exception\IndexIntegrityException;
 use dokuwiki\Search\Exception\IndexLockException;
 use dokuwiki\Search\Exception\IndexWriteException;
-use dokuwiki\Search\Exception\SearchException;
 use dokuwiki\Search\Index\FileIndex;
 use dokuwiki\Search\Index\Lock;
 use dokuwiki\Search\Index\MemoryIndex;
-use dokuwiki\Search\Index\TupleOps;
 
 // Version tag used to force rebuild on upgrade
 const INDEXER_VERSION = 9;
@@ -330,8 +327,10 @@ class Indexer
      * Update the metadata registry with new keys
      *
      * @param string[] $keys metadata key names to ensure are registered
+     *
+     * @internal Only marked public for access via LegacyIndexer
      */
-    protected function updateMetadataRegistry(array $keys): void
+    public function updateMetadataRegistry(array $keys): void
     {
         global $conf;
         $fn = $conf['indexdir'] . '/metadata.idx';
@@ -351,26 +350,12 @@ class Indexer
         }
     }
 
-    // region Deprecated methods
-
-    /**
-     * Find pages containing a metadata value
-     *
-     * @param string $key metadata key name
-     * @param string|string[] $value search term(s)
-     * @param callable|null $func ignored, kept for backward compatibility
-     * @return array
-     *
-     * @deprecated 2026-04-07 use MetadataSearch::lookupKey() instead
-     */
-    public function lookupKey($key, &$value, $func = null)
-    {
-        DebugHelper::dbgDeprecatedFunction(MetadataSearch::class . '::lookupKey()');
-        return (new MetadataSearch())->lookupKey($key, $value);
-    }
-
     /**
      * Return a list of all indexed pages, optionally filtered by metadata key
+     *
+     * Kept on Indexer (not just LegacyIndexer) because several plugins call it
+     * directly on `new Indexer()` instances rather than going through
+     * idx_get_indexer().
      *
      * @param string|null $key metadata key name
      * @return string[]
@@ -382,154 +367,4 @@ class Indexer
         DebugHelper::dbgDeprecatedFunction(MetadataSearch::class . '::getPages()');
         return (new MetadataSearch())->getPages($key);
     }
-
-    /**
-     * Add metadata values for a page
-     *
-     * @param string $page page name
-     * @param string $key metadata key name
-     * @param string|string[]|null $value value(s) to add
-     * @return bool
-     *
-     * @deprecated 2026-04-07 use Collection classes directly instead
-     */
-    public function addMetaKeys($page, $key, $value = null)
-    {
-        DebugHelper::dbgDeprecatedFunction('Collection classes');
-        try {
-            if ($key === 'title') {
-                $collection = new PageTitleCollection();
-            } else {
-                $collection = new PageMetaCollection($key);
-            }
-            $values = is_array($value) ? $value : ($value !== null && $value !== '' ? [$value] : []);
-            $collection->lock()->addEntity($page, $values)->unlock();
-            $this->updateMetadataRegistry([$key]);
-            return true;
-        } catch (SearchException) {
-            return false;
-        }
-    }
-
-    /**
-     * Rename a metadata value in the index
-     *
-     * @param string $key metadata key name
-     * @param string $oldvalue old value
-     * @param string $newvalue new value
-     * @return bool
-     *
-     * @deprecated 2026-04-07 use Collection classes directly instead
-     */
-    public function renameMetaValue($key, $oldvalue, $newvalue)
-    {
-        DebugHelper::dbgDeprecatedFunction('Collection classes');
-        try {
-            $collection = new PageMetaCollection($key);
-            $collection->lock();
-
-            $tokenIndex = $collection->getTokenIndex();
-
-            // find old value — search() is read-only, won't create entries
-            $matches = $tokenIndex->search('/^' . preg_quote($oldvalue, '/') . '$/');
-            if ($matches === []) {
-                $collection->unlock();
-                return true;
-            }
-            $oldid = array_key_first($matches);
-
-            // check if new value already exists (read-only lookup)
-            $newMatches = $tokenIndex->search('/^' . preg_quote($newvalue, '/') . '$/');
-
-            if ($newMatches !== []) {
-                // both values exist — merge frequency data from old to new
-                $newid = array_key_first($newMatches);
-                $freqIndex = $collection->getFrequencyIndex();
-                $reverseIndex = $collection->getReverseIndex();
-                $oldFreqLine = $freqIndex->retrieveRow($oldid);
-
-                if ($oldFreqLine !== '') {
-                    $newFreqLine = $freqIndex->retrieveRow($newid);
-                    foreach (TupleOps::parseTuples($oldFreqLine) as $entityId => $count) {
-                        $newFreqLine = TupleOps::updateTuple($newFreqLine, $entityId, $count);
-
-                        // update reverse index: remove old token, add new
-                        $reverseRow = $reverseIndex->retrieveRow((int)$entityId);
-                        $keyline = explode(':', $reverseRow);
-                        $keyline = array_diff($keyline, [(string)$oldid]);
-                        if (!in_array((string)$newid, $keyline)) {
-                            $keyline[] = $newid;
-                        }
-                        $reverseIndex->changeRow(
-                            (int)$entityId,
-                            implode(':', array_filter($keyline, fn($v) => $v !== ''))
-                        );
-                    }
-                    $freqIndex->changeRow($oldid, '');
-                    $freqIndex->changeRow($newid, $newFreqLine);
-                }
-            } else {
-                // new value doesn't exist — simple rename
-                $tokenIndex->changeRow($oldid, $newvalue);
-            }
-
-            $collection->unlock();
-            return true;
-        } catch (SearchException) {
-            return false;
-        }
-    }
-
-    /**
-     * Get the page ID for a page name
-     *
-     * @param string $page page name
-     * @return int|false
-     *
-     * @deprecated 2026-04-07 use FileIndex directly instead
-     */
-    public function getPID($page)
-    {
-        DebugHelper::dbgDeprecatedFunction(FileIndex::class);
-        try {
-            return (new FileIndex('page', '', true))->accessCachedValue($page);
-        } catch (SearchException) {
-            return false;
-        }
-    }
-
-    /**
-     * Find tokens in the fulltext index
-     *
-     * @param array $tokens list of words to search for
-     * @return array list of pages found [word => [page => count, ...]]
-     *
-     * @deprecated 2026-04-07 use CollectionSearch on PageFulltextCollection instead
-     */
-    public function lookup($tokens)
-    {
-        DebugHelper::dbgDeprecatedFunction(CollectionSearch::class);
-        $collection = new PageFulltextCollection();
-        $search = new CollectionSearch($collection);
-        $termMap = [];
-        foreach ($tokens as $token) {
-            if (!Tokenizer::isValidSearchTerm($token)) continue;
-            $term = $search->addTerm($token);
-            $termMap[$token] = $term;
-        }
-
-        if ($termMap === []) return [];
-        $search->execute();
-
-        $result = [];
-        foreach ($termMap as $word => $term) {
-            $freqs = $term->getEntityFrequencies();
-            // filter to only existing pages
-            $filtered = array_filter($freqs, fn($page) => page_exists($page, '', false), ARRAY_FILTER_USE_KEY);
-            $result[$word] = $filtered;
-        }
-        return $result;
-    }
-
-    // endregion
 }

--- a/inc/Search/LegacyIndexer.php
+++ b/inc/Search/LegacyIndexer.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace dokuwiki\Search;
+
+use dokuwiki\Debug\DebugHelper;
+use dokuwiki\Search\Collection\CollectionSearch;
+use dokuwiki\Search\Collection\PageFulltextCollection;
+use dokuwiki\Search\Collection\PageMetaCollection;
+use dokuwiki\Search\Collection\PageTitleCollection;
+use dokuwiki\Search\Exception\SearchException;
+use dokuwiki\Search\Index\FileIndex;
+use dokuwiki\Search\Index\TupleOps;
+
+/**
+ * Backward-compatible wrapper around {@see Indexer}
+ *
+ * The refactored {@see Indexer} reports failures by throwing
+ * {@see SearchException} subclasses. Plugins written against the legacy
+ * Doku_Indexer API expect the four mutating methods (addPage, deletePage,
+ * renamePage, clear) to return `true` on success or a string error message
+ * on failure. This class wraps an {@see Indexer} instance and restores that
+ * contract for those four methods. It also hosts the legacy helpers
+ * (lookupKey, getPages, addMetaKeys, renameMetaValue, getPID, lookup) that
+ * used to live on Indexer itself.
+ *
+ * It is returned by the deprecated {@see ::idx_get_indexer()} helper, which
+ * is the entry point most plugins use to obtain an indexer instance. New
+ * code should instantiate {@see Indexer} directly and handle
+ * {@see SearchException} via try/catch.
+ *
+ * Composition (not inheritance) is used because PHP does not allow
+ * overriding a `void` return type with `bool|string`.
+ *
+ * @deprecated 2026-04-07 use {@see Indexer} directly with try/catch
+ *
+ * @method string|int getVersion()
+ * @method string[] getAllPages(bool $existsFilter = false)
+ * @method string[] getPages(?string $key = null)
+ * @method bool needsIndexing(string $page, bool $force = false)
+ * @method void checkIntegrity()
+ * @method bool isIndexEmpty()
+ */
+class LegacyIndexer
+{
+    protected Indexer $indexer;
+
+    public function __construct(?Indexer $indexer = null)
+    {
+        $this->indexer = $indexer ?? new Indexer();
+    }
+
+    /**
+     * Forward any other call (getVersion, getAllPages, getPages, needsIndexing,
+     * checkIntegrity, isIndexEmpty, ...) to the wrapped indexer.
+     *
+     * @deprecated 2026-04-07 call the same method on {@see Indexer} directly
+     */
+    public function __call(string $name, array $args): mixed
+    {
+        DebugHelper::dbgDeprecatedFunction(Indexer::class . '::' . $name . '()');
+        return $this->indexer->$name(...$args);
+    }
+
+    /**
+     * @return true|string true on success, error message on failure
+     *
+     * @deprecated 2026-04-07 use {@see Indexer::addPage()} with try/catch instead
+     */
+    public function addPage(string $page, bool $force = false): bool|string
+    {
+        DebugHelper::dbgDeprecatedFunction(Indexer::class . '::addPage()');
+        try {
+            $this->indexer->addPage($page, $force);
+            return true;
+        } catch (SearchException $e) {
+            return $e->getMessage();
+        }
+    }
+
+    /**
+     * @return true|string true on success, error message on failure
+     *
+     * @deprecated 2026-04-07 use {@see Indexer::deletePage()} with try/catch instead
+     */
+    public function deletePage(string $page, bool $force = false): bool|string
+    {
+        DebugHelper::dbgDeprecatedFunction(Indexer::class . '::deletePage()');
+        try {
+            $this->indexer->deletePage($page, $force);
+            return true;
+        } catch (SearchException $e) {
+            return $e->getMessage();
+        }
+    }
+
+    /**
+     * @return true|string true on success, error message on failure
+     *
+     * @deprecated 2026-04-07 use {@see Indexer::renamePage()} with try/catch instead
+     */
+    public function renamePage(string $oldpage, string $newpage): bool|string
+    {
+        DebugHelper::dbgDeprecatedFunction(Indexer::class . '::renamePage()');
+        try {
+            $this->indexer->renamePage($oldpage, $newpage);
+            return true;
+        } catch (SearchException $e) {
+            return $e->getMessage();
+        }
+    }
+
+    /**
+     * @return true|string true on success, error message on failure
+     *
+     * @deprecated 2026-04-07 use {@see Indexer::clear()} with try/catch instead
+     */
+    public function clear(): bool|string
+    {
+        DebugHelper::dbgDeprecatedFunction(Indexer::class . '::clear()');
+        try {
+            $this->indexer->clear();
+            return true;
+        } catch (SearchException $e) {
+            return $e->getMessage();
+        }
+    }
+
+    /**
+     * Find pages containing a metadata value
+     *
+     * @param string $key metadata key name
+     * @param string|string[] $value search term(s)
+     * @param callable|null $func ignored, kept for backward compatibility
+     * @return array
+     *
+     * @deprecated 2026-04-07 use MetadataSearch::lookupKey() instead
+     */
+    public function lookupKey($key, &$value, $func = null)
+    {
+        DebugHelper::dbgDeprecatedFunction(MetadataSearch::class . '::lookupKey()');
+        return (new MetadataSearch())->lookupKey($key, $value);
+    }
+
+    /**
+     * Add metadata values for a page
+     *
+     * @param string $page page name
+     * @param string $key metadata key name
+     * @param string|string[]|null $value value(s) to add
+     * @return bool
+     *
+     * @deprecated 2026-04-07 use Collection classes directly instead
+     */
+    public function addMetaKeys($page, $key, $value = null)
+    {
+        DebugHelper::dbgDeprecatedFunction('Collection classes');
+        try {
+            if ($key === 'title') {
+                $collection = new PageTitleCollection();
+            } else {
+                $collection = new PageMetaCollection($key);
+            }
+            $values = is_array($value) ? $value : ($value !== null && $value !== '' ? [$value] : []);
+            $collection->lock()->addEntity($page, $values)->unlock();
+            $this->indexer->updateMetadataRegistry([$key]);
+            return true;
+        } catch (SearchException) {
+            return false;
+        }
+    }
+
+    /**
+     * Rename a metadata value in the index
+     *
+     * @param string $key metadata key name
+     * @param string $oldvalue old value
+     * @param string $newvalue new value
+     * @return bool
+     *
+     * @deprecated 2026-04-07 use Collection classes directly instead
+     */
+    public function renameMetaValue($key, $oldvalue, $newvalue)
+    {
+        DebugHelper::dbgDeprecatedFunction('Collection classes');
+        try {
+            $collection = new PageMetaCollection($key);
+            $collection->lock();
+
+            $tokenIndex = $collection->getTokenIndex();
+
+            // find old value — search() is read-only, won't create entries
+            $matches = $tokenIndex->search('/^' . preg_quote($oldvalue, '/') . '$/');
+            if ($matches === []) {
+                $collection->unlock();
+                return true;
+            }
+            $oldid = array_key_first($matches);
+
+            // check if new value already exists (read-only lookup)
+            $newMatches = $tokenIndex->search('/^' . preg_quote($newvalue, '/') . '$/');
+
+            if ($newMatches !== []) {
+                // both values exist — merge frequency data from old to new
+                $newid = array_key_first($newMatches);
+                $freqIndex = $collection->getFrequencyIndex();
+                $reverseIndex = $collection->getReverseIndex();
+                $oldFreqLine = $freqIndex->retrieveRow($oldid);
+
+                if ($oldFreqLine !== '') {
+                    $newFreqLine = $freqIndex->retrieveRow($newid);
+                    foreach (TupleOps::parseTuples($oldFreqLine) as $entityId => $count) {
+                        $newFreqLine = TupleOps::updateTuple($newFreqLine, $entityId, $count);
+
+                        // update reverse index: remove old token, add new
+                        $reverseRow = $reverseIndex->retrieveRow((int)$entityId);
+                        $keyline = explode(':', $reverseRow);
+                        $keyline = array_diff($keyline, [(string)$oldid]);
+                        if (!in_array((string)$newid, $keyline)) {
+                            $keyline[] = $newid;
+                        }
+                        $reverseIndex->changeRow(
+                            (int)$entityId,
+                            implode(':', array_filter($keyline, fn($v) => $v !== ''))
+                        );
+                    }
+                    $freqIndex->changeRow($oldid, '');
+                    $freqIndex->changeRow($newid, $newFreqLine);
+                }
+            } else {
+                // new value doesn't exist — simple rename
+                $tokenIndex->changeRow($oldid, $newvalue);
+            }
+
+            $collection->unlock();
+            return true;
+        } catch (SearchException) {
+            return false;
+        }
+    }
+
+    /**
+     * Get the page ID for a page name
+     *
+     * @param string $page page name
+     * @return int|false
+     *
+     * @deprecated 2026-04-07 use FileIndex directly instead
+     */
+    public function getPID($page)
+    {
+        DebugHelper::dbgDeprecatedFunction(FileIndex::class);
+        try {
+            return (new FileIndex('page', '', true))->accessCachedValue($page);
+        } catch (SearchException) {
+            return false;
+        }
+    }
+
+    /**
+     * Find tokens in the fulltext index
+     *
+     * @param array $tokens list of words to search for
+     * @return array list of pages found [word => [page => count, ...]]
+     *
+     * @deprecated 2026-04-07 use CollectionSearch on PageFulltextCollection instead
+     */
+    public function lookup($tokens)
+    {
+        DebugHelper::dbgDeprecatedFunction(CollectionSearch::class);
+        $collection = new PageFulltextCollection();
+        $search = new CollectionSearch($collection);
+        $termMap = [];
+        foreach ($tokens as $token) {
+            if (!Tokenizer::isValidSearchTerm($token)) continue;
+            $term = $search->addTerm($token);
+            $termMap[$token] = $term;
+        }
+
+        if ($termMap === []) return [];
+        $search->execute();
+
+        $result = [];
+        foreach ($termMap as $word => $term) {
+            $freqs = $term->getEntityFrequencies();
+            // filter to only existing pages
+            $filtered = array_filter($freqs, fn($page) => page_exists($page, '', false), ARRAY_FILTER_USE_KEY);
+            $result[$word] = $filtered;
+        }
+        return $result;
+    }
+}

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -205,7 +205,6 @@ function ptln($string, $indent = 0)
 }
 
 /**
-<<<<<<< HEAD
  * Adds/updates the search index for the given page
  *
  * Locking is handled internally.
@@ -231,14 +230,18 @@ function idx_addPage($page, $verbose = false, $force = false)
 /**
  * Create an instance of the indexer.
  *
- * @return dokuwiki\Search\Indexer
+ * Returns a {@see dokuwiki\Search\LegacyIndexer} that preserves the legacy
+ * Doku_Indexer return contract (true|string on success/failure for the four
+ * mutating methods) so existing plugins keep working without try/catch.
+ *
+ * @return dokuwiki\Search\LegacyIndexer
  *
  * @deprecated 2026-04-07 use dokuwiki\Search\Indexer directly
  */
 function idx_get_indexer()
 {
     DebugHelper::dbgDeprecatedFunction(dokuwiki\Search\Indexer::class);
-    return new dokuwiki\Search\Indexer();
+    return new dokuwiki\Search\LegacyIndexer();
 }
 
 /**
@@ -270,7 +273,7 @@ function idx_getIndex($idx, $suffix)
 function idx_lookup(&$words)
 {
     DebugHelper::dbgDeprecatedFunction(dokuwiki\Search\Collection\CollectionSearch::class);
-    return (new dokuwiki\Search\Indexer())->lookup($words);
+    return (new dokuwiki\Search\LegacyIndexer())->lookup($words);
 }
 
 /**


### PR DESCRIPTION
Move the deprecated helpers (lookupKey, addMetaKeys, renameMetaValue, getPID, lookup) off Indexer and into a new LegacyIndexer wrapper. The wrapper also restores the Doku_Indexer return contract (true|string) around addPage/deletePage/renamePage/clear so plugins using the legacy API keep working without try/catch.

idx_get_indexer() now returns the LegacyIndexer; getPages stays on Indexer because plugins call it directly on Indexer instances.

fixes #4645