### PR TITLE
Fix changelog related issues #4635 #4634

### DIFF
--- a/_test/tests/ChangeLog/PageChangeLogTest.php
+++ b/_test/tests/ChangeLog/PageChangeLogTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace dokuwiki\test\ChangeLog;
+
+use dokuwiki\ChangeLog\PageChangeLog;
+
+/**
+ * Tests for dokuwiki\ChangeLog\PageChangeLog.
+ */
+class PageChangeLogTest extends \DokuWikiTest
+{
+    /**
+     * A page deleted through DokuWiki is recorded as its own revision, newer than the
+     * last revision that still had content. getRelativeRevision() must walk back from
+     * that deletion entry to the last content revision (issue #4635).
+     */
+    public function testRevisionBeforeNormalDeletion()
+    {
+        $page = 'changelog_deleted';
+        saveWikiText($page, 'first content', 'create', false);
+        $this->waitForTick(true);
+        saveWikiText($page, 'second content longer', 'edit', false);
+        $this->waitForTick(true);
+
+        $editRev = (new PageChangeLog($page))->currentRevision();
+
+        saveWikiText($page, '', 'delete', false);
+        clearstatcache();
+
+        $changelog = new PageChangeLog($page);
+        $delRev = $changelog->currentRevision();
+
+        $this->assertNotEquals($editRev, $delRev, 'deletion should get its own revision');
+        $this->assertEquals(
+            DOKU_CHANGE_TYPE_DELETE,
+            $changelog->getRevisionInfo($delRev)['type'],
+            'current revision should be the deletion'
+        );
+        $this->assertEquals(
+            $editRev,
+            $changelog->getRelativeRevision($delRev, -1),
+            'the revision before the deletion should be the last edit'
+        );
+    }
+
+    /**
+     * An external deletion is detected and persisted on first read as its own revision
+     * with an unknown exact date, newer than the last content revision.
+     * getRelativeRevision() must walk back from it to that last content revision
+     * (issue #4635).
+     */
+    public function testRevisionBeforeExternalDeletion()
+    {
+        $page = 'changelog_extdeleted';
+        saveWikiText($page, 'first content', 'create', false);
+        $this->waitForTick(true);
+        saveWikiText($page, 'second content longer', 'edit', false);
+        $this->waitForTick(true);
+
+        $editRev = (new PageChangeLog($page))->currentRevision();
+
+        // delete the page file externally, bypassing DokuWiki
+        unlink(wikiFN($page));
+        clearstatcache();
+
+        // first read detects and persists the external deletion
+        $changelog = new PageChangeLog($page);
+        $delRev = $changelog->currentRevision();
+        $delInfo = $changelog->getRevisionInfo($delRev);
+
+        $this->assertNotEquals($editRev, $delRev, 'external deletion should get its own revision');
+        $this->assertEquals(DOKU_CHANGE_TYPE_DELETE, $delInfo['type'], 'current revision should be the deletion');
+        $this->assertFalse($delInfo['timestamp'], 'external deletion has an unknown exact date');
+        $this->assertEquals(
+            $editRev,
+            $changelog->getRelativeRevision($delRev, -1),
+            'the revision before the external deletion should be the last edit'
+        );
+    }
+}

--- a/_test/tests/ChangeLog/PageChangeLogTest.php
+++ b/_test/tests/ChangeLog/PageChangeLogTest.php
@@ -107,4 +107,79 @@ class PageChangeLogTest extends \DokuWikiTest
         clearstatcache();
         $this->assertEquals($lastRev, filemtime(wikiFN($page)), 'file mtime should be reset to the changelog date');
     }
