### PR TITLE
fix(httputils): build a proper internal URL for nginx X-Accel-Redirect

### DIFF
--- a/_test/tests/inc/httputils_xaccel.test.php
+++ b/_test/tests/inc/httputils_xaccel.test.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Tests for the nginx X-Accel-Redirect URL construction
+ *
+ * @see http_xaccel_url()
+ * @see https://github.com/dokuwiki/dokuwiki/issues/2895
+ */
+class httputils_xaccel_test extends DokuWikiTest
+{
+    /**
+     * Files inside the DokuWiki directory keep their path relative to the root.
+     * This is the default layout and must match the historic behaviour.
+     */
+    public function test_file_inside_dokuwiki()
+    {
+        $file = DOKU_INC . 'data/media/wiki/dokuwiki.png';
+        $this->assertEquals(
+            DOKU_REL . 'data/media/wiki/dokuwiki.png',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * lib/ files (also inside the DokuWiki directory) work too.
+     */
+    public function test_libfile_inside_dokuwiki()
+    {
+        $file = DOKU_INC . 'lib/images/fileicons/png.png';
+        $this->assertEquals(
+            DOKU_REL . 'lib/images/fileicons/png.png',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * A media directory moved out of the DokuWiki root is mapped to the URL it
+     * would have by default (below data/media/). This is the regression in
+     * issue #2895, where the previous blind substr() produced a broken path.
+     */
+    public function test_relocated_mediadir()
+    {
+        global $conf;
+        $conf['mediadir'] = '/srv/dokuwiki-media';
+        $file = '/srv/dokuwiki-media/wiki/dokuwiki.png';
+        $this->assertEquals(
+            DOKU_REL . 'data/media/wiki/dokuwiki.png',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * The cache directory (used for resized media, compiled CSS/JS and the
+     * sitemap) is mapped as well when relocated.
+     */
+    public function test_relocated_cachedir()
+    {
+        global $conf;
+        $conf['cachedir'] = '/var/cache/dokuwiki';
+        $file = '/var/cache/dokuwiki/a/abcdef0123.css';
+        $this->assertEquals(
+            DOKU_REL . 'data/cache/a/abcdef0123.css',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * The most specific (longest) configured directory must win, so a file
+     * below a relocated mediadir is not swallowed by a relocated savedir.
+     */
+    public function test_most_specific_dir_wins()
+    {
+        global $conf;
+        $conf['savedir'] = '/srv/dwdata';
+        $conf['mediadir'] = '/srv/dwdata/media';
+        $file = '/srv/dwdata/media/wiki/dokuwiki.png';
+        $this->assertEquals(
+            DOKU_REL . 'data/media/wiki/dokuwiki.png',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * A file outside DokuWiki and all data directories (e.g. served by a
+     * plugin from an arbitrary location) is emitted as its absolute path
+     * behind the dedicated opt-in prefix.
+     */
+    public function test_arbitrary_file_uses_escape_hatch()
+    {
+        $file = '/opt/secret-downloads/report.pdf';
+        $this->assertEquals(
+            DOKU_REL . '_x_accel_redirect/opt/secret-downloads/report.pdf',
+            http_xaccel_url($file)
+        );
+    }
+
+    /**
+     * File names with spaces or other special characters must be URL-encoded,
+     * because nginx URL-decodes the X-Accel-Redirect target.
+     */
+    public function test_special_characters_are_encoded()
+    {
+        $file = DOKU_INC . 'data/media/wiki/some file & more.png';
+        $this->assertEquals(
+            DOKU_REL . 'data/media/wiki/some%20file%20%26%20more.png',
+            http_xaccel_url($file)
+        );
+    }
+}

--- a/inc/httputils.php
+++ b/inc/httputils.php
@@ -78,12 +78,60 @@ function http_sendfile($file)
         ob_end_clean();
         exit;
     } elseif ($conf['xsendfile'] == 3) {
-        // FS#2388 nginx just needs the relative path.
-        $file = DOKU_REL . substr($file, strlen(fullpath(DOKU_INC)) + 1);
-        header("X-Accel-Redirect: $file");
+        // FS#2388, #2895 nginx needs an internal redirect URL, not a file path.
+        header("X-Accel-Redirect: " . http_xaccel_url($file));
         ob_end_clean();
         exit;
     }
+}
+
+/**
+ * Build the internal redirect URL for nginx's X-Accel-Redirect header
+ *
+ * Construct a request path from a given file path that nginx can resolve to the file through an `internal` location.
+ * A. Files inside the DokuWiki installation are returned as relative paths.
+ * B. Standard data directory paths are returned as /data/* paths regardless of their actual location (reconfigured
+ *    savedir or mediadir).
+ * C. Paths outside the DokuWiki installation are returned with a /_x_accel_redirect/ prefix
+ *
+ * Nginx admins need to configure appropriate internal location mappings.
+ *
+ * @param string $file absolute path of the file to send
+ * @return string the relative URL for the X-Accel-Redirect header
+ */
+function http_xaccel_url($file)
+{
+    global $conf;
+
+    $file = fullpath($file);
+
+    if (str_starts_with($file, DOKU_INC)) {
+        // A. files inside the DokuWiki directory: keep their path relative to the root
+        $path = substr($file, strlen(DOKU_INC));
+    } else {
+        // C. files outside DokuWiki and its data dirs: add prefix (overridden below if a root matches)
+        $path = '_x_accel_redirect/' . ltrim($file, '/');
+
+        // B. files in a relocated data directory: map back to their default URL below data/
+        $roots = [
+            $conf['mediadir']    => 'data/media/',
+            $conf['mediaolddir'] => 'data/media_attic/',
+            $conf['cachedir']    => 'data/cache/',
+            $conf['savedir']     => 'data/',
+        ];
+        // match the most specific (longest) root first so nested directories win
+        uksort($roots, fn($a, $b) => strlen($b) - strlen($a));
+
+        foreach ($roots as $root => $logical) {
+            if (str_starts_with($file, $root . '/')) {
+                $path = $logical . substr($file, strlen($root) + 1);
+                break;
+            }
+        }
+    }
+
+    // URL-encode each segment (nginx URL-decodes the redirect target before resolving it)
+    return DOKU_REL . implode('/', array_map('rawurlencode', explode('/', $path)));
 }
 
 /**


### PR DESCRIPTION
Unlike Apache's mod_xsendfile and lighttpd's X-LIGHTTPD-send-file, which both accept an absolute file system path and stream the file directly, nginx treats X-Accel-Redirect as a URL: it performs an internal subrequest against the value and resolves it through `internal` location blocks in its own configuration. The redirect target therefore must be a request path nginx can map back to a file, not the file system path itself.

The previous implementation blindly stripped DOKU_INC's length from the file path, which produced a broken URL whenever a data directory had been relocated outside the DokuWiki tree.

Route the file through three cases instead: files inside DOKU_INC keep their path relative to the wiki root; files in a relocated mediadir, mediaolddir, cachedir or savedir are mapped back to their default URL below data/; everything else falls through an opt-in /_x_accel_redirect/ prefix.

Path segments are URL-encoded so filenames with spaces or other special characters resolve (fixes another potential bug in the previous implementation).

Nginx configuration:

For the default layout no extra configuration is needed - files keep their path relative to the wiki root and the regular wiki location already serves them. For relocated data directories admins must add an `internal` location below the wiki's URL space pointing at the actual file system path, e.g.:

    location /data/media/ { internal; alias /srv/dokuwiki-media/; }

For the /_x_accel_redirect/ fallback (used when a plugin serves files from outside the wiki and its data directories), admins opt in by adding:

    location /_x_accel_redirect/ { internal; alias /; }

When the wiki is installed under a sub path, prefix both locations accordingly (e.g. /wiki/data/media/ and /wiki/_x_accel_redirect/).

fixes: #2895