### PR TITLE
fix(parser): bound and de-backtrack inline closer lookaheads

### DIFF
--- a/_test/tests/Parsing/ParserMode/FormattingTest.php
+++ b/_test/tests/Parsing/ParserMode/FormattingTest.php
@@ -349,4 +349,27 @@ class FormattingTest extends ParserTestBase
         $this->assertContains('strong_open', array_column($this->H->calls, 0));
         $this->assertContains('strong_close', array_column($this->H->calls, 0));
     }
+
+    /**
+     * The closer lookahead scans at most AbstractMode::CLOSER_SCAN_LIMIT
+     * (1024) characters: spans up to that length are recognized, a closer
+     * further away leaves the delimiters literal. The cap bounds the
+     * parser's worst case on delimiter-dense input that never closes.
+     */
+    function testCloserScanLimit()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->parse('**' . str_repeat('a', 1000) . '** **' . str_repeat('b', 2000) . '**');
+        $modes = array_column($this->H->calls, 0);
+        $this->assertContains(
+            'strong_open',
+            $modes,
+            'A 1000 character span must still be recognized'
+        );
+        $this->assertSame(
+            1,
+            count(array_keys($modes, 'strong_open')),
+            'A span whose closer is beyond the scan limit must stay literal'
+        );
+    }
 }

--- a/inc/Parsing/Lexer/ParallelRegex.php
+++ b/inc/Parsing/Lexer/ParallelRegex.php
@@ -86,6 +86,9 @@ class ParallelRegex
                     case PREG_BACKTRACK_LIMIT_ERROR:
                         msg('A PCRE backtrack error occured. Try to increase the pcre.backtrack_limit in php.ini', -1);
                         break;
+                    case PREG_JIT_STACKLIMIT_ERROR:
+                        msg('A PCRE JIT stacklimit error occured. Try to disable pcre.jit in php.ini', -1);
+                        break;
                     case PREG_RECURSION_LIMIT_ERROR:
                         msg('A PCRE recursion error occured. Try to increase the pcre.recursion_limit in php.ini', -1);
                         break;

--- a/inc/Parsing/ParserMode/AbstractMode.php
+++ b/inc/Parsing/ParserMode/AbstractMode.php
@@ -61,13 +61,72 @@ abstract class AbstractMode
     protected const NOT_AT_PARA_BREAK = '(?!\n[ \t]*\n)';
 
     /**
-     * Quantified group matching any character that does not start a paragraph
-     * break. Convenience for the common case of "consume until paragraph end".
+     * Maximum distance in bytes that closerAhead() scans for a closing
+     * delimiter. Spans whose closer sits further away from the opener
+     * (within the same paragraph) are not recognized and render as literal
+     * text. The cap bounds the parser's worst case on delimiter-dense
+     * input that never closes; see closerAhead() for the full reasoning.
+     */
+    protected const CLOSER_SCAN_LIMIT = 1024;
+
+    /**
+     * Builds a zero-width assertion: a closer matching the given pattern
+     * occurs within the next CLOSER_SCAN_LIMIT characters and before the
+     * next paragraph break.
      *
      * Example:
-     *     return '\*\*(?=' . self::CONTENT_UNTIL_PARA . '\*\*)';
+     *     return '\*\*(?=[^\s*])' . self::closerAhead('[^\s]\*\*');
+     *
+     * The scan advances one character at a time and stops at the first
+     * position where the closer matches. The quantifier is possessive, so
+     * the regex engine never backtracks into the scan and discards its
+     * backtracking state as it goes: one scan costs time linear in the
+     * distance to the closer and constant memory. On real content closers
+     * sit near their openers, so parsing stays effectively linear.
+     *
+     * The cap exists because the lexer runs this lookahead once per opener
+     * candidate: with an unbounded scan, a paragraph stuffed with openers
+     * that never close costs openers-times-paragraph-length - quadratic
+     * wall-clock on crafted input. The cap makes the worst case linear in
+     * the document size (openers times the cap), trading away spans longer
+     * than CLOSER_SCAN_LIMIT, which do not occur in real content. The
+     * naive greedy form this replaces (consume everything up to the
+     * paragraph break, then back up until the closer matches) had the
+     * unbounded quadratic worst case, hit it on ordinary pages too (any
+     * opener whose paragraph runs long re-scanned from the paragraph end)
+     * and kept one backtracking frame per scanned character while doing
+     * so: on large paragraphs that exhausted the PCRE JIT stack (the match
+     * silently failed and the lexer emitted everything after it as plain
+     * text) or, with the JIT disabled, the PHP memory limit. Truly linear
+     * parsing without a span-length limit needs closer verification
+     * outside the per-opener regex (CommonMark-style delimiter pairing).
+     *
+     * The closer pattern must not be able to match starting on whitespace:
+     * the scan stops unconditionally at a paragraph break and only tests the
+     * closer once there.
+     *
+     * The assertion is built from two lookaheads because of how PCRE
+     * compiles counted repeats: {0,n} on a GROUP is compiled by replicating
+     * the group's bytecode n times, so putting the cap directly on the
+     * scanning group blows the maximum pattern size ("regular expression is
+     * too large"). A counted repeat on a single dot compiles to one compact
+     * opcode instead. So the first lookahead probes, via a bounded lazy dot,
+     * that a closer occurs within the cap at all, and the second runs the
+     * possessive stop-at-the-first-closer scan described above - unbounded
+     * as written, but the first closer is within the cap when the probe
+     * succeeded and the scan never runs past the first closer, so it is
+     * bounded in effect.
+     *
+     * @param string $closer pattern for the closing delimiter, including any
+     *                       flanking context (e.g. a preceding non-whitespace
+     *                       character class)
+     * @return string
      */