+
+    /**
+     * A detected external edit whose date predates the most recent change already recorded
+     * in the global changelog must stay out of the recent-changes feed (or it would appear
+     * above newer entries with an old date), but is still recorded in the page's own
+     * changelog (issue #4634).
+     */
+    public function testOutOfOrderExternalEditKeptOutOfGlobalChangelog()
+    {
+        global $conf;
+        $page = 'changelog_outoforder';
+        saveWikiText($page, 'first content', 'create', false);
+
+        $changelog = new PageChangeLog($page);
+        $createRev = $changelog->currentRevision();
+
+        // external edit with different content, dated after the create but well before the
+        // global changelog's last-modified time
+        $globalFile = $conf['changelog'];
+        $extRev = $createRev + 10;
+        file_put_contents(wikiFN($page), 'externally edited content');
+        touch(wikiFN($page), $extRev);
+        touch($globalFile, $createRev + 100000);
+        clearstatcache();
+
+        $changelog = new PageChangeLog($page);
+        $detectedRev = $changelog->currentRevision();
+        $detectedInfo = $changelog->getRevisionInfo($detectedRev);
+
+        // detected and recorded in the page's own changelog: the create plus the external edit
+        $this->assertEquals($extRev, $detectedRev, 'external edit should be detected at the file mtime');
+        $this->assertEquals(DOKU_CHANGE_TYPE_EDIT, $detectedInfo['type'], 'should be an external edit');
+        $this->assertEquals(
+            [$extRev, $createRev],
+            $changelog->getRevisions(-1, 200),
+            'page changelog should hold the create and the external edit'
+        );
+
+        // ...but kept out of the global recent-changes feed
+        $this->assertStringNotContainsString(
+            "$extRev\t",
+            file_get_contents($globalFile),
+            'out-of-order external edit must not be appended to the global changelog'
+        );
+    }
+
+    /**
+     * A genuinely current external edit (dated at or after the global changelog's last
+     * recorded change) must still reach the recent-changes feed (issue #4634).
+     */
+    public function testCurrentExternalEditReachesGlobalChangelog()
+    {
+        global $conf;
+        $page = 'changelog_freshext';
+        saveWikiText($page, 'first content', 'create', false);
+
+        $changelog = new PageChangeLog($page);
+        $createRev = $changelog->currentRevision();
+
+        // external edit dated after the create, so it is newer than the feed's most recent
+        // change (the create just written there) and should be appended
+        $extRev = $createRev + 100;
+        file_put_contents(wikiFN($page), 'externally edited content');
+        touch(wikiFN($page), $extRev);
+        clearstatcache();
+
+        $changelog = new PageChangeLog($page);
+        $changelog->currentRevision();
+
+        $this->assertStringContainsString(
+            "$extRev\t",
+            file_get_contents($conf['changelog']),
+            'a current external edit should be appended to the global changelog'
+        );
+    }
 }

--- a/_test/tests/ChangeLog/PageChangeLogTest.php
+++ b/_test/tests/ChangeLog/PageChangeLogTest.php
@@ -77,4 +77,34 @@ class PageChangeLogTest extends \DokuWikiTest
             'the revision before the external deletion should be the last edit'
         );
     }
+
+    /**
+     * A current revision's file can have its modification time bumped without any content
+     * change (a backup restore, a git checkout, ...). That must not be recorded as an
+     * external edit: the content is compared against the last revision and, when identical,
+     * the file mtime is reset to the recorded revision date instead (issue #4634).
+     */
+    public function testTouchedFileWithUnchangedContentIsNotExternalEdit()
+    {
+        $page = 'changelog_touched';
+        saveWikiText($page, 'first content', 'create', false);
+
+        $changelog = new PageChangeLog($page);
+        $lastRev = $changelog->currentRevision();
+
+        // bump the file mtime forward without changing the content
+        touch(wikiFN($page), $lastRev + 1000);
+        clearstatcache();
+
+        $changelog = new PageChangeLog($page);
+        $currentRev = $changelog->currentRevision();
+        $currentInfo = $changelog->getRevisionInfo($currentRev);
+
+        $this->assertEquals($lastRev, $currentRev, 'unchanged content must not create an external revision');
+        $this->assertArrayNotHasKey('timestamp', $currentInfo, 'should not be a synthesized external edit');
+        $this->assertCount(1, $changelog->getRevisions(-1, 200), 'no external edit entry should be added');
+
+        clearstatcache();
+        $this->assertEquals($lastRev, filemtime(wikiFN($page)), 'file mtime should be reset to the changelog date');
+    }
 }

