### PR TITLE
Preserve edid and onselect across media manager search (#4608)

### DIFF
--- a/inc/media.php
+++ b/inc/media.php
@@ -1576,13 +1576,23 @@ function media_getuploadsize()
 function media_searchform($ns, $query = '', $fullscreen = false)
 {
     global $lang;
+    global $INPUT;
+
+    // In popup mode the search reloads the whole page, so the parameters the
+    // opening editor or plugin relies on (edid, onselect - see media.js) have to
+    // be carried over in the action URL or they would be lost after a search.
+    $action = DOKU_BASE . 'lib/exe/mediamanager.php';
+    $keep = array_filter(['edid' => $INPUT->str('edid'), 'onselect' => $INPUT->str('onselect')]);
+    if ($keep) {
+        $action .= '?' . buildURLparams($keep, '&');
+    }
 
     // The default HTML search form
     $form = new Form([
         'id'     => 'dw__mediasearch',
         'action' => ($fullscreen)
                     ? media_managerURL([], '&')
-                    : DOKU_BASE . 'lib/exe/mediamanager.php',
+                    : $action,
     ]);
     $form->addTagOpen('div')->addClass('no');
     $form->setHiddenField('ns', $ns);

--- a/lib/scripts/media.js
+++ b/lib/scripts/media.js
@@ -268,9 +268,9 @@ var dw_mediamanager = {
                 }
             }
         }
-        edid = String.prototype.match.call(document.location, /&edid=([^&]+)/);
+        edid = String.prototype.match.call(document.location, /[?&]edid=([^&]+)/);
         edid = edid ? edid[1] : 'wiki__text';
-        cb = String.prototype.match.call(document.location, /&onselect=([^&]+)/);
+        cb = String.prototype.match.call(document.location, /[?&]onselect=([^&]+)/);
         cb = cb ? cb[1].replace(/[^\w]+/, '') : 'dw_mediamanager_item_select';
 
         // arguments here only match the dw_mediamanager_item_select function, these will need to change if you override cb with onselect GET param


### PR DESCRIPTION
The media manager popup search reloads the whole page, dropping the edid and onselect parameters that plugins (e.g. struct, prosemirror) rely on to insert media and run their callback. Carry them over in the search form action URL so they survive the reload, and match them in media.js regardless of their position in the query string.