### PR TITLE
fix duplicated TOC caused by corrupted persistent metadata (#3179)

### DIFF
--- a/inc/parser/metadata.php
+++ b/inc/parser/metadata.php
@@ -78,6 +78,16 @@ class Doku_Renderer_metadata extends Doku_Renderer
         if (!isset($this->persistent['creator'])) {
             $this->persistent['creator'] = '';
         }
+
+        // The table of contents is always rebuilt from the page's headings during rendering and
+        // must never be part of the persistent metadata. Buggy plugin versions and callers of
+        // p_set_metadata() could leak it into the persistent data, which then caused the TOC to be
+        // appended again on every render, resulting in a permanently duplicated TOC (see #3179).
+        // Dropping it here lets such corrupted metadata heal itself on the next render.
+        if (isset($this->persistent['description']['tableofcontents'])) {
+            unset($this->persistent['description']['tableofcontents']);
+        }
+
         // reset metadata to persistent values
         $this->meta = $this->persistent;
     }


### PR DESCRIPTION
The table of contents is appended to the metadata on every render. When a tableofcontents entry leaks into the persistent metadata (e.g. via buggy plugin versions or callers of p_set_metadata that write back a full description array), document_start() copied it into the current metadata before the headings re-appended it, permanently duplicating the TOC.

The duplication was only visible when the XHTML output was served from cache, since a fresh render populates the global $TOC from a single pass. This explains why purging the cache or editing the page fixed it temporarily while a reload brought it back.

Strip the tableofcontents from the persistent metadata in document_start() so already-corrupted .meta files heal themselves on the next render.