--- a/_test/tests/Ui/PageDiffTest.php
+++ b/_test/tests/Ui/PageDiffTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace dokuwiki\test\Ui;
+
+use dokuwiki\Ui\PageDiff;
+
+/**
+ * Tests for the page diff view dokuwiki\Ui\PageDiff.
+ */
+class PageDiffTest extends \DokuWikiTest
+{
+    /**
+     * Determine which two revisions PageDiff would compare for a ?do=diff request
+     * that carries no rev or rev2 parameters.
+     *
+     * Clears any leftover request parameters, then runs PageDiff's internal request
+     * handler, which derives the default comparison pair from the changelog. Returns
+     * the timestamps it selected for the older and newer side of the diff.
+     *
+     * @param string $page page id to diff
+     * @return array the older (rev1) and newer (rev2) revision timestamps or false
+     */
+    private function resolveDefaultDiff($page)
+    {
+        global $INPUT, $INFO;
+        // make sure no rev parameters leak in from a previous request
+        $INPUT->remove('rev');
+        $INPUT->remove('rev2');
+        $INFO['id'] = $page;
+
+        $diff = new PageDiff($page);
+        $this->callInaccessibleMethod($diff, 'handle', []);
+        return [
+            $this->getInaccessibleProperty($diff, 'rev1'),
+            $this->getInaccessibleProperty($diff, 'rev2'),
+        ];
+    }
+
+    /**
+     * Without rev parameters, the diff of an existing page compares the previous
+     * revision with the current one.
+     */
+    public function testExistingPageComparesPreviousToCurrent()
+    {
+        $page = 'pagediff_existing';
+        // the page file's mtime after each save is that revision's timestamp
+        saveWikiText($page, 'first content', 'create', false);
+        clearstatcache();
+        $previous = filemtime(wikiFN($page));
+        $this->waitForTick(true);
+        saveWikiText($page, 'second content', 'edit', false);
+        clearstatcache();
+        $current = filemtime(wikiFN($page));
+
+        [$rev1, $rev2] = $this->resolveDefaultDiff($page);
+
+        $this->assertEquals($previous, $rev1, 'older side should be the previous revision');
+        $this->assertEquals($current, $rev2, 'newer side should be the current revision');
+    }
+
+    /**
+     * Regression test for issue #4635: opening the default diff of a page deleted
+     * through DokuWiki compares the last edit with the deletion, instead of comparing
+     * the deletion entry with itself.
+     */
+    public function testNormalDeletionComparesPreviousToDeletion()
+    {
+        $page = 'pagediff_deleted';
+        saveWikiText($page, 'some content', 'create', false);
+        clearstatcache();
+        $contentRev = filemtime(wikiFN($page)); // last revision that still had content
+        $this->waitForTick(true);
+
+        saveWikiText($page, '', 'delete', false);
+        clearstatcache();
+        $this->assertFileDoesNotExist(wikiFN($page));
+
+        [$rev1, $rev2] = $this->resolveDefaultDiff($page);
+
+        $this->assertEquals($contentRev, $rev1, 'older side should be the content revision before deletion');
+        $this->assertGreaterThan(
+            $rev1,
+            $rev2,
+            'newer side must be the later deletion, not the same revision compared with itself'
+        );
+    }
+
+    /**
+     * Regression test for issue #4635: opening the default diff of an externally
+     * deleted page compares the last edit with the persisted deletion, instead of
+     * comparing the deletion entry with itself.
+     */
+    public function testExternalDeletionComparesPreviousToDeletion()
+    {
+        $page = 'pagediff_extdeleted';
+        saveWikiText($page, 'some content', 'create', false);
+        clearstatcache();
+        $contentRev = filemtime(wikiFN($page)); // last revision that still had content
+
+        // delete the page file externally, bypassing DokuWiki; resolving the diff is
+        // what triggers detection and persistence of the synthesized deletion entry,
+        // which is dated lastRev+1 at the earliest, so no tick is needed here
+        unlink(wikiFN($page));
+        clearstatcache();
+
+        [$rev1, $rev2] = $this->resolveDefaultDiff($page);
+
+        $this->assertEquals($contentRev, $rev1, 'older side should be the content revision before external deletion');
+        $this->assertGreaterThan(
+            $rev1,
+            $rev2,
+            'newer side must be the later deletion, not the same revision compared with itself'
+        );
+    }
+
+    /**
+     * Regression test for issue #4635: the rendered diff of a deleted page shows the
+     * removed content rather than an empty diff.
+     */
+    public function testDeletionDiffRendersRemovedContent()
+    {
+        global $INPUT, $INFO;
+
+        $page = 'pagediff_removedcontent';
+        saveWikiText($page, 'zqxdistinctivebody', 'create', false);
+        $this->waitForTick(true);
+        saveWikiText($page, '', 'delete', false);
+        clearstatcache();
+
+        $INPUT->remove('rev');
+        $INPUT->remove('rev2');
+        $INFO['id'] = $page;
+
+        $diff = new PageDiff($page);
+        ob_start();
+        $diff->show();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString(
+            'zqxdistinctivebody',
+            $html,
+            'the diff should display the removed content, not an empty diff'
+        );
+    }
+}