-    protected const CONTENT_UNTIL_PARA = '(?:' . self::NOT_AT_PARA_BREAK . '.)*';
+    protected static function closerAhead(string $closer): string
+    {
+        return '(?=.{0,' . self::CLOSER_SCAN_LIMIT . '}?' . $closer . ')'
+            . '(?=(?:' . self::NOT_AT_PARA_BREAK . '(?!' . $closer . ').)*+' . $closer . ')';
+    }
 
     /**
      * Character class: a single "non-word" character — ASCII whitespace or

--- a/inc/Parsing/ParserMode/Deleted.php
+++ b/inc/Parsing/ParserMode/Deleted.php
@@ -19,7 +19,7 @@ class Deleted extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<del>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</del>)';
+        return '<del>(?=[^\s])' . self::closerAhead('[^\s]</del>');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Emphasis.php
+++ b/inc/Parsing/ParserMode/Emphasis.php
@@ -28,7 +28,7 @@ class Emphasis extends AbstractFormatting
      */
     protected function getEntryPattern(): string
     {
-        return '//(?=[^\s/])(?=' . self::CONTENT_UNTIL_PARA . '[^\s:]//)';
+        return '//(?=[^\s/])' . self::closerAhead('[^\s:]//');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmBacktickDouble.php
+++ b/inc/Parsing/ParserMode/GfmBacktickDouble.php
@@ -31,15 +31,15 @@ class GfmBacktickDouble extends GfmBacktickSingle
 
     /**
      * Entry pattern. Same shape as the parent but with doubled
-     * delimiters. The body character class admits either a non-backtick
-     * or a lone backtick (one that isn't followed by another, so not
-     * part of a run-of-two) — such a stray backtick cannot form a valid
-     * n=2 closer.
+     * delimiters. The body admits a lone backtick (one that isn't
+     * followed by another, so not part of a run-of-two) instead of the
+     * parent's backtick runs — such a stray backtick cannot form a valid
+     * n=2 closer. Deterministic and possessive like the parent's body.
      */
     protected function getEntryPattern(): string
     {
         return '(?<!`)``(?!`)(?='
-            . '(?:' . self::NOT_AT_PARA_BREAK . '(?:[^`]|`(?!`)))+'
+            . '(?:[^`\n]++|\n(?![ \t]*\n)|`(?!`))++'
             . '(?<!`)``(?!`)'
             . ')';
     }

--- a/inc/Parsing/ParserMode/GfmBacktickSingle.php
+++ b/inc/Parsing/ParserMode/GfmBacktickSingle.php
@@ -56,15 +56,21 @@ class GfmBacktickSingle extends AbstractMode
     /**
      * Entry pattern. The length-boundary guards (?<!`)...(?!`) around
      * each delimiter ensure a run of two or more backticks is never read
-     * as an n=1 opener or closer. The body character class, which admits
-     * either a non-backtick or a run of two-or-more backticks, lets
-     * those longer runs live inside the body since they cannot be valid
-     * n=1 closers.
+     * as an n=1 opener or closer. The body admits runs of non-backticks,
+     * newlines that don't start a blank line, and runs of two-or-more
+     * backticks — the latter live inside the body since they cannot be
+     * valid n=1 closers.
+     *
+     * The body alternatives start with mutually exclusive characters and
+     * all quantifiers are possessive, so the closer-existence scan never
+     * backtracks: it stops at the first lone backtick (or fails at the
+     * paragraph break) without accumulating backtracking state. See
+     * AbstractMode::closerAhead() for why that matters.
      */
     protected function getEntryPattern(): string
     {
         return '(?<!`)`(?!`)(?='
-            . '(?:' . self::NOT_AT_PARA_BREAK . '(?:[^`]|``+))+'
+            . '(?:[^`\n]++|\n(?![ \t]*\n)|``++)++'
             . '(?<!`)`(?!`)'
             . ')';
     }

--- a/inc/Parsing/ParserMode/GfmDeleted.php
+++ b/inc/Parsing/ParserMode/GfmDeleted.php
@@ -36,13 +36,13 @@ class GfmDeleted extends AbstractFormatting
         //                            are fenced-code markers, not strike)
         //   ~~                     — two opening tildes
         //   (?=[^\s~])             — next body char: not whitespace, not `~`
-        //   (?=                    — lookahead: a valid closer must exist
-        //     CONTENT_UNTIL_PARA   —   body that doesn't cross a blank line
+        //   closerAhead(           — lookahead: a valid closer must exist
+        //                            before the next blank line
         //     [^\s]~~              —   non-whitespace, then closing `~~`
         //     (?!~)                —   and not followed by another `~`
         //   )
         return '(?<!~)~~(?=[^\s~])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]~~(?!~))';
+            . self::closerAhead('[^\s]~~(?!~)');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasisStrong.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisStrong.php
@@ -38,8 +38,8 @@ class GfmEmphasisStrong extends AbstractFormatting
         //   \*\*\*                   — exactly three opening `*`
         //   (?=[^\s*])               — next body char: not whitespace, not `*`
         //                              (flanking-opener rule)
-        //   (?=                      — lookahead: a valid closer must exist
-        //     CONTENT_UNTIL_PARA     —   body that doesn't cross a paragraph
+        //   closerAhead(             — lookahead: a valid closer must exist
+        //                              before the next paragraph break
         //     [^\s]                  —   last body char: not whitespace
         //                              (flanking-closer rule)
         //     \*\*\*                 —   closing `***`
@@ -47,7 +47,7 @@ class GfmEmphasisStrong extends AbstractFormatting
         //                              (exactly 3, not 4+)
         //   )
         return '(?<!\*)\*\*\*(?=[^\s*])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\*\*\*(?!\*))';
+            . self::closerAhead('[^\s]\*\*\*(?!\*)');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasisStrongUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisStrongUnderscore.php
@@ -31,7 +31,7 @@ class GfmEmphasisStrongUnderscore extends GfmEmphasisStrong
         // `(?!_)` for exactly-3 length, and NO_WORD_AFTER for word-boundary.
         return self::NO_WORD_BEFORE
             . '(?<!_)___(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]___(?!_)' . self::NO_WORD_AFTER . ')';
+            . self::closerAhead('[^\s]___(?!_)' . self::NO_WORD_AFTER);
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasisUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisUnderscore.php
@@ -38,7 +38,7 @@ class GfmEmphasisUnderscore extends AbstractFormatting
         // to ever close (or close at an invalid position).
         return self::NO_WORD_BEFORE
             . '_(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]_' . self::NO_WORD_AFTER . ')';
+            . self::closerAhead('[^\s]_' . self::NO_WORD_AFTER);
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmStrongUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmStrongUnderscore.php
@@ -35,7 +35,7 @@ class GfmStrongUnderscore extends AbstractFormatting
     {
         return self::NO_WORD_BEFORE
             . '__(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]__' . self::NO_WORD_AFTER . ')';
+            . self::closerAhead('[^\s]__' . self::NO_WORD_AFTER);
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Monospace.php
+++ b/inc/Parsing/ParserMode/Monospace.php
@@ -19,7 +19,7 @@ class Monospace extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '\x27\x27(?=[^\s\x27])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\x27\x27)';
+        return '\x27\x27(?=[^\s\x27])' . self::closerAhead('[^\s]\x27\x27');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Strong.php
+++ b/inc/Parsing/ParserMode/Strong.php
@@ -22,7 +22,7 @@ class Strong extends AbstractFormatting
         // Flanking rules (simplified): opener must be followed by non-whitespace
         // non-`*`; closer must be preceded by non-whitespace. This rejects
         // `** foo**`, `**foo **`, and empty pairs `****`.
-        return '\*\*(?=[^\s*])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\*\*)';
+        return '\*\*(?=[^\s*])' . self::closerAhead('[^\s]\*\*');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Subscript.php
+++ b/inc/Parsing/ParserMode/Subscript.php
@@ -19,7 +19,7 @@ class Subscript extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<sub>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</sub>)';
+        return '<sub>(?=[^\s])' . self::closerAhead('[^\s]</sub>');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Superscript.php
+++ b/inc/Parsing/ParserMode/Superscript.php
@@ -19,7 +19,7 @@ class Superscript extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<sup>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</sup>)';
+        return '<sup>(?=[^\s])' . self::closerAhead('[^\s]</sup>');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Underline.php
+++ b/inc/Parsing/ParserMode/Underline.php
@@ -19,7 +19,7 @@ class Underline extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '__(?=[^\s_])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]__)';
+        return '__(?=[^\s_])' . self::closerAhead('[^\s]__');
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
The inline formatting entry patterns verified closer existence with a greedy scan (CONTENT_UNTIL_PARA) that consumed everything up to the next paragraph break and then backtracked until the closer matched. That re-scanned from the paragraph end once per opener - quadratic time even on ordinary pages whose paragraphs run long - and kept one backtracking frame per scanned character: on paragraphs of roughly 32KB and up that exhausted the PCRE JIT stack, silently failing the match so everything after it rendered as plain text, or exhausted the PHP memory limit with the JIT disabled. Crafted delimiter-dense input hit the quadratic case at will (20+ seconds for a 32KB page).

