### PR TITLE
fix(media): handle multi-valued EXIF date tags in JpegMeta::getDates()

### DIFF
--- a/_test/tests/inc/JpegMeta_getDates.test.php
+++ b/_test/tests/inc/JpegMeta_getDates.test.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Tests for JpegMeta::getDates() with multi-valued EXIF date tags
+ */
+class JpegMeta_getDates_test extends DokuWikiTest {
+
+    /**
+     * When an EXIF date tag occurs more than once it is stored as an array.
+     * getDates() must still return a string date instead of passing the array
+     * to strtotime(). See #4628.
+     */
+    function test_array_datetime() {
+        $jpeg = new class('') extends JpegMeta {
+            function __construct($file) {
+                parent::__construct($file);
+                $this->_markers = array(array('marker' => 0xE1, 'data' => ''));
+                $this->_info = array(
+                    'file' => array('UnixTime' => 1107431129),
+                    'jfif' => array(),
+                    'jpeg' => array(),
+                    'xmp'  => array(),
+                    'adobe' => array(),
+                    'exif' => array(
+                        'ByteAlign' => 'Little Endian',
+                        'DateTime'  => array('2005:02:03 11:25:29', '2005:02:04 09:44:46'),
+                    ),
+                );
+            }
+        };
+
+        $dates = $jpeg->getDates();
+        $this->assertEquals('2005-02-03 11:25:29', $dates['EarliestTimeStr']);
+        $this->assertEquals('ExifDateTime', $dates['EarliestTimeSource']);
+    }
+}

--- a/inc/JpegMeta.php
+++ b/inc/JpegMeta.php
@@ -664,6 +664,7 @@ class JpegMeta {
             $dates['ExifDateTime'] = $this->_info['exif']['DateTime'];
 
             $aux = $this->_info['exif']['DateTime'];
+            if (is_array($aux)) $aux = reset($aux);
             $aux[4] = "-";
             $aux[7] = "-";
             $t = strtotime($aux);
@@ -683,6 +684,7 @@ class JpegMeta {
             $dates['ExifDateTimeOriginal'] = $this->_info['exif']['DateTimeOriginal'];
 
             $aux = $this->_info['exif']['DateTimeOriginal'];
+            if (is_array($aux)) $aux = reset($aux);
             $aux[4] = "-";
             $aux[7] = "-";
             $t = strtotime($aux);
@@ -702,6 +704,7 @@ class JpegMeta {
             $dates['ExifDateTimeDigitized'] = $this->_info['exif']['DateTimeDigitized'];
 
             $aux = $this->_info['exif']['DateTimeDigitized'];
+            if (is_array($aux)) $aux = reset($aux);
             $aux[4] = "-";
             $aux[7] = "-";
             $t = strtotime($aux);


### PR DESCRIPTION
When an EXIF date tag (DateTime, DateTimeOriginal, DateTimeDigitized) appears more than once in a JPEG, the parser stores its value as an array rather than a string. `getDates()` then assigned that array to `$aux` and passed it straight to `strtotime()`, which throws `TypeError: strtotime(): Argument #1 ($datetime) must be of type string, array given` on PHP 8 and breaks the image detail page for affected images.

This takes the first value when the tag is an array, matching how the parser represents a single-valued tag. Added a regression test for the array case.

Fixes #4628
