### PR TITLE
re-add return values to indxer calls #4661

### DIFF
--- a/_test/tests/Search/IndexerTest.php
+++ b/_test/tests/Search/IndexerTest.php
@@ -174,11 +174,11 @@ class IndexerTest extends \DokuWikiTest
         $indexer = new Indexer();
 
         saveWikiText('needsidx', 'Some content.', 'Test initialization');
+        // a brand-new page has no .indexed tag yet, so it always needs indexing
         $this->assertTrue($indexer->needsIndexing('needsidx'));
 
+        // once indexed it is up to date, even when saved and indexed in the same second
         $indexer->addPage('needsidx');
-        // ensure the .indexed tag is strictly newer than the wiki file
-        touch(metaFN('needsidx', '.indexed'), time() + 1);
         $this->assertFalse($indexer->needsIndexing('needsidx'));
         $this->assertTrue($indexer->needsIndexing('needsidx', true)); // force
     }
@@ -196,9 +196,7 @@ class IndexerTest extends \DokuWikiTest
         saveWikiText('logpage', 'Log test content.', 'Test initialization');
         $indexer->addPage('logpage');
 
-        // ensure the .indexed tag is strictly newer so second call detects "up to date"
-        touch(metaFN('logpage', '.indexed'), time() + 1);
-
+        // second call detects the page is already up to date
         $indexer->addPage('logpage');
         $this->assertNotEmpty($messages);
         $this->assertStringContainsString('up to date', end($messages));

--- a/_test/tests/Search/IndexerTest.php
+++ b/_test/tests/Search/IndexerTest.php
@@ -54,16 +54,12 @@ class IndexerTest extends \DokuWikiTest
         saveWikiText('old_name', 'Old page content words.', 'Test initialization');
         $indexer->addPage('old_name');
 
-        // move the page on disk
-        io_rename(wikiFN('old_name'), wikiFN('new_name'));
-        saveWikiText('new_name', 'Old page content words.', 'Renamed');
-
         $indexer->renamePage('old_name', 'new_name');
 
-        // new page should be indexed
+        // the entity is renamed in place: new name present, old name gone
         $pageIndex = new FileIndex('page');
-        $result = $pageIndex->search('/^new_name$/');
-        $this->assertNotEmpty($result, 'new_name not found in page.idx after rename');
+        $this->assertNotEmpty($pageIndex->search('/^new_name$/'), 'new_name not found in page.idx after rename');
+        $this->assertEmpty($pageIndex->search('/^old_name$/'), 'old_name should be gone from page.idx after rename');
     }
 
     /**
@@ -161,9 +157,8 @@ class IndexerTest extends \DokuWikiTest
     public function testGetVersion()
     {
         $indexer = new Indexer();
-        $version = $indexer->getVersion();
-        $this->assertNotEmpty($version);
-        $this->assertIsString((string)$version);
+        // with no version-modifying plugins active the raw INDEXER_VERSION is returned
+        $this->assertSame(\dokuwiki\Search\INDEXER_VERSION, $indexer->getVersion());
     }
 
     /**
@@ -181,6 +176,59 @@ class IndexerTest extends \DokuWikiTest
         $indexer->addPage('needsidx');
         $this->assertFalse($indexer->needsIndexing('needsidx'));
         $this->assertTrue($indexer->needsIndexing('needsidx', true)); // force
+    }
+
+    /**
+     * addPage returns true when it indexed the page and false when there was nothing to do
+     */
+    public function testAddPageReturn()
+    {
+        $indexer = new Indexer();
+
+        saveWikiText('retadd', 'Some content to index.', 'Test initialization');
+        $this->assertTrue($indexer->addPage('retadd'), 'addPage should report work done');
+
+        // already up to date: nothing to do
+        $this->assertFalse($indexer->addPage('retadd'), 'addPage should report nothing to do when up to date');
+
+        // forcing reindexing always reports work done
+        $this->assertTrue($indexer->addPage('retadd', true), 'forced addPage should report work done');
+    }
+
+    /**
+     * deletePage returns true when it removed the page and false when there was nothing to do
+     */
+    public function testDeletePageReturn()
+    {
+        $indexer = new Indexer();
+
+        // never indexed and not forced: nothing to do
+        $this->assertFalse($indexer->deletePage('retdel'), 'deletePage should report nothing to do for an unknown page');
+
+        saveWikiText('retdel', 'Delete me content.', 'Test initialization');
+        $indexer->addPage('retdel');
+        $this->assertTrue($indexer->deletePage('retdel'), 'deletePage should report work done');
+
+        // the delete removed the .indexed tag, so a second unforced call has nothing to do
+        $this->assertFalse($indexer->deletePage('retdel'), 'deletePage should report nothing to do once removed');
+    }
+
+    /**
+     * renamePage returns true when it renamed the page and false for the no-op cases
+     */
+    public function testRenamePageReturn()
+    {
+        $indexer = new Indexer();
+
+        // identical names: nothing to do
+        $this->assertFalse($indexer->renamePage('retrename', 'retrename'), 'renamePage should report nothing to do for identical names');
+
+        // old page not in the index: nothing to do
+        $this->assertFalse($indexer->renamePage('retrename', 'retrenamed'), 'renamePage should report nothing to do for an unindexed page');
+
+        saveWikiText('retrename', 'Rename me content.', 'Test initialization');
+        $indexer->addPage('retrename');
+        $this->assertTrue($indexer->renamePage('retrename', 'retrenamed'), 'renamePage should report work done');
     }
 
     /**

--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -130,15 +130,16 @@ class Indexer
      * @param string $page The page to index
      * @param bool $force force reindexing even when the index is up to date
      *
+     * @return bool true if the page was indexed, false if there was nothing to do
      * @throws IndexAccessException
      * @throws IndexLockException
      * @throws IndexWriteException
      */
