### PR TITLE
fix(auth): scope media ACL checks to the namespace

### DIFF
--- a/_test/tests/inc/auth_mediaaclpath.test.php
+++ b/_test/tests/inc/auth_mediaaclpath.test.php
@@ -1,0 +1,93 @@
+<?php
+
+use dokuwiki\test\mock\AuthPlugin;
+
+/**
+ * Tests for mediaAclPath() and its effect on media ACL evaluation.
+ */
+class auth_mediaaclpath_test extends DokuWikiTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        global $auth;
+        $auth = new AuthPlugin();
+    }
+
+    public function provideMediaIds(): array
+    {
+        return [
+            // [media id, expected ACL path]
+            'nested namespace'   => ['wiki:sub:image.png', 'wiki:sub:*'],
+            'single namespace'   => ['wiki:image.png', 'wiki:*'],
+            'root namespace'     => ['image.png', '*'],
+            'empty id'           => ['', '*'],
+            'page-like id'       => ['wiki:secret.png', 'wiki:*'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMediaIds
+     */
+    public function test_mediaAclPath_transform($id, $expected)
+    {
+        $this->assertSame($expected, mediaAclPath($id));
+    }
+
+    /**
+     * A page-intended exact-ID rule (e.g. wiki:secret.png as a page) must NOT
+     * govern a media file with the same ID. The media file's permission is
+     * decided solely by its namespace ACL.
+     */
+    public function test_mediaAclPath_ignores_exact_id_rule()
+    {
+        global $conf;
+        global $AUTH_ACL;
+        $conf['useacl'] = 1;
+
+        $AUTH_ACL = [
+            '*                  @ALL    8',  // everyone has upload on root
+            'wiki:secret.png    @ALL    0',  // page-intended deny on this exact ID
+        ];
+
+        // raw-id check (the old buggy pattern) hits the deny rule
+        $this->assertEquals(AUTH_NONE, auth_aclcheck('wiki:secret.png', '', []));
+
+        // the helper produces wiki:*, which the deny rule does not match
+        $this->assertEquals(AUTH_UPLOAD, auth_aclcheck(mediaAclPath('wiki:secret.png'), '', []));
+    }
+
+    /**
+     * Namespace-level ACLs must still apply to media via mediaAclPath().
+     */
+    public function test_mediaAclPath_applies_namespace_rule()
+    {
+        global $conf;
+        global $AUTH_ACL;
+        $conf['useacl'] = 1;
+
+        $AUTH_ACL = [
+            '*           @ALL    8',
+            'private:*   @ALL    0',
+        ];
+
+        $this->assertEquals(AUTH_NONE, auth_aclcheck(mediaAclPath('private:image.png'), '', []));
+        $this->assertEquals(AUTH_UPLOAD, auth_aclcheck(mediaAclPath('public:image.png'), '', []));
+    }
+
+    /**
+     * Root-namespace media must still resolve against the root ACL rule.
+     */
+    public function test_mediaAclPath_root_namespace()
+    {
+        global $conf;
+        global $AUTH_ACL;
+        $conf['useacl'] = 1;
+
+        $AUTH_ACL = [
+            '*  @ALL  8',
+        ];
+
+        $this->assertEquals(AUTH_UPLOAD, auth_aclcheck(mediaAclPath('image.png'), '', []));
+    }
+}

--- a/inc/File/MediaFile.php
+++ b/inc/File/MediaFile.php
@@ -185,7 +185,7 @@ class MediaFile
      */
     public function userPermission()
     {
-        return auth_quickaclcheck(getNS($this->id) . ':*');
+        return auth_quickaclcheck(mediaAclPath($this->id));
     }
 
     /** @return JpegMeta */

--- a/inc/Remote/ApiCore.php
+++ b/inc/Remote/ApiCore.php
@@ -838,7 +838,7 @@ class ApiCore
     public function getMedia($media, $rev = 0)
     {
         $media = cleanID($media);
-        if (auth_quickaclcheck($media) < AUTH_READ) {
+        if (auth_quickaclcheck(mediaAclPath($media)) < AUTH_READ) {
             throw new AccessDeniedException('You are not allowed to read this media file', 211);
         }
 
@@ -875,7 +875,7 @@ class ApiCore
     public function getMediaInfo($media, $rev = 0, $author = false, $hash = false)
     {
         $media = cleanID($media);
-        if (auth_quickaclcheck($media) < AUTH_READ) {
+        if (auth_quickaclcheck(mediaAclPath($media)) < AUTH_READ) {
             throw new AccessDeniedException('You are not allowed to read this media file', 211);
         }
 
@@ -912,7 +912,7 @@ class ApiCore
     public function getMediaUsage($media)
     {
         $media = cleanID($media);
-        if (auth_quickaclcheck($media) < AUTH_READ) {
+        if (auth_quickaclcheck(mediaAclPath($media)) < AUTH_READ) {
             throw new AccessDeniedException('You are not allowed to read this media file', 211);
         }
         if (!media_exists($media)) {
@@ -944,7 +944,7 @@ class ApiCore
 
         $media = cleanID($media);
         // check that this media exists
-        if (auth_quickaclcheck($media) < AUTH_READ) {
+        if (auth_quickaclcheck(mediaAclPath($media)) < AUTH_READ) {
             throw new AccessDeniedException('You are not allowed to read this media file', 211);
         }
         if (!media_exists($media, 0)) {
@@ -994,7 +994,7 @@ class ApiCore
     public function saveMedia($media, $base64, $overwrite = false)
     {
         $media = cleanID($media);
-        $auth = auth_quickaclcheck(getNS($media) . ':*');
+        $auth = auth_quickaclcheck(mediaAclPath($media));
 
         if ($media === '') {
             throw new RemoteException('Empty or invalid media ID given', 231);
@@ -1047,7 +1047,7 @@ class ApiCore
     {
         $media = cleanID($media);
 
-        $auth = auth_quickaclcheck($media);
+        $auth = auth_quickaclcheck(mediaAclPath($media));
         $res = media_delete($media, $auth);
         if ($res & DOKU_MEDIA_DELETED) {
             return true;

--- a/inc/Remote/LegacyApiCore.php
+++ b/inc/Remote/LegacyApiCore.php
@@ -477,7 +477,7 @@ class LegacyApiCore extends ApiCore
                 'lastModified' => $this->toDate($recent->revision),
                 'author' => $recent->author,
                 'version' => $recent->revision,
-                'perms' => auth_quickaclcheck($recent->id),
+                'perms' => auth_quickaclcheck(mediaAclPath($recent->id)),
                 'size' => @filesize(mediaFN($recent->id)),
             ];
         }

--- a/inc/Remote/Response/Media.php
+++ b/inc/Remote/Response/Media.php
@@ -52,7 +52,7 @@ class Media extends ApiResponse
         $this->file = mediaFN($this->id, $revision);
         $this->revision = $revision ?: $mtime ?: filemtime($this->file);
         $this->size = $size ?? filesize($this->file);
-        $this->permission = $perms ?? auth_quickaclcheck($this->id);
+        $this->permission = $perms ?? auth_quickaclcheck(mediaAclPath($this->id));
         ;
         $this->isimage = (bool)($isimage ?? preg_match("/\.(jpe?g|gif|png)$/", $id));
         $this->hash = $hash;

--- a/inc/auth.php
+++ b/inc/auth.php
@@ -702,6 +702,21 @@ function auth_quickaclcheck($id)
 }
 
 /**
+ * Build the ACL path for a media file.
+ *
+ * Media files do not have per-file ACLs; permissions are always evaluated against the namespace
+ * they live in. This returns the namespace wildcard path (e.g. "wiki:*" or "*" for root-namespace
+ * media) suitable for passing to auth_quickaclcheck() or auth_aclcheck().
+ *
+ * @param string $id media ID (needs to be resolved and cleaned)
+ * @return string the ACL path to check
+ */
+function mediaAclPath($id)
+{
+    return ltrim(getNS($id) . ':*', ':');
+}
+
+/**
  * Returns the maximum rights a user has for the given ID or its namespace
  *
  * @author  Andreas Gohr <andi@splitbrain.org>

--- a/inc/changelog.php
+++ b/inc/changelog.php
@@ -356,7 +356,7 @@ function _handleRecentLogLine($line, $ns, $flags, &$seen)
 
     // check ACL
     if ($flags & RECENTS_MEDIA_CHANGES) {
-        $recent['perms'] = auth_quickaclcheck(getNS($recent['id']) . ':*');
+        $recent['perms'] = auth_quickaclcheck(mediaAclPath($recent['id']));
     } else {
         $recent['perms'] = auth_quickaclcheck($recent['id']);
     }

--- a/inc/fetch.functions.php
+++ b/inc/fetch.functions.php
@@ -174,7 +174,7 @@ function checkFileStatus(&$media, &$file, $rev = '', $width = 0, $height = 0)
         }
 
         //check permissions (namespace only)
-        if (auth_quickaclcheck(getNS($media) . ':X') < AUTH_READ) {
+        if (auth_quickaclcheck(mediaAclPath($media)) < AUTH_READ) {
             return [403, 'Forbidden'];
         }
         $file = mediaFN($media, $rev);

--- a/inc/media.php
+++ b/inc/media.php
@@ -138,7 +138,7 @@ function media_ispublic($id)
 {
     if (media_isexternal($id)) return true;
     $id = cleanID($id);
-    if (auth_aclcheck(getNS($id) . ':*', '', []) >= AUTH_READ) return true;
+    if (auth_aclcheck(mediaAclPath($id), '', []) >= AUTH_READ) return true;
     return false;
 }
 
@@ -261,7 +261,7 @@ function media_inuse($id)
 function media_delete($id, $auth)
 {
     global $lang;
-    $auth = auth_quickaclcheck(ltrim(getNS($id) . ':*', ':'));
+    $auth = auth_quickaclcheck(mediaAclPath($id));
     if ($auth < AUTH_DELETE) return DOKU_MEDIA_NOT_AUTH;
     if (media_inuse($id)) return DOKU_MEDIA_INUSE;
 

--- a/inc/search.php
+++ b/inc/search.php
@@ -209,7 +209,7 @@ function search_media(&$data, $base, $file, $type, $lvl, $opts)
     }
 
     //check ACL for namespace (we have no ACL for mediafiles)
-    $info['perm'] = auth_quickaclcheck(getNS($info['id']) . ':*');
+    $info['perm'] = auth_quickaclcheck(mediaAclPath($info['id']));
     if (empty($opts['skipacl']) && $info['perm'] < AUTH_READ) {
         return false;
     }
@@ -276,7 +276,7 @@ function search_mediafiles(&$data, $base, $file, $type, $lvl, $opts)
     }
 
     //check ACL for namespace (we have no ACL for mediafiles)
-    $info['perm'] = auth_quickaclcheck(getNS($id) . ':*');
+    $info['perm'] = auth_quickaclcheck(mediaAclPath($id));
     if (empty($opts['skipacl']) && $info['perm'] < AUTH_READ) {
         return false;
     }

--- a/lib/exe/detail.php
+++ b/lib/exe/detail.php
@@ -26,7 +26,7 @@ session_write_close();
 
 $ERROR = false;
 // check image permissions
-$AUTH = auth_quickaclcheck($IMG);
+$AUTH = auth_quickaclcheck(mediaAclPath($IMG));
 if ($AUTH >= AUTH_READ) {
     // check if image exists
     $SRC = mediaFN($IMG, $REV);


### PR DESCRIPTION
Media files have no per-file ACLs; permissions must be evaluated against the namespace they live in. Several call sites passed the raw media ID to auth_quickaclcheck(), so a page-intended exact-ID rule (e.g. on wiki:secret.png) could silently apply to a media file sharing that ID.

Introduce mediaAclPath() that builds the correct namespace wildcard path (handling root-namespace media) and route all media-related ACL checks through it. Also normalize the lone `:X` sentinel variant in fetch.functions.php to the standard `:*` form.

fixes: #4647