### PR TITLE
Cache: key on resolved base URL instead of the raw Host header

### DIFF
--- a/inc/Cache/CacheParser.php
+++ b/inc/Cache/CacheParser.php
@@ -23,8 +23,6 @@ class CacheParser extends Cache
      */
     public function __construct($id, $file, $mode, $syntax = null)
     {
-        global $INPUT;
-
         if ($id) {
             $this->page = $id;
         }
@@ -33,9 +31,22 @@ class CacheParser extends Cache
 
         $this->setEvent('PARSER_CACHE_USE');
         parent::__construct(
-            $file . $INPUT->server->str('HTTP_HOST') . $INPUT->server->str('SERVER_PORT') . ($syntax ?? ''),
+            $file . ($syntax ?? '') . $this->getEnvironmentKey(),
             '.' . $mode
         );
+    }
+
+    /**
+     * Environment-dependent fragment to append to the cache key
+     *
+     * The returned fragment is appended to the cache key in the constructor. Child classes can override
+     * this to include environment-dependent information like DOKU_BASE.
+     *
+     * @return string
+     */
+    protected function getEnvironmentKey()
+    {
+        return '';
     }
 
     /**

--- a/inc/Cache/CacheRenderer.php
+++ b/inc/Cache/CacheRenderer.php
@@ -55,6 +55,23 @@ class CacheRenderer extends CacheParser
         return true;
     }
 
+    /**
+     * Adds the wiki base URL to the cache key for rendered output
+     *
+     * Rendered output contains internal links and media sources built from
+     * DOKU_BASE, so cache entries must not be shared between requests served
+     * under a different base URL.
+     *
+     * @return string
+     */
+    protected function getEnvironmentKey()
+    {
+        if ($this->mode === 'metadata') {
+            return '';
+        }
+        return DOKU_BASE;
+    }
+
     protected function addDependencies()
     {
         global $conf;

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -113,8 +113,6 @@ function css_out()
     // The generated script depends on some dynamic options
     $cache = new Cache(
         'styles' .
-        $_SERVER['HTTP_HOST'] .
-        $_SERVER['SERVER_PORT'] .
         $INPUT->bool('preview') .
         DOKU_BASE .
         $tpl .

--- a/lib/exe/js.php
+++ b/lib/exe/js.php
@@ -84,8 +84,7 @@ function js_out()
     // Let plugins decide to either put more scripts here or to remove some
     Event::createAndTrigger('JS_SCRIPT_LIST', $files);
 
-    // The generated script depends on some dynamic options
-    $cache = new Cache('scripts' . $_SERVER['HTTP_HOST'] . $_SERVER['SERVER_PORT'] . md5(serialize($files)), '.js');
+    $cache = new Cache('scripts' . DOKU_BASE . Ip::isSsl() . md5(serialize($files)), '.js');
     $cache->setEvent('JS_CACHE_USE');
 
     $cache_files = array_merge($files, getConfigFiles('main'));


### PR DESCRIPTION
The instruction (.i), render (.xhtml) and metadata cache keys embedded the client-supplied HTTP_HOST and SERVER_PORT, as did the JS and CSS dispatchers. A crawler varying the Host header - or a wiki reachable under several names - thus multiplied every cached artifact per host value, growing the cache directory without bound.

Instructions and metadata never embed resolved URLs, so they drop the host component entirely. Rendered output and the JS/CSS bundles key on DOKU_BASE (plus the SSL flag for JS) instead: fixed when baseurl is configured, and only varying for genuine multi-domain canonical setups. Feeds keep host/port keying since their links are always absolute.

This should address the obvious cases mentioned in #4574