-    public function addPage(string $page, bool $force = false): void
+    public function addPage(string $page, bool $force = false): bool
     {
         if (!$this->needsIndexing($page, $force)) {
             $this->log("Indexer: index for $page up to date");
-            return;
+            return false;
         }
 
         // create shared writable page index early so we can resolve the PID for plugins
@@ -199,6 +200,7 @@ class Indexer
         // update index tag file
         io_saveFile(metaFN($data['page'], '.indexed'), $this->getVersion());
         $this->log("Indexer: finished indexing {$data['page']}");
+        return true;
     }
 
     /**
@@ -209,16 +211,17 @@ class Indexer
      * @param string $page The page to remove
      * @param bool $force force deletion even when no .indexed tag exists
      *
+     * @return bool true if the page was removed, false if there was nothing to do
      * @throws IndexAccessException
      * @throws IndexLockException
      * @throws IndexWriteException
      */
-    public function deletePage(string $page, bool $force = false): void
+    public function deletePage(string $page, bool $force = false): bool
     {
         $idxtag = metaFN($page, '.indexed');
         if (!$force && !file_exists($idxtag)) {
             $this->log("Indexer: $page.indexed file does not exist, ignoring");
-            return;
+            return false;
         }
 
         $pageIndex = new FileIndex('page', '', true);
@@ -232,6 +235,7 @@ class Indexer
 
         $this->log("Indexer: deleted $page from index");
         @unlink($idxtag);
+        return true;
     }
 
     /**
@@ -252,13 +256,14 @@ class Indexer
      * @param string $oldpage The old page name
      * @param string $newpage The new page name
      *
+     * @return bool true if the page was renamed, false if there was nothing to do
      * @throws IndexAccessException
      * @throws IndexLockException
      * @throws IndexWriteException
      */
-    public function renamePage(string $oldpage, string $newpage): void
+    public function renamePage(string $oldpage, string $newpage): bool
     {
-        if ($oldpage === $newpage) return;
+        if ($oldpage === $newpage) return false;
 
         $pageIndex = new FileIndex('page', '', true);
 
@@ -275,7 +280,7 @@ class Indexer
         if ($oldId === null) {
             $pageIndex->unlock();
             $this->log("Indexer: $oldpage is not in the index, nothing to rename");
-            return;
+            return false;
         }
 
         // If the new name already has its own entity, drop its indexed data first.
@@ -293,6 +298,7 @@ class Indexer
 
         $pageIndex->unlock();
         $this->log("Indexer: renamed $oldpage to $newpage in index");
+        return true;
     }
 
     /**

--- a/inc/Search/Indexer.php
+++ b/inc/Search/Indexer.php
@@ -115,8 +115,11 @@ class Indexer
 
         if (trim(io_readFile($idxtag)) != $this->getVersion()) return true;
 
+        // the index tag is written when the page is indexed; the page only needs
+        // (re-)indexing if it was changed *after* that - an equal mtime means it was
+        // saved and indexed within the same second and is therefore up to date
         $last = @filemtime($idxtag);
-        return $last <= @filemtime(wikiFN($page));
+        return $last < @filemtime(wikiFN($page));
     }
 
     /**

--- a/inc/Search/LegacyIndexer.php
+++ b/inc/Search/LegacyIndexer.php
@@ -62,7 +62,8 @@ class LegacyIndexer
     }
 
     /**
-     * @return true|string true on success, error message on failure
+     * @return bool|string true if work was done, false if there was nothing to do,
+     *                     error message string on failure
      *
      * @deprecated 2026-04-07 use {@see Indexer::addPage()} with try/catch instead
      */