Replace the greedy scan with closerAhead(): a possessive scan that stops at the first valid closer, never backtracks and keeps no state, capped at CLOSER_SCAN_LIMIT (1024) characters so the worst case is linear in the document size instead of quadratic in the paragraph length. Spans whose closer sits further away inside one paragraph now render literal; such spans do not occur in real content and previously broke the whole remainder of the page via the JIT stack failure. The cap is implemented as a bounded lazy-dot probe combined with the possessive scan because a counted repeat on the scanning group itself would be replicated at compile time and exceed PCRE's pattern size limit.

The adversarial 32KB page drops from 20+ seconds to under half a second without JIT; a benign 34KB page without blank lines goes from silent markup loss (JIT) or a memory-limit fatal (no JIT) to parsing correctly in well under a second either way.

Give the GFM backtick body loops the same treatment: deterministic alternatives with possessive quantifiers, removing their per-character backtracking frames. Report PREG_JIT_STACKLIMIT_ERROR in ParallelRegex::split() so any future JIT stack exhaustion surfaces a message instead of silently truncating the parse. Add a regression test codifying the scan cap.

Note: the issue was found and addressed by Claude Fable. I gave it a first review and the approach looks fine, but I want to give it a bit more review before merging. I think we're really hitting the limitations of our parser here.