### PR TITLE
make getUserData() fail safely on non-string input

### DIFF
--- a/inc/Extension/AuthPlugin.php
+++ b/inc/Extension/AuthPlugin.php
@@ -114,6 +114,12 @@ abstract class AuthPlugin extends Plugin
      * deleteUsers directly. The event handlers can prevent the modification, for
      * example for enforcing a user name schema.
      *
+     * The triggered AUTH_USER_CHANGE event carries the modification type and the
+     * parameters in its data. Note that params[0] differs by type: for 'create' and
+     * 'modify' it is a single user name (string), but for 'delete' it is the list of
+     * user names to remove (string[]). Event handlers calling getUserData() on
+     * params[0] need to account for this.
+     *
      * @author Gabriel Birke <birke@d-scribe.de>
      * @param string $type Modification type ('create', 'modify', 'delete')
      * @param array $params Parameters for the createUser, modifyUser or deleteUsers method.

--- a/lib/plugins/authad/auth.php
+++ b/lib/plugins/authad/auth.php
@@ -207,9 +207,9 @@ class auth_plugin_authad extends AuthPlugin
         global $lang;
         global $ID;
         global $INPUT;
+        if (!is_string($user) || $user == '') return false;
         $adldap = $this->initAdLdap($this->getUserDomain($user));
         if (!$adldap) return false;
-        if ($user == '') return false;
 
         $fields = ['mail', 'displayname', 'samaccountname', 'lastpwd', 'pwdlastset', 'useraccountcontrol'];
 

--- a/lib/plugins/authldap/auth.php
+++ b/lib/plugins/authldap/auth.php
@@ -142,7 +142,7 @@ class auth_plugin_authldap extends AuthPlugin
      *
      * @param string $user
      * @param bool $requireGroups (optional) - ignored, groups are always supplied by this plugin
-     * @return  array containing user data or false
+     * @return  array|bool containing user data or false
      * @author  <evaldas.auryla@pheur.org>
      * @author  Stephane Chazelas <stephane.chazelas@emerson.com>
      * @author  Steffen Schoch <schoch@dsb.net>
@@ -153,6 +153,7 @@ class auth_plugin_authldap extends AuthPlugin
      */
     public function getUserData($user, $requireGroups = true)
     {
+        if (!is_string($user) || $user == '') return false;
         return $this->fetchUserData($user);
     }
 

--- a/lib/plugins/authpdo/auth.php
+++ b/lib/plugins/authpdo/auth.php
@@ -164,6 +164,7 @@ class auth_plugin_authpdo extends AuthPlugin
      */
     public function getUserData($user, $requireGroups = true)
     {
+        if (!is_string($user)) return false;
         $data = $this->selectUser($user);
         if ($data == false) return false;
 

--- a/lib/plugins/authplain/_test/userdata.test.php
+++ b/lib/plugins/authplain/_test/userdata.test.php
@@ -61,4 +61,24 @@ class userdata_test extends DokuWikiTest
         $actual = $this->auth->retrieveGroups(10,3);
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * A single user name returns its data
+     */
+    public function test_getUserData_string()
+    {
+        $data = $this->auth->getUserData('user_1');
+        $this->assertIsArray($data);
+        $this->assertEquals('admin@example.com', $data['mail']);
+    }
+
+    /**
+     * Passing a non-string (e.g. the array of user names from a 'delete'
+     * AUTH_USER_CHANGE event) must fail safely instead of crashing with an
+     * "Array to string conversion" warning. See #4567.
+     */
+    public function test_getUserData_array()
+    {
+        $this->assertFalse($this->auth->getUserData(['user_1', 'user_2']));
+    }
 }

--- a/lib/plugins/authplain/auth.php
+++ b/lib/plugins/authplain/auth.php
@@ -93,6 +93,7 @@ class auth_plugin_authplain extends AuthPlugin
      */
     public function getUserData($user, $requireGroups = true)
     {
+        if (!is_string($user)) return false;
         if ($this->users === null) $this->loadUserData();
         return $this->users[$user] ?? false;
     }


### PR DESCRIPTION
When removing multiple users at once, plugins listening on the AUTH_USER_CHANGE event may pass the array of user names (params[0] for 'delete') to getUserData(), which crashed authplain with an "Array to string conversion" / illegal offset error.

Guard the bundled auth backends so a non-string user fails safely by returning false, and document that AUTH_USER_CHANGE params[0] is a string for create/modify but a string[] for delete.

Fixes #4567