@@ -70,15 +71,15 @@ class LegacyIndexer
     {
         DebugHelper::dbgDeprecatedFunction(Indexer::class . '::addPage()');
         try {
-            $this->indexer->addPage($page, $force);
-            return true;
+            return $this->indexer->addPage($page, $force);
         } catch (SearchException $e) {
             return $e->getMessage();
         }
     }
 
     /**
-     * @return true|string true on success, error message on failure
+     * @return bool|string true if work was done, false if there was nothing to do,
+     *                     error message string on failure
      *
      * @deprecated 2026-04-07 use {@see Indexer::deletePage()} with try/catch instead
      */
@@ -86,15 +87,15 @@ class LegacyIndexer
     {
         DebugHelper::dbgDeprecatedFunction(Indexer::class . '::deletePage()');
         try {
-            $this->indexer->deletePage($page, $force);
-            return true;
+            return $this->indexer->deletePage($page, $force);
         } catch (SearchException $e) {
             return $e->getMessage();
         }
     }
 
     /**
-     * @return true|string true on success, error message on failure
+     * @return bool|string true if work was done, false if there was nothing to do,
+     *                     error message string on failure
      *
      * @deprecated 2026-04-07 use {@see Indexer::renamePage()} with try/catch instead
      */
@@ -102,8 +103,13 @@ class LegacyIndexer
     {
         DebugHelper::dbgDeprecatedFunction(Indexer::class . '::renamePage()');
         try {
-            $this->indexer->renamePage($oldpage, $newpage);
-            return true;
+            $result = $this->indexer->renamePage($oldpage, $newpage);
+            // a false result for differing names means the old page was not in the
+            // index; restore the legacy error message that callers expect here
+            if ($result === false && $oldpage !== $newpage) {
+                return 'page is not in index';
+            }
+            return $result;
         } catch (SearchException $e) {
             return $e->getMessage();
         }

--- a/inc/TaskRunner.php
+++ b/inc/TaskRunner.php
@@ -211,11 +211,10 @@ class TaskRunner
                 echo $msg . NL;
             });
             if (!page_exists($ID)) {
-                $indexer->deletePage($ID, true);
+                return $indexer->deletePage($ID);
             } else {
-                $indexer->addPage($ID, true);
+                return $indexer->addPage($ID);
             }
-            return true;
         } catch (SearchException $e) {
             $msg = $e::class . ' : ' . $e->getMessage();
             echo $msg;

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -210,10 +210,10 @@ function ptln($string, $indent = 0)
  *
  * Locking is handled internally.
  *
- * @param string        $page   name of the page to index
- * @param boolean       $verbose    print status messages
- * @param boolean       $force  force reindexing even when the index is up to date
- * @return string|boolean  the function completed successfully
+ * @param string $page   name of the page to index
+ * @param boolean $verbose    ignored; status messages are no longer printed
+ * @param boolean $force  force reindexing even when the index is up to date
+ * @return boolean true if the page was indexed, false if there was nothing to do or an error occurred
  *
  * @deprecated 2026-04-07 use Indexer class instead
  */
@@ -221,8 +221,7 @@ function idx_addPage($page, $verbose = false, $force = false)
 {
     DebugHelper::dbgDeprecatedFunction('dokuwiki\Search\Indexer::addPage()');
     try {
-        (new dokuwiki\Search\Indexer())->addPage($page, $force);
-        return true;
+        return (new dokuwiki\Search\Indexer())->addPage($page, $force);
     } catch (\dokuwiki\Search\Exception\SearchException $e) {
         return false;
     }


### PR DESCRIPTION
This make other tasks run again. I also found a few issues in the tests, which in turn found a bug when page saving and indexing happened at the same second (probably a rare real-world issue).

@annda can you have a look?