--- a/inc/ChangeLog/ChangeLog.php
+++ b/inc/ChangeLog/ChangeLog.php
@@ -752,19 +752,25 @@ abstract class ChangeLog
     }
 
     /**
-     * Append a log entry to the changelog files and update the in-memory cache.
+     * Append a log entry to the local and global changelog and update the in-memory cache.
      *
-     * The caller MUST hold io_lock() on the local changelog file. The global changelog
-     * is a different file with its own lock (acquired briefly here). This is what
-     * addLogEntry() runs under its lock, and what persistCurrentRevisionInfo() calls
-     * directly while it's holding the same lock for the detect-and-write critical section.
+     * Locking is the caller's responsibility: this method appends to the local changelog
+     * directly and assumes the caller already holds io_lock() on it.
+     *
+     * This method is currently used by addLogEntry() for normal edits and by persistCurrentRevisionInfo()
+     * for detected external edits, both of which hold the local changelog lock around the call.
+     *
+     * Writing the global changelog is triggered from here via writeGlobalLogEntry(); being a separate
+     * file it has its own locking, which is handled by io_saveFile() rather than by the
+     * local lock above.
      *
      * @param array $info    Revision info structure
      * @param int $timestamp log line date (optional)
+     * @param bool $external entry is a detected external edit (kept out of the global feed when out of order)
      * @return array revision info of added log line
      * @throws \RuntimeException if the local changelog write fails
      */
-    protected function writeLogEntry(array $info, $timestamp = null)
+    protected function writeLogEntry(array $info, $timestamp = null, $external = false)
     {
         global $conf;
 
@@ -784,13 +790,43 @@ abstract class ChangeLog
         fclose($fh);
         if (!$fileexists && !empty($conf['fperm'])) chmod($localFile, $conf['fperm']);
 
-        // global changelog has its own lock and msg() reporting via io_saveFile()
-        io_saveFile($this->getGlobalChangelogFilename(), $logline, true);
+        $this->writeGlobalLogEntry($logline, $info['date'], $external);
 
         $this->currentRevision = $info['date'];
         $info['mode'] = $this->getMode();
         $this->cache[$this->id][$this->currentRevision] = $info;
         return $info;
+    }
+
+    /**
+     * Append a log line to the global changelog (the cross-page recent-changes feed).
+     *
+     * The write goes through io_saveFile(), which locks the global changelog and reports
+     * errors via msg(). That locking is independent of the local changelog lock the caller
+     * holds, as the global changelog is a separate file.
+     *
+     * A detected external edit ($external) is skipped here when its date is older than the
+     * feed's most recent change: appending it would place it at the top of recent changes
+     * with an old date (issue #4634). Skipping does not lose the entry — writeLogEntry() has
+     * already recorded it in the page's own changelog; it is only kept out of the cross-page
+     * feed. Normal edits are always appended.
+     *
+     * @param string $logline the changelog line to append
+     * @param int $date revision date of the entry, compared against the feed's last change
+     * @param bool $external entry is a detected external edit
+     */
+    protected function writeGlobalLogEntry($logline, $date, $external)
+    {
+        $globalFile = $this->getGlobalChangelogFilename();
+
+        // skip an out-of-order external edit
+        if ($external) {
+            clearstatcache(false, $globalFile);
+            $globalMtime = @filemtime($globalFile);
+            if ($globalMtime !== false && $date < $globalMtime) return;
+        }
+
+        io_saveFile($globalFile, $logline, true);
     }
 
     /**
@@ -826,7 +862,7 @@ abstract class ChangeLog
                 if (!$this->saveExternalAttic($revInfo)) return false;
             }
 
-            $this->writeLogEntry($revInfo);
+            $this->writeLogEntry($revInfo, null, true);
             return true;
         } catch (\RuntimeException) {
             // silent fallback to in-memory synthesis

--- a/inc/ChangeLog/ChangeLog.php
+++ b/inc/ChangeLog/ChangeLog.php
@@ -664,6 +664,19 @@ abstract class ChangeLog
                     $fileRev > $lastRev &&
                     $this->getRevisionInfo($lastRev, false)['type'] == DOKU_CHANGE_TYPE_DELETE
             );
+
+            // A current revision's file modification time can change without its content
+            // changing, e.g. when the file is touched or rewritten in place by an external
+            // process (a backup restore, a git checkout, ...). If the content is identical
+            // to the last recorded revision, no external edit actually happened: reset the
+            // file mtime to the recorded revision date and treat that as the current one.
+            if (!$isJustCreated && $this->currentContentMatchesRevision($lastRev)) {
+                @touch($fileLastMod, $lastRev);
+                clearstatcache(false, $fileLastMod);
+                $this->currentRevision = $lastRev;
+                return $this->getRevisionInfo($lastRev);
+            }
+
             $filesize_new = filesize($this->getFilename());
             $filesize_old = $isJustCreated ? 0 : io_getSizeFile($this->getFilename($lastRev));
             $sizechange = $filesize_new - $filesize_old;
@@ -832,6 +845,19 @@ abstract class ChangeLog
      * @return bool true on success or no-op, false to abort persistence
      */
     abstract protected function saveExternalAttic(array $revInfo);
