### PR TITLE
Emit a guard newline in TextareaElement to preserve leading newlines

### DIFF
--- a/_test/tests/Form/TextareaElementTest.php
+++ b/_test/tests/Form/TextareaElementTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace dokuwiki\test\Form;
+
+use dokuwiki\Form;
+
+class TextareaElementTest extends \DokuWikiTest
+{
+    /**
+     * Create a form with a textarea element and return the raw inner HTML of the textarea.
+     */
+    private function rawTextareaBody(string $value): string
+    {
+        $form = new Form\Form();
+        $form->addTextarea('wikitext', 'label')->val($value);
+
+        $this->assertSame(
+            1,
+            preg_match('#<textarea[^>]*>(.*?)</textarea>#s', $form->toHTML(), $m),
+            'expected exactly one textarea'
+        );
+        return $m[1];
+    }
+
+    public function testStartTagIsFollowedByGuardNewline()
+    {
+        $this->assertStringStartsWith("\n", $this->rawTextareaBody('hello'));
+    }
+
+    public function testValueIsEmittedInFullAfterGuard()
+    {
+        // a value beginning with a newline must appear unaltered after the
+        // guard: the start tag is followed by the guard newline and then the
+        // form-encoded value (including its own leading newline)
+        $value = "\n## heading\n";
+        $this->assertSame("\n" . formText($value), $this->rawTextareaBody($value));
+    }
+}

--- a/inc/Form/TextareaElement.php
+++ b/inc/Form/TextareaElement.php
@@ -48,7 +48,14 @@ class TextareaElement extends InputElement
     protected function mainElementHTML()
     {
         if ($this->useInput) $this->prefillInput();
-        return '<textarea ' . buildAttributes($this->attrs()) . '>' .
+        // The browser's HTML parser ignores a single newline immediately
+        // after a <textarea> start tag, so a value that itself begins with a
+        // newline would lose it on round-trip. We emit a guard newline that
+        // absorbs the one the browser drops, keeping the value intact.
+        // See the HTML Standard, "in body" insertion mode (the LF right after
+        // <textarea> is dropped as an authoring convenience):
+        // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody
+        return '<textarea ' . buildAttributes($this->attrs()) . '>' . "\n" .
             formText($this->val()) . '</textarea>';
     }
 }


### PR DESCRIPTION
A browser's HTML parser ignores a single newline immediately after a <textarea> start tag, so a value whose first character is a newline lost it on round-trip (e.g. saving a page or section whose source starts with a blank line silently dropped that line).

This patch emits a guard newline right after the start tag so the one the browser drops is absorbed and the value stays intact.

This should hopefully deal with sometimes vanishing new-lines on section edits I've seen in the past.