### PR TITLE
fix(indexer): explicitly handle renames

### DIFF
--- a/_test/tests/Search/IndexerTest.php
+++ b/_test/tests/Search/IndexerTest.php
@@ -4,6 +4,7 @@ namespace dokuwiki\test\Search;
 
 use dokuwiki\Search\Indexer;
 use dokuwiki\Search\Index\FileIndex;
+use dokuwiki\Search\MetadataSearch;
 
 /**
  * Tests the Indexer class
@@ -63,6 +64,77 @@ class IndexerTest extends \DokuWikiTest
         $pageIndex = new FileIndex('page');
         $result = $pageIndex->search('/^new_name$/');
         $this->assertNotEmpty($result, 'new_name not found in page.idx after rename');
+    }
+
+    /**
+     * renamePage must preserve the renamed page's outgoing references
+     *
+     * The rename only changes the page's name in the index, not its content, so all of
+     * its index associations - including the pages it links to (relation_references) -
+     * must survive under the new name. This is what allows a page renamed early during a
+     * namespace move to still be found as a backlink source for pages moved afterwards.
+     * It must work even though the destination page is not on disk yet at rename time
+     * (the move operation writes it only later), so re-indexing from disk cannot be relied
+     * upon here.
+     *
+     * @see https://github.com/dokuwiki/dokuwiki - regression after the indexer rewrite
+     */
+    public function testRenamePagePreservesOutgoingReferences()
+    {
+        $indexer = new Indexer();
+
+        saveWikiText('refsource', '[[target:page]]', 'Test initialization');
+        $indexer->addPage('refsource');
+
+        $search = new MetadataSearch();
+
+        // sanity: the source page references target:page
+        $value = 'target:page';
+        $this->assertEquals(['refsource'], $search->lookupKey('relation_references', $value));
+
+        // rename the source page WITHOUT writing the destination to disk first,
+        // mimicking how the move plugin calls renamePage before saving the new page
+        $indexer->renamePage('refsource', 'moved:newsource');
+
+        // the outgoing reference must now belong to the renamed page
+        $value = 'target:page';
+        $this->assertEquals(
+            ['moved:newsource'],
+            $search->lookupKey('relation_references', $value),
+            'rename lost the outgoing reference of the renamed page'
+        );
+    }
+
+    /**
+     * renamePage onto a name that already has its own index entry
+     *
+     * The renamed page must take over the destination name (keeping its own data) while the
+     * destination's previous data is dropped. The stale destination row must be vacated so the
+     * name resolves only to the renamed entity and does not leak as a phantom page.
+     */
+    public function testRenamePageOntoExistingPage()
+    {
+        $indexer = new Indexer();
+
+        saveWikiText('src', '[[target:fromsrc]]', 'Test initialization');
+        $indexer->addPage('src');
+        saveWikiText('dst', '[[target:fromdst]]', 'Test initialization');
+        $indexer->addPage('dst');
+
+        $indexer->renamePage('src', 'dst');
+
+        $search = new MetadataSearch();
+
+        // dst now carries src's outgoing reference ...
+        $value = 'target:fromsrc';
+        $this->assertEquals(['dst'], $search->lookupKey('relation_references', $value));
+        // ... and the destination's previous reference is gone
+        $value = 'target:fromdst';
+        $this->assertEquals([], $search->lookupKey('relation_references', $value));
+
+        // exactly one entity named 'dst', the old name and any phantom entry are gone
+        $allPages = $indexer->getAllPages();
+        $this->assertSame(['dst'], array_values(array_filter($allPages, fn($p) => $p === 'dst' || $p === 'src')));
     }
 
     /**

--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -234,8 +234,17 @@ class Indexer
     /**
      * Rename a page in the search index
      *
-     * The page must already have been moved on disk before calling this.
-     * Clears the old page's data and re-indexes under the new name.
+     * This renames the page's entity entry in place: its entity ID (the row in the
+     * page index) is kept and only its name is changed. Because every collection
+     * (title, fulltext and all metadata keys such as relation_references) is keyed by
+     * that entity ID, all token, frequency and reverse associations are preserved and
+     * transparently belong to the new name afterwards.
+     *
+     * In particular this keeps the renamed page's *outgoing* references intact. That is
+     * essential during multi-step operations such as namespace moves: a page renamed
+     * early on must still be discoverable as a backlink source for pages that are moved
+     * later. Re-indexing from disk instead would lose this, because the destination page
+     * has usually not been written to disk yet when this method is called.
      *
      * @param string $oldpage The old page name
      * @param string $newpage The new page name
@@ -246,8 +255,41 @@ class Indexer
      */
     public function renamePage(string $oldpage, string $newpage): void
     {
-        $this->deletePage($oldpage, true);
-        $this->addPage($newpage, true);
+        if ($oldpage === $newpage) return;
+
+        $pageIndex = new FileIndex('page', '', true);
+
+        // locate the existing entity rows; stop as soon as both are known
+        $oldId = null;
+        $newId = null;
+        foreach ($pageIndex as $rid => $value) {
+            if ($value === $oldpage) $oldId = $rid;
+            if ($value === $newpage) $newId = $rid;
+            if ($oldId !== null && $newId !== null) break;
+        }
+
+        // nothing to rename if the old page was never indexed
+        if ($oldId === null) {
+            $pageIndex->unlock();
+            $this->log("Indexer: $oldpage is not in the index, nothing to rename");
+            return;
+        }
+
+        // If the new name already has its own entity, drop its indexed data first.
+        // deletePage() intentionally keeps the entity row in page.idx, so we additionally
+        // blank that row - an empty entry is the index's "removed" marker (see getAllPages()).
+        // Otherwise two rows would carry the new name and a lookup could resolve to the
+        // now-empty one instead of the renamed entity that holds the data.
+        if ($newId !== null) {
+            $this->deletePage($newpage, true);
+            $pageIndex->changeRow($newId, '');
+        }
+
+        // rename in place — keeps the entity ID and thus all index associations
+        $pageIndex->changeRow($oldId, $newpage);
+
+        $pageIndex->unlock();
+        $this->log("Indexer: renamed $oldpage to $newpage in index");
     }
 
     /**


### PR DESCRIPTION
In an attempt to simplify the index handling, the newly refactored indexer implemented a rename as delete+add sequence.

This had unintended consequences for the move plugin which may move several pages at once, requiring a working index even while some pages have already been moved while others still remain at their old location.

Related to #4646