+
+    /**
+     * Whether the current item file's content is byte-identical to the stored content
+     * of the given revision.
+     *
+     * Used to tell a real external edit apart from a mere mtime bump: when the content
+     * is unchanged the file was only touched, not edited. Returns false when either file
+     * is missing so detection falls back to treating the change as external.
+     *
+     * @param int $rev revision timestamp to compare the current file against
+     * @return bool true if the content is identical
+     */
+    abstract protected function currentContentMatchesRevision($rev);
 
     /**
      * Mechanism to trace no-actual external current revision

--- a/inc/ChangeLog/MediaChangeLog.php
+++ b/inc/ChangeLog/MediaChangeLog.php
@@ -76,4 +76,24 @@ class MediaChangeLog extends ChangeLog
         if (!empty($conf['fmode'])) @chmod($atticfile, $conf['fmode']);
         return true;
     }
+
+    /**
+     * Compare the current media file against the attic copy of a revision.
+     *
+     * Media revisions are stored as raw copies. The (potentially large, binary) files are
+     * not loaded into memory: a differing size rules out a match immediately, otherwise the
+     * contents are hashed in a streaming fashion via md5_file().
+     *
+     * @param int $rev revision timestamp to compare the current file against
+     * @return bool true if the content is identical
+     */
+    protected function currentContentMatchesRevision($rev)
+    {
+        $current = $this->getFilename();
+        $attic = $this->getFilename($rev);
+        if (!file_exists($current) || !file_exists($attic)) return false;
+        if (filesize($current) !== filesize($attic)) return false;
+
+        return md5_file($current) === md5_file($attic);
+    }
 }

--- a/inc/ChangeLog/PageChangeLog.php
+++ b/inc/ChangeLog/PageChangeLog.php
@@ -71,4 +71,23 @@ class PageChangeLog extends ChangeLog
         $atticfile = $this->getFilename($revInfo['date']);
         return io_writeWikiPage($atticfile, io_readWikiPage($file, $this->id, ''), $this->id, $revInfo['date']);
     }
+
+    /**
+     * Compare the current page content against the (gzip-aware) attic copy of a revision.
+     *
+     * Both sides are already loaded (and decompressed) into memory by io_readWikiPage, so
+     * they are compared directly rather than via a hash: the string comparison stops at the
+     * first differing byte and avoids hashing the full contents.
+     *
+     * @param int $rev revision timestamp to compare the current page against
+     * @return bool true if the decompressed content is identical
+     */
+    protected function currentContentMatchesRevision($rev)
+    {
+        $current = $this->getFilename();
+        $attic = $this->getFilename($rev);
+        if (!file_exists($current) || !file_exists($attic)) return false;
+
+        return io_readWikiPage($current, $this->id, '') === io_readWikiPage($attic, $this->id, $rev);
+    }
 }

--- a/inc/Ui/Diff.php
+++ b/inc/Ui/Diff.php
@@ -117,10 +117,15 @@ abstract class Diff extends Ui
         if (!isset($this->rev1, $this->rev2)) {
             $rev2 = $this->changelog->currentRevision();
             if ($rev2 > $this->changelog->lastRevision()) {
+                // current is an as-yet-unrecorded external edit, compare with last recorded revision
                 $rev1 = $this->changelog->lastRevision();
             } else {
-                $revs = $this->changelog->getRevisions(0, 1);
-                $rev1 = count($revs) ? $revs[0] : false;
+                // current revision is recorded as the last changelog entry; the older side is the
+                // entry immediately before it. getRelativeRevision() is used rather than
+                // getRevisions(0, 1) because the latter only skips the current revision when the item
+                // file still exists, so for a deleted page it would return the deletion entry itself
+                // and the view would end up comparing the current revision with itself.
+                $rev1 = $this->changelog->getRelativeRevision($rev2, -1);
             }
             $this->rev1 = $rev1;
             $this->rev2 = $rev2;


### PR DESCRIPTION
This addresses three issues:

* diffs when a page was deleted (no longer comparing against itself) #4635 
* not adding detected external changes to the global change log if that would destroy the timeline (eg. the external edit is too old) #4634 
* not treating lastmod changes (no content change) as external edit but instead restore the recorded timestamp #4634 