### PR TITLE
fix(parser): verify inline formatting closers without rescanning per opener

### DIFF
--- a/_test/tests/Parsing/Lexer/LexerTest.php
+++ b/_test/tests/Parsing/Lexer/LexerTest.php
@@ -6,7 +6,7 @@ use dokuwiki\Parsing\Lexer\Lexer;
 
 class LexerTest extends \DokuWikiTest
 {
-    function testNoPatterns()
+    public function testNoPatterns()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler);
@@ -14,7 +14,7 @@ class LexerTest extends \DokuWikiTest
         $this->assertSame([], $handler->recorded);
     }
 
-    function testEmptyPage()
+    public function testEmptyPage()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler);
@@ -23,7 +23,7 @@ class LexerTest extends \DokuWikiTest
         $this->assertSame([], $handler->recorded);
     }
 
-    function testSinglePattern()
+    public function testSinglePattern()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler);
@@ -41,7 +41,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testMultiplePattern()
+    public function testMultiplePattern()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler);
@@ -53,7 +53,7 @@ class LexerTest extends \DokuWikiTest
         $this->assertSame($expected, $actual);
     }
 
-    function testIsolatedPattern()
+    public function testIsolatedPattern()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "a");
@@ -72,7 +72,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testModeChange()
+    public function testModeChange()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "a");
@@ -97,7 +97,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testNesting()
+    public function testNesting()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "a");
@@ -121,7 +121,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testSingular()
+    public function testSingular()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "a");
@@ -138,7 +138,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testUnwindTooFar()
+    public function testUnwindTooFar()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "a");
@@ -151,7 +151,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testModeMapping()
+    public function testModeMapping()
     {
         $handler = new RecordingHandler();
         $lexer = new Lexer($handler, "mode_a");
@@ -173,7 +173,7 @@ class LexerTest extends \DokuWikiTest
         ], $handler->recorded);
     }
 
-    function testIndex()
+    public function testIndex()
     {
         $doc = "aaa<file>bcd</file>eee";
         $handler = new RecordingHandler();
@@ -195,7 +195,7 @@ class LexerTest extends \DokuWikiTest
         ], $caught);
     }
 
-    function testIndexLookaheadEqual()
+    public function testIndexLookaheadEqual()
     {
         $doc = "aaa<file>bcd</file>eee";
         $handler = new RecordingHandler();
@@ -217,7 +217,7 @@ class LexerTest extends \DokuWikiTest
         ], $caught);
     }
 
-    function testIndexLookaheadNotEqual()
+    public function testIndexLookaheadNotEqual()
     {
         $doc = "aaa<file>bcd</file>eee";
         $handler = new RecordingHandler();
@@ -239,7 +239,7 @@ class LexerTest extends \DokuWikiTest
         ], $caught);
     }
 
-    function testIndexLookbehindEqual()
+    public function testIndexLookbehindEqual()
     {
         $doc = "aaa<file>bcd</file>eee";
         $handler = new RecordingHandler();
@@ -261,7 +261,7 @@ class LexerTest extends \DokuWikiTest
         ], $caught);
     }
 
-    function testIndexLookbehindNotEqual()
+    public function testIndexLookbehindNotEqual()
     {
         $doc = "aaa<file>bcd</file>eee";
         $handler = new RecordingHandler();
@@ -297,7 +297,7 @@ class LexerTest extends \DokuWikiTest
      * `<a/>` that was consumed as a SPECIAL token on the previous step. Before
      * the fix, `</x>` would fall out as UNMATCHED instead of EXIT.
      */
-    function testIndexLookbehindAcrossConsumedToken()
+    public function testIndexLookbehindAcrossConsumedToken()
     {
         $doc = "<x><a/></x>";
         $handler = new RecordingHandler();
@@ -320,7 +320,7 @@ class LexerTest extends \DokuWikiTest
      * This test is primarily to ensure the correct match is chosen
      * when there are non-captured elements in the pattern.
      */
-    function testIndexSelectCorrectMatch()
+    public function testIndexSelectCorrectMatch()
     {
         $doc = "ALL FOOLS ARE FOO";
         $pattern = '\bFOO\b';
@@ -336,5 +336,185 @@ class LexerTest extends \DokuWikiTest
         $this->assertSame('FOO', $caught[0][1]);
         $this->assertSame(\DOKU_LEXER_SPECIAL, $caught[0][2]);
         $this->assertSame($matches[0][1], $caught[0][3]);
+    }
+
+    public function testCloserPatternSkipsCandidateWithoutCloserBeforeBoundary()
+    {
+        // no closer (\w followed by **) before the blank line: the first
+        // ** stays literal; the span after the boundary still matches
+        $doc = "** foo\n\n**bar**";
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('\w\*\*', 'caught', '\n\n');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $caught = array_values(array_filter($handler->recorded, fn($c) => $c[0] === 'caught'));
+        $this->assertSame([
+            ['caught', '**', \DOKU_LEXER_ENTER, 8],
+            ['caught', 'bar', \DOKU_LEXER_UNMATCHED, 10],
+            ['caught', '**', \DOKU_LEXER_EXIT, 13],
+        ], $caught);
+        // the rejected candidate stays part of the unmatched text
+        $this->assertSame(['ignore', "** foo\n\n", \DOKU_LEXER_UNMATCHED, 0], $handler->recorded[0]);
+    }
+
+    public function testCloserPatternWithoutBoundaryScansWholeSubject()
+    {
+        // same shape, but with no boundary the closer behind the blank
+        // line counts and the first ** does enter the mode
+        $doc = "** foo\n\n**bar**";
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('\w\*\*', 'caught');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $this->assertSame(['caught', '**', \DOKU_LEXER_ENTER, 0], $handler->recorded[0]);
+    }
+
+    public function testCloserPatternRejectsAllCandidates()
+    {
+        $doc = 'a ** b ** c';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('\w\*\*', 'caught');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $this->assertSame([
+            ['ignore', 'a ** b ** c', \DOKU_LEXER_UNMATCHED, 0],
+        ], $handler->recorded);
+    }
+
+    public function testCloserScanIgnoresCloserInsideSpecialPatternMatch()
+    {
+        // the only closer candidate sits inside a special pattern's match,
+        // which the lexer consumes atomically — the scan must not count it,
+        // so the entry is rejected
+        $doc = 'a **b %%c** d%% e';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('(?<=\w)\*\*', 'caught');
+        $lexer->addSpecialPattern('%%.*?%%', 'caught', 'prot');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $this->assertSame([
+            ['ignore', $doc, \DOKU_LEXER_UNMATCHED, 0],
+        ], $handler->recorded);
+    }
+
+    public function testCloserScanFindsCloserBehindSpecialPatternMatch()
+    {
+        // a real closer behind the atomically consumed span still
+        // validates the entry
+        $doc = 'a **b %%c** d%% e** f';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('(?<=\w)\*\*', 'caught');
+        $lexer->addSpecialPattern('%%.*?%%', 'caught', 'prot');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $this->assertSame(['caught', '**', \DOKU_LEXER_ENTER, 2], $handler->recorded[1]);
+    }
+
+    public function testCloserScanIgnoresCloserInsideVerbatimModeSpan()
+    {
+        // the only closer candidate sits inside the span of a nested
+        // verbatim mode (only exit patterns of its own): the scan derives
+        // the span from the entry and exit patterns and skips it
+        $doc = 'a **b <v>c** d</v> e';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('(?<=\w)\*\*', 'caught');
+        $lexer->addEntryPattern('<v>', 'caught', 'verb');
+        $lexer->addExitPattern('</v>', 'verb');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        $this->assertTrue($lexer->parse($doc));
+        $this->assertSame([
+            ['ignore', $doc, \DOKU_LEXER_UNMATCHED, 0],
+        ], $handler->recorded);
+    }
+
+    public function testCloserMemoIsResetBetweenParses()
+    {
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'caught');
+        $lexer->addCloserPattern('\w\*\*', 'caught');
+        $lexer->addExitPattern('\*\*', 'caught');
+
+        // first parse memoizes "no closer from position 4 onwards"
+        $this->assertTrue($lexer->parse('x ** a'));
+        $this->assertSame([
+            ['ignore', 'x ** a', \DOKU_LEXER_UNMATCHED, 0],
+        ], $handler->recorded);
+
+        // a stale memo would reject the same position in the next subject
+        $handler->recorded = [];
+        $this->assertTrue($lexer->parse('x **b** c'));
+        $this->assertSame(['caught', '**', \DOKU_LEXER_ENTER, 2], $handler->recorded[1]);
+    }
+
+    public function testCloserCheckLooksPastUnguardedEnclosingMode()
+    {
+        // inner // sits in an unguarded middle mode inside a guarded outer
+        // mode; its only closer lies beyond the outer closer. The enclosing
+        // check must step over the unguarded middle, reach the outer, and
+        // reject, so the inner // stays literal instead of pairing across the
+        // middle and outer boundaries.
+        $doc = '**A ((B //C)) D** E F//G//';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'outer');
+        $lexer->addCloserPattern('(?<=\w)\*\*', 'outer');
+        $lexer->addEntryPattern('\(\(', 'outer', 'middle'); // unguarded: no closer
+        $lexer->addExitPattern('\)\)', 'middle');
+        $lexer->addEntryPattern('//', 'middle', 'inner');
+        $lexer->addCloserPattern('(?<=\w)//', 'inner');
+        $lexer->addExitPattern('//', 'inner');
+        $lexer->addExitPattern('\*\*', 'outer');
+
+        $this->assertTrue($lexer->parse($doc));
+        $enterModes = array_column(
+            array_filter($handler->recorded, fn($c) => $c[2] === \DOKU_LEXER_ENTER),
+            0
+        );
+        $this->assertContains('outer', $enterModes);
+        $this->assertContains('middle', $enterModes);
+        $this->assertNotContains('inner', $enterModes);
+    }
+
+    public function testCloserCheckAllowsInnerClosingBeforeGuardedAncestor()
+    {
+        // same shape, but the inner // now closes before the outer closer, so
+        // nesting through the unguarded middle is allowed
+        $doc = '**A ((B //C// D)) E**';
+        $handler = new RecordingHandler();
+        $lexer = new Lexer($handler, 'ignore', true);
+        $lexer->addEntryPattern('\*\*', 'ignore', 'outer');
+        $lexer->addCloserPattern('(?<=\w)\*\*', 'outer');
+        $lexer->addEntryPattern('\(\(', 'outer', 'middle'); // unguarded: no closer
+        $lexer->addExitPattern('\)\)', 'middle');
+        $lexer->addEntryPattern('//', 'middle', 'inner');
+        $lexer->addCloserPattern('(?<=\w)//', 'inner');
+        $lexer->addExitPattern('//', 'inner');
+        $lexer->addExitPattern('\*\*', 'outer');
+
+        $this->assertTrue($lexer->parse($doc));
+        $enterModes = array_column(
+            array_filter($handler->recorded, fn($c) => $c[2] === \DOKU_LEXER_ENTER),
+            0
+        );
+        $this->assertContains('inner', $enterModes);
     }
 }

--- a/_test/tests/Parsing/ParserMode/FormattingTest.php
+++ b/_test/tests/Parsing/ParserMode/FormattingTest.php
@@ -4,22 +4,26 @@ namespace dokuwiki\test\Parsing\ParserMode;
 
 use dokuwiki\Parsing\ParserMode\Deleted;
 use dokuwiki\Parsing\ParserMode\Emphasis;
+use dokuwiki\Parsing\ParserMode\Externallink;
+use dokuwiki\Parsing\ParserMode\Footnote;
 use dokuwiki\Parsing\ParserMode\Internallink;
 use dokuwiki\Parsing\ParserMode\Monospace;
 use dokuwiki\Parsing\ParserMode\Strong;
 use dokuwiki\Parsing\ParserMode\Subscript;
 use dokuwiki\Parsing\ParserMode\Superscript;
 use dokuwiki\Parsing\ParserMode\Underline;
+use dokuwiki\Parsing\ParserMode\Unformatted;
 
 /**
  * Tests for the individual formatting modes (bold, italic, underline, etc.)
  */
 class FormattingTest extends ParserTestBase
 {
-    function testStrong()
+    public function testStrong()
     {
         $this->P->addMode('strong', new Strong());
         $this->P->parse('Foo **Bar** Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -34,10 +38,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testEmphasis()
+    public function testEmphasis()
     {
         $this->P->addMode('emphasis', new Emphasis());
         $this->P->parse('Foo //Bar// Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -52,10 +57,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testUnderline()
+    public function testUnderline()
     {
         $this->P->addMode('underline', new Underline());
         $this->P->parse('Foo __Bar__ Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -70,10 +76,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testMonospace()
+    public function testMonospace()
     {
         $this->P->addMode('monospace', new Monospace());
         $this->P->parse("Foo ''Bar'' Baz");
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -88,10 +95,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSubscript()
+    public function testSubscript()
     {
         $this->P->addMode('subscript', new Subscript());
         $this->P->parse('Foo <sub>Bar</sub> Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -106,10 +114,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSuperscript()
+    public function testSuperscript()
     {
         $this->P->addMode('superscript', new Superscript());
         $this->P->parse('Foo <sup>Bar</sup> Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -124,10 +133,11 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testDeleted()
+    public function testDeleted()
     {
         $this->P->addMode('deleted', new Deleted());
         $this->P->parse('Foo <del>Bar</del> Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -142,11 +152,12 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testNesting()
+    public function testNesting()
     {
         $this->P->addMode('strong', new Strong());
         $this->P->addMode('emphasis', new Emphasis());
         $this->P->parse('Foo **bold //and italic// text** Bar');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -165,7 +176,7 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testStrongClosesAfterLink()
+    public function testStrongClosesAfterLink()
     {
         // Regression: `**[[link]]**` must close Strong on the trailing `**`.
         // Strong's exit pattern `(?<=[^\s])\*\*` needs to see the `]` that
@@ -175,6 +186,7 @@ class FormattingTest extends ParserTestBase
         $this->P->addMode('strong', new Strong());
         $this->P->addMode('internallink', new Internallink());
         $this->P->parse('**[[wiki:x|link]]** bar');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -189,7 +201,7 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testStrongClosesAfterEmphasis()
+    public function testStrongClosesAfterEmphasis()
     {
         // Regression: `**foo//bar//**` — after emphasis closes, Strong's
         // closing `**` must still match; its lookbehind sees the `/` left
@@ -197,6 +209,7 @@ class FormattingTest extends ParserTestBase
         $this->P->addMode('strong', new Strong());
         $this->P->addMode('emphasis', new Emphasis());
         $this->P->parse('**foo//bar//**');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -214,7 +227,7 @@ class FormattingTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testNoSelfNesting()
+    public function testNoSelfNesting()
     {
         // With flanking-aware Strong: an opener matches only if a valid
         // closer exists (closer preceded by non-whitespace); a closer only
@@ -224,6 +237,7 @@ class FormattingTest extends ParserTestBase
         // Strong does not re-open inside itself.
         $this->P->addMode('strong', new Strong());
         $this->P->parse('Foo **bold **not nested** end** Bar');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -246,7 +260,7 @@ class FormattingTest extends ParserTestBase
      * further down must stay literal — otherwise the lexer greedily swallows
      * the paragraph break.
      */
-    function testDelimitersDoNotSpanParagraphBoundary(
+    public function testDelimitersDoNotSpanParagraphBoundary(
         string $modeName,
         $mode,
         string $input
@@ -279,7 +293,7 @@ class FormattingTest extends ParserTestBase
      * A single newline inside a delimiter pair is still valid (multi-line
      * formatting), only blank lines end it.
      */
-    function testStrongAllowsSingleNewline()
+    public function testStrongAllowsSingleNewline()
     {
         $this->P->addMode('strong', new Strong());
         $this->P->parse("**open\nclose**");
@@ -297,7 +311,7 @@ class FormattingTest extends ParserTestBase
      * a non-whitespace character, and a closing delimiter must be preceded
      * by one. Empty delimiter pairs stay literal.
      */
-    function testFlankingRejectsInvalidDelimiters(
+    public function testFlankingRejectsInvalidDelimiters(
         string $modeName,
         $mode,
         string $input
@@ -342,11 +356,363 @@ class FormattingTest extends ParserTestBase
     /**
      * Single-character bodies still match, they're the smallest valid span.
      */
-    function testStrongSingleCharacterBody()
+    public function testStrongSingleCharacterBody()
     {
         $this->P->addMode('strong', new Strong());
         $this->P->parse('**a**');
         $this->assertContains('strong_open', array_column($this->H->calls, 0));
         $this->assertContains('strong_close', array_column($this->H->calls, 0));
+    }
+
+    /**
+     * An opener without a valid closer must stay literal while a later
+     * valid span in the same paragraph still matches. The closer scan
+     * rejects the first candidate (its only potential closer is preceded
+     * by whitespace, or is the very opener of the valid span) without
+     * blocking the second.
+     *
+     * @dataProvider provideRejectedOpenerBeforeValidSpan
+     */
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral(
+        string $modeName,
+        $mode,
+        string $input,
+        string $openInstruction
+    ) {
+        $this->P->addMode($modeName, $mode);
+        $this->P->parse($input);
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains([$openInstruction, []], $calls);
+        $this->assertContains(['cdata', ['bar']], $calls);
+        $this->assertStringContainsString(' foo ', $this->H->calls[2][1][0]);
+    }
+
+    public static function provideRejectedOpenerBeforeValidSpan(): array
+    {
+        return [
+            'strong'      => ['strong',      new Strong(),      '** foo **bar**',          'strong_open'],
+            'emphasis'    => ['emphasis',    new Emphasis(),    '// foo //bar//',          'emphasis_open'],
+            'underline'   => ['underline',   new Underline(),   '__ foo __bar__',          'underline_open'],
+            'monospace'   => ['monospace',   new Monospace(),   "'' foo ''bar''",          'monospace_open'],
+            'deleted'     => ['deleted',     new Deleted(),     '<del> foo <del>bar</del>', 'deleted_open'],
+            'subscript'   => ['subscript',   new Subscript(),   '<sub> foo <sub>bar</sub>', 'subscript_open'],
+            'superscript' => ['superscript', new Superscript(), '<sup> foo <sup>bar</sup>', 'superscript_open'],
+        ];
+    }
+
+    /**
+     * A closer in the next paragraph must not validate an opener in the
+     * current one, and the paragraph after a rejected opener must parse
+     * normally (the closer-free memo range ends at the paragraph break).
+     */
+    public function testRejectedOpenerDoesNotAffectNextParagraph()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->parse("**no closer here\n\n**closed** here");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['cdata', ["\n**no closer here\n\n"]], $calls);
+        $this->assertContains(['strong_open', []], $calls);
+        $this->assertContains(['cdata', ['closed']], $calls);
+    }
+
+    /**
+     * There is no length limit on a formatting span within a paragraph:
+     * real pages contain styled spans well beyond 32KB, which must not
+     * degrade to literal text. This is what caps the closer scan cannot
+     * provide (a PCRE counted repeat maxes out at 65535) and why the scan
+     * runs as a memoized lexer closer pattern instead.
+     */
+    public function testVeryLongSpanIsRecognized()
+    {
+        $body = trim(str_repeat('some words ', 7000)); // ~77KB
+        $this->P->addMode('strong', new Strong());
+        $this->P->parse('**' . $body . '**');
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['strong_open', []], $calls);
+        $this->assertContains(['cdata', [$body]], $calls);
+    }
+
+    /**
+     * Delimiter-dense input without any closer must stay literal — and,
+     * although a test can't assert wall clock, it exercises the memoized
+     * closer-free range that keeps this shape linear instead of scanning
+     * the paragraph once per opener.
+     */
+    public function testManyOpenersWithoutCloserStayLiteral()
+    {
+        $text = trim(str_repeat('**a ', 500));
+        $this->P->addMode('strong', new Strong());
+        $this->P->parse($text);
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['strong_open', []], $calls);
+        $this->assertContains(['cdata', ["\n" . $text]], $calls);
+    }
+
+    /**
+     * An inner delimiter must not pair with one in a following sibling span:
+     * its closer lies beyond the enclosing mode's closer, so it can never
+     * close within the parent and must stay literal. Here the `//` inside the
+     * first `''…''` would otherwise reach the `//` of the second, dragging the
+     * monospace boundary along with it.
+     */
+    public function testInnerDelimiterDoesNotSpanEnclosingCloser()
+    {
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->parse("''a//b'', ''c//d''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['a//b']], $calls);
+        $this->assertContains(['cdata', ['c//d']], $calls);
+    }
+
+    /**
+     * The counterpart to the above: an inner delimiter whose closer does sit
+     * inside the enclosing span still nests normally.
+     */
+    public function testInnerDelimiterClosingWithinEnclosingSpanNests()
+    {
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->parse("''a//b//c''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['monospace_open', []], $calls);
+        $this->assertContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['b']], $calls);
+    }
+
+    /**
+     * The enclosing closer may directly follow the inner opener. The `//`
+     * in the first `''…''` sits right before the closing `''`, so it can
+     * only pair with the `//` of the second span — it must stay literal
+     * even though no character separates it from the monospace closer.
+     */
+    public function testInnerDelimiterAdjacentToEnclosingCloserStaysLiteral()
+    {
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->parse("''//'', ''a c//d''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['//']], $calls);
+        $this->assertContains(['cdata', ['a c//d']], $calls);
+    }
+
+    /**
+     * A closer lookalike inside protected content does not count against a
+     * nested delimiter: the `''` inside the nowiki span never closes the
+     * monospace mode, so the emphasis pair around it still nests.
+     */
+    public function testFakeEnclosingCloserInProtectedContentStillNests()
+    {
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('unformatted', new Unformatted());
+        $this->P->parse("''a //b <nowiki>x''y</nowiki> c// d''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['emphasis_open', []], $calls);
+        $this->assertContains(['unformatted', ["x''y"]], $calls);
+        $this->assertContains(['cdata', [' d']], $calls);
+    }
+
+    /**
+     * A closer lookalike inside protected content does not validate an
+     * opener either: the only `''` after the candidate lies in a nowiki
+     * span the lexer will consume verbatim, so monospace never opens.
+     */
+    public function testFakeCloserInProtectedContentDoesNotOpenFormatting()
+    {
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('unformatted', new Unformatted());
+        $this->P->parse("x ''a <nowiki>b''</nowiki> c");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['monospace_open', []], $calls);
+        $this->assertContains(['unformatted', ["b''"]], $calls);
+    }
+
+    /**
+     * A guarded formatting mode may enclose an unguarded mode (a footnote)
+     * that itself contains formatting. The enclosing-closer check must look
+     * past the unguarded footnote to the strong span: the inner // has its
+     * only closer beyond the strong closer, so it stays literal instead of
+     * opening inside the footnote and pairing across the footnote and strong
+     * boundaries (which left strong unclosed).
+     */
+    public function testFormattingInsideFootnoteDoesNotPairAcrossEnclosingStrong()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('footnote', new Footnote());
+        $this->P->parse('**b ((n //x)) c** and //y//');
+
+        $names = array_column($this->flattenCalls($this->H->calls), 0);
+        $counts = array_count_values($names);
+
+        // emphasis opens once, for the trailing //y// only, not inside the footnote
+        $this->assertSame(1, $counts['emphasis_open'] ?? 0);
+        // strong is closed properly rather than left dangling
+        $this->assertArrayHasKey('strong_close', $counts);
+    }
+
+    /**
+     * A // preceded by a colon is a valid emphasis closer, so the span in
+     * //identifier:// closes at that delimiter and the following **label**
+     * is emitted as strong.
+     */
+    public function testEmphasisClosesAtColonPrecededDelimiter()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('externallink', new Externallink());
+        $this->P->parse('//identifier:// **label**');
+
+        $calls = [
+            ['document_start', []],
+            ['p_open', []],
+            ['cdata', ["\n"]],
+            ['emphasis_open', []],
+            ['cdata', ['identifier:']],
+            ['emphasis_close', []],
+            ['cdata', [' ']],
+            ['strong_open', []],
+            ['cdata', ['label']],
+            ['strong_close', []],
+            ['cdata', ['']],
+            ['p_close', []],
+            ['document_end', []],
+        ];
+        $this->assertCalls($calls, $this->H->calls);
+    }
+
+    /**
+     * A recognized URL scheme is consumed as a link token whose content the
+     * closer scan never looks into, so the // in http:// cannot close the
+     * span. Emphasis wraps the whole run and closes at the trailing //.
+     */
+    public function testEmphasisWrapsRecognizedUrl()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('externallink', new Externallink());
+        $this->P->parse('//italic known url http://foo.com/bar is here//');
+
+        $calls = [
+            ['document_start', []],
+            ['p_open', []],
+            ['cdata', ["\n"]],
+            ['emphasis_open', []],
+            ['cdata', ['italic known url ']],
+            ['externallink', ['http://foo.com/bar', null]],
+            ['cdata', [' is here']],
+            ['emphasis_close', []],
+            ['cdata', ['']],
+            ['p_close', []],
+            ['document_end', []],
+        ];
+        $this->assertCalls($calls, $this->H->calls);
+    }
+
+    /**
+     * An unrecognized scheme is plain text and gets no special guarding: the
+     * // in proto:// closes emphasis like any other delimiter, and the text
+     * past that closer stays literal.
+     */
+    public function testUnrecognizedSchemeClosesEmphasis()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('externallink', new Externallink());
+        $this->P->parse('//italic unknown url proto://foo.com/bar is here//');
+
+        $calls = [
+            ['document_start', []],
+            ['p_open', []],
+            ['cdata', ["\n"]],
+            ['emphasis_open', []],
+            ['cdata', ['italic unknown url proto:']],
+            ['emphasis_close', []],
+            ['cdata', ['foo.com/bar is here//']],
+            ['p_close', []],
+            ['document_end', []],
+        ];
+        $this->assertCalls($calls, $this->H->calls);
+    }
+
+    /**
+     * A recognized URL greedily consumes the trailing //, so no closer
+     * remains before the paragraph break. The opener therefore stays literal
+     * rather than opening a span that could never close.
+     */
+    public function testRecognizedUrlEatingTrailingCloserLeavesOpenerLiteral()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('externallink', new Externallink());
+        $this->P->parse('//italic known url http://foo.com/bar//');
+
+        $calls = [
+            ['document_start', []],
+            ['p_open', []],
+            ['cdata', ["\n//italic known url "]],
+            ['externallink', ['http://foo.com/bar//', null]],
+            ['cdata', ['']],
+            ['p_close', []],
+            ['document_end', []],
+        ];
+        $this->assertCalls($calls, $this->H->calls);
+    }
+
+    /**
+     * An unrecognized scheme's // closes emphasis at proto://; the trailing
+     * // has nothing after it to open a new span and stays literal.
+     */
+    public function testUnrecognizedSchemeClosesEmphasisWithLiteralTail()
+    {
+        $this->P->addMode('strong', new Strong());
+        $this->P->addMode('emphasis', new Emphasis());
+        $this->P->addMode('externallink', new Externallink());
+        $this->P->parse('//italic unknown url proto://foo.com/bar//');
+
+        $calls = [
+            ['document_start', []],
+            ['p_open', []],
+            ['cdata', ["\n"]],
+            ['emphasis_open', []],
+            ['cdata', ['italic unknown url proto:']],
+            ['emphasis_close', []],
+            ['cdata', ['foo.com/bar//']],
+            ['p_close', []],
+            ['document_end', []],
+        ];
+        $this->assertCalls($calls, $this->H->calls);
+    }
+
+    /**
+     * Flatten a handler call list, inlining the calls a footnote buffers in
+     * its nest rewrite, into a list of [name, args] pairs.
+     *
+     * @param array $calls
+     * @return array[]
+     */
+    private function flattenCalls(array $calls): array
+    {
+        $out = [];
+        foreach ($calls as $call) {
+            if ($call[0] === 'nest') {
+                $out = array_merge($out, $this->flattenCalls($call[1][0]));
+            } else {
+                $out[] = [$call[0], $call[1]];
+            }
+        }
+        return $out;
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmDeletedTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmDeletedTest.php
@@ -15,10 +15,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->setSyntax('md');
     }
 
-    function testBasicStrikethrough()
+    public function testBasicStrikethrough()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('Foo ~~Bar~~ Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -33,10 +34,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSingleCharacterBody()
+    public function testSingleCharacterBody()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('foo ~~b~~ bar');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -51,10 +53,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testMultipleWords()
+    public function testMultipleWords()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('~~three four five~~');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -69,10 +72,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testTwoSeparateStrikethroughsOnOneLine()
+    public function testTwoSeparateStrikethroughsOnOneLine()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('~~one~~ and ~~two~~');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -91,10 +95,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testUnmatchedOpenerDoesNotStrike()
+    public function testUnmatchedOpenerDoesNotStrike()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('foo ~~bar with no closer');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -105,10 +110,11 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testOpenerFollowedBySpaceDoesNotStrike()
+    public function testOpenerFollowedBySpaceDoesNotStrike()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('foo ~~ bar~~ baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -119,30 +125,33 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testEmptyDelimiterDoesNotStrike()
+    public function testEmptyDelimiterDoesNotStrike()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('foo ~~~~ bar');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('deleted_open', $modes,
             'Empty `~~~~` must stay literal');
     }
 
-    function testTripleTildeDoesNotStrike()
+    public function testTripleTildeDoesNotStrike()
     {
         // `~~~` is the GFM fenced-code-block marker; strikethrough must not
         // consume a run of three or more tildes.
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('foo ~~~bar~~~ baz');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('deleted_open', $modes,
             'Run of 3+ tildes must not trigger strikethrough');
     }
 
-    function testMultilineStrikethrough()
+    public function testMultilineStrikethrough()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse("~~line\nline\nline~~");
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -157,38 +166,60 @@ class GfmDeletedTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testDoesNotSpanParagraphBoundary()
+    public function testDoesNotSpanParagraphBoundary()
     {
         // An unclosed `~~` followed by a blank line must stay literal.
         // Mirrors GFM spec example 492.
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse("This ~~has a\n\nnew paragraph~~.");
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('deleted_open', $modes,
             'GfmDeleted must not open when the closing `~~` is past a blank line');
     }
 
-    function testAllowsSingleNewline()
+    public function testAllowsSingleNewline()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse("~~open\nclose~~");
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('deleted_open', $modes,
             'GfmDeleted must still match across a single newline');
     }
 
-    function testTrailingWhitespaceBeforeCloserDoesNotStrike()
+    public function testTrailingWhitespaceBeforeCloserDoesNotStrike()
     {
         $this->P->addMode('gfm_deleted', new GfmDeleted());
         $this->P->parse('~~foo bar ~~');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('deleted_open', $modes,
             'Closer preceded by whitespace must not match');
     }
 
-    function testSortValue()
+    public function testSortValue()
     {
         $mode = new GfmDeleted();
         $this->assertSame(130, $mode->getSort());
+    }
+
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral()
+    {
+        $this->P->addMode('gfm_deleted', new GfmDeleted());
+        $this->P->parse('~~ foo ~~bar~~');
+        $this->assertContains('deleted_open', array_column($this->H->calls, 0));
+        $this->assertStringContainsString('~~ foo ', $this->H->calls[2][1][0]);
+    }
+
+    public function testVeryLongSpanIsRecognized()
+    {
+        $body = trim(str_repeat('some words ', 7000)); // ~77KB
+        $this->P->addMode('gfm_deleted', new GfmDeleted());
+        $this->P->parse('~~' . $body . '~~');
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['deleted_open', []], $calls);
+        $this->assertContains(['cdata', [$body]], $calls);
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmEmphasisStrongTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmEmphasisStrongTest.php
@@ -19,10 +19,11 @@ class GfmEmphasisStrongTest extends ParserTestBase
         $this->setSyntax('md');
     }
 
-    function testBasic()
+    public function testBasic()
     {
         $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
         $this->P->parse('Foo ***Bar*** Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -39,10 +40,11 @@ class GfmEmphasisStrongTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSingleCharacter()
+    public function testSingleCharacter()
     {
         $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
         $this->P->parse('***a***');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('emphasis_open', $modes);
         $this->assertContains('strong_open', $modes);
@@ -50,28 +52,28 @@ class GfmEmphasisStrongTest extends ParserTestBase
         $this->assertContains('emphasis_close', $modes);
     }
 
-    function testLeadingWhitespaceDoesNotMatch()
+    public function testLeadingWhitespaceDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
         $this->P->parse('*** foo***');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testTrailingWhitespaceDoesNotMatch()
+    public function testTrailingWhitespaceDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
         $this->P->parse('***foo ***');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testDoesNotSpanParagraphBoundary()
+    public function testDoesNotSpanParagraphBoundary()
     {
         $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
         $this->P->parse("***foo\n\nbar***");
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testLongerSymmetricRunDoesNotMatch()
+    public function testLongerSymmetricRunDoesNotMatch()
     {
         // `****foo****` has 4 asterisks each side. The entry pattern requires
         // the opener run to be exactly 3 (via `(?<!\*)` and `(?!\*)` on the
@@ -82,7 +84,7 @@ class GfmEmphasisStrongTest extends ParserTestBase
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testAsymmetricDoesNotMatch()
+    public function testAsymmetricDoesNotMatch()
     {
         // `***foo**` has 3 asterisks on the left but only 2 on the right.
         // The entry's closing-delimiter lookahead requires exactly 3 `*`s
@@ -92,8 +94,16 @@ class GfmEmphasisStrongTest extends ParserTestBase
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testSortValue()
+    public function testSortValue()
     {
         $this->assertSame(65, (new GfmEmphasisStrong())->getSort());
+    }
+
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral()
+    {
+        $this->P->addMode('gfm_emphasis_strong', new GfmEmphasisStrong());
+        $this->P->parse('*** foo ***bar***');
+        $this->assertContains('emphasis_open', array_column($this->H->calls, 0));
+        $this->assertStringContainsString('*** foo ', $this->H->calls[2][1][0]);
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmEmphasisStrongUnderscoreTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmEmphasisStrongUnderscoreTest.php
@@ -18,10 +18,11 @@ class GfmEmphasisStrongUnderscoreTest extends ParserTestBase
         $this->setSyntax('md');
     }
 
-    function testBasic()
+    public function testBasic()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('Foo ___Bar___ Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -38,7 +39,7 @@ class GfmEmphasisStrongUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSingleCharacter()
+    public function testSingleCharacter()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('___a___');
@@ -46,56 +47,56 @@ class GfmEmphasisStrongUnderscoreTest extends ParserTestBase
         $this->assertContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testLeadingWhitespaceDoesNotMatch()
+    public function testLeadingWhitespaceDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('___ foo___');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testTrailingWhitespaceDoesNotMatch()
+    public function testTrailingWhitespaceDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('___foo ___');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testDoesNotSpanParagraphBoundary()
+    public function testDoesNotSpanParagraphBoundary()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse("___foo\n\nbar___");
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testLongerSymmetricRunDoesNotMatch()
+    public function testLongerSymmetricRunDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('____foo____');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testAsymmetricDoesNotMatch()
+    public function testAsymmetricDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('___foo__');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testIntrawordDoesNotMatch()
+    public function testIntrawordDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('abc___foo___');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testMultibyteIntrawordDoesNotMatch()
+    public function testMultibyteIntrawordDoesNotMatch()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('für___etwas___');
         $this->assertNotContains('emphasis_open', array_column($this->H->calls, 0));
     }
 
-    function testMultibyteContentInside()
+    public function testMultibyteContentInside()
     {
         $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
         $this->P->parse('foo ___für___ bar');
@@ -103,8 +104,16 @@ class GfmEmphasisStrongUnderscoreTest extends ParserTestBase
         $this->assertContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testSortValue()
+    public function testSortValue()
     {
         $this->assertSame(65, (new GfmEmphasisStrongUnderscore())->getSort());
+    }
+
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral()
+    {
+        $this->P->addMode('gfm_emphasis_strong_underscore', new GfmEmphasisStrongUnderscore());
+        $this->P->parse('___ foo ___bar___');
+        $this->assertContains('emphasis_open', array_column($this->H->calls, 0));
+        $this->assertStringContainsString('___ foo ', $this->H->calls[2][1][0]);
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmEmphasisTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmEmphasisTest.php
@@ -2,7 +2,9 @@
 
 namespace dokuwiki\test\Parsing\ParserMode;
 
+use dokuwiki\Parsing\ParserMode\GfmBacktickSingle;
 use dokuwiki\Parsing\ParserMode\GfmEmphasis;
+use dokuwiki\Parsing\ParserMode\Monospace;
 
 /**
  * Tests for the GFM asterisk emphasis mode (`*text*`).
@@ -196,5 +198,81 @@ class GfmEmphasisTest extends ParserTestBase
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('emphasis_open', $modes,
             'GfmEmphasis must still match across a single newline');
+    }
+
+    function testAsteriskDoesNotSpanMonospaceBoundary()
+    {
+        // A `*` in a glob inside ''…'' must not pair with the `*` of a
+        // following ''…'' span: its closer lies past the monospace closer, so
+        // it stays literal instead of dragging the monospace boundary along.
+        $this->setSyntax('dw+md');
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('gfm_emphasis', new GfmEmphasis());
+        $this->P->parse("''aaa*.conf'', ''bbb*.conf''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['aaa*.conf']], $calls);
+        $this->assertContains(['cdata', ['bbb*.conf']], $calls);
+    }
+
+    function testAsteriskStillEmphasisesWithinOneMonospaceSpan()
+    {
+        // The counterpart: a `*…*` pair fully inside one ''…'' span still
+        // renders as emphasis.
+        $this->setSyntax('dw+md');
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('gfm_emphasis', new GfmEmphasis());
+        $this->P->parse("''a*b*c''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['b']], $calls);
+    }
+
+    function testAsteriskAdjacentToMonospaceCloserStaysLiteral()
+    {
+        // A lone `*` as the entire ''…'' content sits right before the
+        // monospace closer; pairing it with a `*` in a later span would
+        // drag the monospace boundary along, so it stays literal.
+        $this->setSyntax('dw+md');
+        $this->P->addMode('monospace', new Monospace());
+        $this->P->addMode('gfm_emphasis', new GfmEmphasis());
+        $this->P->parse("''*'' as the subdomain name, e.g.: ''*.example.com''");
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['emphasis_open', []], $calls);
+        $this->assertContains(['cdata', ['*']], $calls);
+        $this->assertContains(['cdata', ['*.example.com']], $calls);
+    }
+
+    function testAsteriskCloserInsideBacktickSpanDoesNotCount()
+    {
+        // The only closing `*` candidate lives inside a backtick code
+        // span whose content is verbatim — the opener can never close, so
+        // it stays literal.
+        $this->setSyntax('dw+md');
+        $this->P->addMode('gfm_emphasis', new GfmEmphasis());
+        $this->P->addMode('gfm_backtick_single', new GfmBacktickSingle());
+        $this->P->parse('*conf `x*y` end.');
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertNotContains(['emphasis_open', []], $calls);
+        $this->assertContains(['unformatted', ['x*y']], $calls);
+    }
+
+    function testAsteriskPairSpanningBacktickSpanStillEmphasises()
+    {
+        // The counterpart: with a real closer behind the code span, the
+        // emphasis wraps the span instead of being rejected because of it.
+        $this->setSyntax('dw+md');
+        $this->P->addMode('gfm_emphasis', new GfmEmphasis());
+        $this->P->addMode('gfm_backtick_single', new GfmBacktickSingle());
+        $this->P->parse('*a `b` c*');
+
+        $calls = array_map(fn($call) => [$call[0], $call[1]], $this->H->calls);
+        $this->assertContains(['emphasis_open', []], $calls);
+        $this->assertContains(['emphasis_close', []], $calls);
+        $this->assertContains(['unformatted', ['b']], $calls);
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmEmphasisUnderscoreTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmEmphasisUnderscoreTest.php
@@ -15,10 +15,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->setSyntax('md');
     }
 
-    function testBasicUnderscore()
+    public function testBasicUnderscore()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('Foo _Bar_ Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -33,10 +34,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSingleCharacter()
+    public function testSingleCharacter()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('foo _b_ bar');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -51,10 +53,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testMultipleWords()
+    public function testMultipleWords()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('_one two three_');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -69,11 +72,12 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testIntrawordUnderscoreIsNotEmphasised()
+    public function testIntrawordUnderscoreIsNotEmphasised()
     {
         // GFM's key word-boundary rule: underscores inside words stay literal.
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('this_is_not_an_emphasis');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -84,10 +88,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testOpenerFollowedBySpaceDoesNotEmphasise()
+    public function testOpenerFollowedBySpaceDoesNotEmphasise()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('foo _ bar_ baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -98,7 +103,7 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testDoubleUnderscoreDoesNotEmphasise()
+    public function testDoubleUnderscoreDoesNotEmphasise()
     {
         // `__foo__` must stay literal. At the first `_`, the lookahead
         // `(?=[^\s_])` forbids entry (next char is another `_`). At the
@@ -107,6 +112,7 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         // `__foo` can't open emphasis at the inner underscore).
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('foo __bar__ baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -117,10 +123,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testTwoSeparateEmphasisOnOneLine()
+    public function testTwoSeparateEmphasisOnOneLine()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('_one_ and _two_');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -139,10 +146,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testMultilineEmphasis()
+    public function testMultilineEmphasis()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse("_line\nline\nline_");
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -157,25 +165,27 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSortValue()
+    public function testSortValue()
     {
         $mode = new GfmEmphasisUnderscore();
         $this->assertSame(80, $mode->getSort());
     }
 
-    function testDoesNotSpanParagraphBoundary()
+    public function testDoesNotSpanParagraphBoundary()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse("_open\n\nclose_");
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('emphasis_open', $modes,
             'GfmEmphasisUnderscore must not open when the closing `_` is past a blank line');
     }
 
-    function testAllowsSingleNewlineInsideMultiline()
+    public function testAllowsSingleNewlineInsideMultiline()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse("_open\nclose_");
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('emphasis_open', $modes,
             'GfmEmphasisUnderscore must still match across a single newline');
@@ -198,10 +208,11 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
      *
      * @dataProvider provideMultibyteIntrawordCases
      */
-    function testIntrawordUnderscoreInMultibyteText(string $input)
+    public function testIntrawordUnderscoreInMultibyteText(string $input)
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse($input);
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains(
             'emphasis_open',
@@ -233,11 +244,12 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
      * following letters are multibyte. Verifies that both the lookbehind
      * and the closing-delimiter lookahead reject multibyte word chars.
      */
-    function testMultibyteWordCharsAreNotTreatedAsBoundary()
+    public function testMultibyteWordCharsAreNotTreatedAsBoundary()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         // Intraword between Cyrillic on the left and Cyrillic on the right.
         $this->P->parse('до_середины_текста');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertNotContains('emphasis_open', $modes,
             'Cyrillic-surrounded `_` must not emphasize');
@@ -248,14 +260,23 @@ class GfmEmphasisUnderscoreTest extends ParserTestBase
      * punctuation, multibyte content *inside* the emphasis span is fine.
      * `_für etwas_` surrounded by spaces should emphasize the multibyte text.
      */
-    function testMultibyteContentInsideEmphasisWorks()
+    public function testMultibyteContentInsideEmphasisWorks()
     {
         $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
         $this->P->parse('foo _für etwas_ bar');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('emphasis_open', $modes,
             'Multibyte text inside `_..._` must emphasize when boundaries are clear');
         $this->assertContains('emphasis_close', $modes,
             'Multibyte text inside `_..._` must emphasize when boundaries are clear');
+    }
+
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral()
+    {
+        $this->P->addMode('gfm_emphasis_underscore', new GfmEmphasisUnderscore());
+        $this->P->parse('_ foo _bar_');
+        $this->assertContains('emphasis_open', array_column($this->H->calls, 0));
+        $this->assertStringContainsString('_ foo ', $this->H->calls[2][1][0]);
     }
 }

--- a/_test/tests/Parsing/ParserMode/GfmStrongUnderscoreTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmStrongUnderscoreTest.php
@@ -15,10 +15,11 @@ class GfmStrongUnderscoreTest extends ParserTestBase
         $this->setSyntax('md');
     }
 
-    function testBasic()
+    public function testBasic()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('Foo __Bar__ Baz');
+
         $calls = [
             ['document_start', []],
             ['p_open', []],
@@ -33,24 +34,26 @@ class GfmStrongUnderscoreTest extends ParserTestBase
         $this->assertCalls($calls, $this->H->calls);
     }
 
-    function testSingleCharacter()
+    public function testSingleCharacter()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('__x__');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('strong_open', $modes);
         $this->assertContains('strong_close', $modes);
     }
 
-    function testMultipleWords()
+    public function testMultipleWords()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('__one two three__');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('strong_open', $modes);
     }
 
-    function testIntrawordDoesNotOpen()
+    public function testIntrawordDoesNotOpen()
     {
         // `foo__bar__` — opening `__` intraword (preceded by `o`).
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
@@ -58,28 +61,28 @@ class GfmStrongUnderscoreTest extends ParserTestBase
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testLeadingWhitespaceDoesNotOpen()
+    public function testLeadingWhitespaceDoesNotOpen()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('__ foo bar__');
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testTrailingWhitespaceDoesNotClose()
+    public function testTrailingWhitespaceDoesNotClose()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('__foo bar __');
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testEmptyDelimiterDoesNotMatch()
+    public function testEmptyDelimiterDoesNotMatch()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('____');
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testMultibyteIntrawordDoesNotMatch()
+    public function testMultibyteIntrawordDoesNotMatch()
     {
         // Cyrillic spec example: `пристаням__стремятся__` — intraword, literal.
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
@@ -87,7 +90,7 @@ class GfmStrongUnderscoreTest extends ParserTestBase
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testMultibyteContentInsideStrongWorks()
+    public function testMultibyteContentInsideStrongWorks()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('foo __für etwas__ bar');
@@ -95,27 +98,36 @@ class GfmStrongUnderscoreTest extends ParserTestBase
         $this->assertContains('strong_close', array_column($this->H->calls, 0));
     }
 
-    function testDoesNotSpanParagraphBoundary()
+    public function testDoesNotSpanParagraphBoundary()
     {
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse("__open\n\nclose__");
         $this->assertNotContains('strong_open', array_column($this->H->calls, 0));
     }
 
-    function testSortValue()
+    public function testSortValue()
     {
         $this->assertSame(70, (new GfmStrongUnderscore())->getSort());
     }
 
-    function testInstructionNameIsStrong()
+    public function testInstructionNameIsStrong()
     {
         // The mode name is distinct (so it coexists with DW Strong in the
         // lexer) but it must emit the same `strong_open`/`strong_close`
         // instructions so the XHTML renderer outputs <strong>.
         $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
         $this->P->parse('__x__');
+
         $modes = array_column($this->H->calls, 0);
         $this->assertContains('strong_open', $modes);
         $this->assertNotContains('gfm_strong_underscore_open', $modes);
+    }
+
+    public function testRejectedOpenerBeforeValidSpanStaysLiteral()
+    {
+        $this->P->addMode('gfm_strong_underscore', new GfmStrongUnderscore());
+        $this->P->parse('__ foo __bar__');
+        $this->assertContains('strong_open', array_column($this->H->calls, 0));
+        $this->assertStringContainsString('__ foo ', $this->H->calls[2][1][0]);
     }
 }

--- a/inc/MailUtils.php
+++ b/inc/MailUtils.php
@@ -21,10 +21,17 @@ class MailUtils
      * Pattern for use in email detection and validation.
      *
      * Uses non-capturing groups since the parser does not allow captures.
+     *
+     * The dot-separated groups are possessive: an atext run stops at the
+     * next dot or the @, and a domain label always ends in a dot, so neither
+     * group can over-consume and neither ever needs to backtrack. A plain
+     * quantifier here is a ReDoS vector: a long `a.a.a.a…` local part or
+     * `a.a.a.a…` domain makes the non-JIT PCRE engine retain one
+     * backtracking frame per segment before the match ultimately fails.
      */
     public const PREG_PATTERN_VALID_EMAIL =
-        '[' . self::RFC2822_ATEXT . ']+(?:\.[' . self::RFC2822_ATEXT . ']+)*'
-        . '@(?i:[0-9a-z][0-9a-z-]*\.)+(?i:[a-z]{2,63})';
+        '[' . self::RFC2822_ATEXT . ']+(?:\.[' . self::RFC2822_ATEXT . ']+)*+'
+        . '@(?i:[0-9a-z][0-9a-z-]*\.)++(?i:[a-z]{2,63})';
 
     // region email-address obfuscation
 

--- a/inc/Parsing/Lexer/CloserPattern.php
+++ b/inc/Parsing/Lexer/CloserPattern.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace dokuwiki\Parsing\Lexer;
+
+/**
+ * A closer-existence check guarding a lexer mode.
+ *
+ * Holds one mode's closer and boundary patterns, the scan regex compiled
+ * from them, and the memoized verdicts of earlier scans. The Lexer calls
+ * position() to ask whether a valid closer exists ahead of an entry match;
+ * memoizing the verdict keeps that check linear over a whole parse.
+ *
+ * See Lexer::addCloserPattern() for the contract the patterns follow.
+ */
+class CloserPattern
+{
+    /** @var string pattern matching a valid closer, in plain PCRE syntax */
+    protected string $closer;
+    /** @var string|null pattern the closer must occur before, in plain PCRE syntax */
+    protected ?string $boundary;
+    /** @var string|null scan regex built by compile(), null until then */
+    protected ?string $scan = null;
+    /** @var int|null start of the range proven to see the memoized closer */
+    protected ?int $successFrom = null;
+    /** @var int|null memoized closer position, valid from successFrom on */
+    protected ?int $closerPos = null;
+    /** @var int|null start of the range proven closer-free */
+    protected ?int $failFrom = null;
+    /** @var int|null exclusive end of the range proven closer-free */
+    protected ?int $failUntil = null;
+
+    /**
+     * Translates both patterns from the lexer convention into plain PCRE
+     * syntax. Building the scan regex is deferred to compile().
+     *
+     * @param string $pattern regex fragment matching the closing delimiter,
+     *                        flanking context expressed as lookarounds
+     * @param string|null $boundary regex fragment the closer must occur
+     *                              before; null to scan to the end of the
+     *                              subject
+     */
+    public function __construct(string $pattern, ?string $boundary = null)
+    {
+        $this->closer = ParallelRegex::escapePattern($pattern);
+        $this->boundary = $boundary === null ? null : ParallelRegex::escapePattern($boundary);
+    }
+
+    /**
+     * Whether compile() has built the scan regex yet.
+     *
+     * @return bool
+     */
+    public function isCompiled(): bool
+    {
+        return $this->scan !== null;
+    }
+
+    /**
+     * Builds the scan regex from the mode's patterns and the opaque spans
+     * supplied by the Lexer.
+     *
+     * It matches the earliest of three things ahead: the boundary (named
+     * group "bound"), the closer (named group "closer"), or an opaque span
+     * — a stretch the lexer consumes atomically, so a closer lookalike
+     * inside it can never really close the mode (see Lexer::opaqueSpans()).
+     * Alternative order breaks same-position ties: the boundary wins over a
+     * span starting at the same byte, and the closer is never swallowed by
+     * one. position() interprets the matches.
+     *
+     * @param string[] $opaqueSpans regex fragments in plain PCRE syntax,
+     *                              each matching one whole span the scan
+     *                              must not look into
+     * @param bool $case true for case sensitive matching
+     * @return void
+     */
+    public function compile(array $opaqueSpans, bool $case): void
+    {
+        $alternatives = [];
+        if ($this->boundary !== null) {
+            $alternatives[] = '(?<bound>' . $this->boundary . ')';
+        }
+        $alternatives[] = '(?<closer>' . $this->closer . ')';
+        $alternatives = array_merge($alternatives, $opaqueSpans);
+
+        $flags = $case ? 'ms' : 'msi';
+        $this->scan = '/' . implode('|', $alternatives) . '/' . $flags;
+    }
+
+    /**
+     * Byte position where the first valid closer at or after $from starts,
+     * or null if none occurs before the boundary (or the end of subject).
+     * Requires compile() to have run.
+     *
+     * Answers from the memo when possible, otherwise runs the scan (see
+     * compile()), hopping over opaque spans, and memoizes the verdict: on
+     * success the range from $from up to the closer, on failure the
+     * closer-free range up to the boundary (or end of subject). A verdict
+     * holds for any position in its range because the leftmost scan proves
+     * no closer lies earlier; positions inside opaque spans are never
+     * queried, since the lexer consumes those without matching entry
+     * patterns in them.
+     *
+     * @param string $subject the full subject being lexed
+     * @param int $from byte position just after the entry pattern match
+     * @return int|null
+     */
+    public function position(string $subject, int $from): ?int
+    {
+        if ($this->successFrom !== null && $from >= $this->successFrom && $from <= $this->closerPos) {
+            return $this->closerPos;
+        }
+        if ($this->failFrom !== null && $from >= $this->failFrom && $from < $this->failUntil) {
+            return null;
+        }
+
+        $pos = $from;
+        while (preg_match($this->scan, $subject, $match, PREG_OFFSET_CAPTURE, $pos) === 1) {
+            if (isset($match['bound']) && $match['bound'][1] !== -1) {
+                $this->failFrom = $from;
+                $this->failUntil = $match['bound'][1] + 1;
+                return null;
+            }
+            if (isset($match['closer']) && $match['closer'][1] !== -1) {
+                $this->successFrom = $from;
+                $this->closerPos = $match['closer'][1];
+                return $this->closerPos;
+            }
+            // an opaque span: resume behind it
+            $pos = max($match[0][1] + strlen($match[0][0]), $pos + 1);
+        }
+
+        $this->failFrom = $from;
+        $this->failUntil = strlen($subject) + 1;
+        return null;
+    }
+
+    /**
+     * Forgets all memoized scan verdicts, which only hold for the subject
+     * they were computed on. The compiled scan regex is kept — it depends
+     * only on the connected patterns, not on the subject.
+     *
+     * @return void
+     */
+    public function reset(): void
+    {
+        $this->successFrom = null;
+        $this->closerPos = null;
+        $this->failFrom = null;
+        $this->failUntil = null;
+    }
+}

--- a/inc/Parsing/Lexer/Lexer.php
+++ b/inc/Parsing/Lexer/Lexer.php
@@ -20,10 +20,18 @@ use dokuwiki\Parsing\Handler;
  */
 class Lexer
 {
-    /** Signal for leaving a mode */
+    /** @var string Signal for leaving a mode */
     public const MODE_EXIT = '__exit';
-    /** Prefix marking special (enter-and-exit) patterns */
+    /** @var string Prefix marking special (enter-and-exit) patterns */
     public const MODE_SPECIAL_PREFIX = '_';
+    /**
+     * Pattern matching a paragraph break: a blank line — two newlines
+     * possibly separated by horizontal whitespace. The usual boundary
+     * for addCloserPattern().
+     *
+     * @var string
+     */
+    public const PARA_BREAK = '\n[ \t]*\n';
 
     /** @var ParallelRegex[] */
     protected $regexes = [];
@@ -33,6 +41,8 @@ class Lexer
     protected $modeStack;
     /** @var array mode "rewrites" */
     protected $mode_handlers = [];
+    /** @var CloserPattern[] closer-existence checks, keyed by the mode they guard */
+    protected $closerPatterns = [];
     /** @var bool case sensitive? */
     protected $case;
 
@@ -84,6 +94,54 @@ class Lexer
             $this->regexes[$mode] = new ParallelRegex($this->case);
         }
         $this->regexes[$mode]->addPattern($pattern, $new_mode);
+    }
+
+    /**
+     * Requires a closer to exist ahead before any entry pattern may enter
+     * the given mode.
+     *
+     * Whenever an entry pattern for $mode matches, the subject is scanned
+     * from the end of that match for $pattern — before the next $boundary
+     * match if a boundary is given, anywhere ahead otherwise. If no closer
+     * is found the entry is rejected and its delimiter stays literal text;
+     * see reduce() for how the rejected match is discarded.
+     *
+     * Keeping the check out of the entry pattern is what makes it
+     * affordable. A closer lookahead written into the entry pattern is
+     * re-evaluated for every candidate the regex engine tries — quadratic
+     * on input dense with delimiters that never close. Here the scan runs
+     * once per position and its verdict is memoized, so together with the
+     * lexer consuming each entered span the whole parse stays linear; see
+     * CloserPattern for the scan and its memo.
+     *
+     * The pattern must match where the closing delimiter starts, with
+     * flanking requirements expressed as lookarounds (the convention exit
+     * patterns follow, e.g. (?<=[^\s])\*\* for strong). A pattern that
+     * consumed flanking context instead would skew the closer positions
+     * canEnter() compares across modes, and could not see a closer whose
+     * delimiter directly follows the opener, since the scan starts only
+     * after the entry match.
+     *
+     * The closer must not be able to match where the boundary matches,
+     * since the scan stops unconditionally at the boundary. It also does
+     * not look inside content the lexer consumes atomically; see
+     * opaqueSpans().
+     *
+     * A mode has exactly one closer check, shared by all its entry
+     * patterns; registering another replaces it. The memo is reset at the
+     * start of every parse() run.
+     *
+     * @param string $pattern regex fragment matching the closing delimiter,
+     *                        flanking context expressed as lookarounds
+     * @param string $mode    the mode entered by the guarded entry patterns
+     * @param string|null $boundary regex fragment the closer must occur
+     *                              before (usually self::PARA_BREAK); null
+     *                              to scan to the end of the subject
+     * @return void
+     */
+    public function addCloserPattern($pattern, $mode, $boundary = null)
+    {
+        $this->closerPatterns[$mode] = new CloserPattern($pattern, $boundary);
     }
 
     /**
@@ -143,6 +201,7 @@ class Lexer
         if (! isset($this->handler)) {
             return false;
         }
+        $this->resetCloserMemos();
         $offset = 0;
         while (is_array($parsed = $this->reduce($raw, $offset))) {
             [$unmatched, $matched, $mode] = $parsed;
@@ -293,6 +352,16 @@ class Lexer
      * patterns can see characters before the current offset. Empty
      * subjects (offset past end) will not be matched.
      *
+     * A matched entry pattern for a guarded mode (one with a closer
+     * pattern) is discarded when canEnter() rejects it: its delimiter
+     * stays unparsed text and matching resumes one byte on, so a shorter
+     * delimiter overlapping the rejected one still gets its turn.
+     * Resuming past the delimiter also skips any rival pattern anchored
+     * at that exact byte, which is safe: guarded modes are registered
+     * only by the core, and two core delimiters sharing a byte share an
+     * equivalent closer, so one rejection implies the other. Plugin
+     * patterns are never guarded and so never take this path.
+     *
      * @param string $raw     The full subject to parse.
      * @param int    $offset  Byte offset at which to resume matching.
      * @return array|bool     Three item list of unparsed content followed by the
@@ -307,11 +376,217 @@ class Lexer
         if ($offset >= strlen($raw)) {
             return true;
         }
-        if ($action = $this->regexes[$this->modeStack->getCurrent()]->split($raw, $split, $offset)) {
+        $initialOffset = $offset;
+        while ($action = $this->regexes[$this->modeStack->getCurrent()]->split($raw, $split, $offset)) {
             [$unparsed, $match] = $split;
-            return [$unparsed, $match, $action];
+            $matchPos = $offset + strlen($unparsed);
+
+            if (
+                is_string($action)
+                && isset($this->closerPatterns[$action])
+                && !$this->canEnter($action, $raw, $matchPos + strlen($match))
+            ) {
+                $offset = $matchPos + 1;
+                if ($offset >= strlen($raw)) {
+                    return true;
+                }
+                continue;
+            }
+
+            return [substr($raw, $initialOffset, $matchPos - $initialOffset), $match, $action];
         }
         return true;
+    }
+
+    /**
+     * May an entry pattern for the given mode enter at this position?
+     *
+     * Two conditions must hold. First, a valid closer for the mode must
+     * exist ahead, before its boundary — otherwise a delimiter that can
+     * never close would stay open forever. Second, when the entry sits
+     * inside a guarded mode, that mode's closer must not come first: an
+     * inner delimiter whose closer lies beyond the enclosing closer can
+     * never close within its parent, so it stays literal rather than span
+     * across the parent boundary (e.g. a stray '*' in ''glob/*.conf''
+     * pairing with the '*' of a following ''…'' span).
+     *
+     * The enclosing mode is the nearest guarded ancestor on the stack, not
+     * necessarily the immediate parent; see nearestGuardedAncestor().
+     *
+     * @param string $mode the mode entered by the matched entry pattern
+     * @param string $subject the full subject being lexed
+     * @param int $from byte position just after the entry pattern match
+     * @return bool
+     */
+    protected function canEnter(string $mode, string $subject, int $from): bool
+    {
+        $closerPos = $this->closerPosition($mode, $subject, $from);
+        if ($closerPos === null) {
+            return false;
+        }
+
+        $enclosing = $this->nearestGuardedAncestor($mode);
+        if ($enclosing !== null) {
+            $enclosingCloserPos = $this->closerPosition($enclosing, $subject, $from);
+            if ($enclosingCloserPos !== null && $enclosingCloserPos < $closerPos) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The nearest mode on the stack that has its own closer and could thus
+     * constrain where a delimiter entering $mode may close, or null if none
+     * does.
+     *
+     * The search walks from the immediate parent outward, stepping over
+     * unguarded modes — plugins, list items, anything with no closer. Such
+     * a mode offers no closer to compare against, yet a guarded ancestor
+     * beyond it still constrains the inner delimiter (e.g. ''strong'' around
+     * a plugin span holding an ''emphasis'' whose only closer lies further
+     * on), so skipping it reaches that ancestor.
+     *
+     * Only the nearest guarded ancestor matters: when it opened it was
+     * validated against its own nearest guarded ancestor, so the
+     * "closes before its parent" relation chains up the stack and one level
+     * is enough. The walk also stops at $mode itself — a same-mode ancestor
+     * shares this candidate's closer pattern, so its closer cannot fall
+     * before the candidate's and can never be the rejecting constraint.
+     *
+     * @param string $mode the mode about to be entered
+     * @return string|null the nearest guarded ancestor, or null if none
+     */
+    protected function nearestGuardedAncestor(string $mode): ?string
+    {
+        $stack = $this->modeStack->getStack();
+        for ($i = count($stack) - 1; $i >= 0; $i--) {
+            $enclosing = $stack[$i];
+            if ($enclosing === $mode) {
+                return null;
+            }
+            if (isset($this->closerPatterns[$enclosing])) {
+                return $enclosing;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Byte position where the first valid closer for the given mode at or
+     * after $from starts, or null if none exists; delegates to the mode's
+     * CloserPattern (see position()).
+     *
+     * The scan regex is compiled on first use, not in addCloserPattern(),
+     * because the opaque-span derivation needs the patterns of all connected
+     * modes, and other modes' connectTo() calls may run after this mode's
+     * postConnect() has registered the closer.
+     *
+     * @param string $mode the mode whose closer pattern applies
+     * @param string $subject the full subject being lexed
+     * @param int $from byte position just after the entry pattern match
+     * @return int|null
+     */
+    protected function closerPosition(string $mode, string $subject, int $from): ?int
+    {
+        $closerPattern = $this->closerPatterns[$mode];
+        if (!$closerPattern->isCompiled()) {
+            $closerPattern->compile($this->opaqueSpans($mode), $this->case);
+        }
+        return $closerPattern->position($subject, $from);
+    }
+
+    /**
+     * Derives the spans within the given mode whose content a closer scan
+     * must not look into.
+     *
+     * Content the lexer consumes without exposing it to the mode's exit
+     * pattern can never hold a real closer — a %%..%% span may contain the
+     * characters that would close an enclosing bold span, yet the bold exit
+     * cannot fire inside it. Such content is identified from the already
+     * registered patterns:
+     *
+     * - A plain or special pattern is consumed in one step, so the pattern
+     *   itself describes the span. (Zero-width matches would stall parse(),
+     *   so each consumes at least one byte.)
+     * - An entry pattern leads into a nested mode. If that mode is verbatim
+     *   (see verbatimExit()), the lexer consumes up to its first exit, so
+     *   the span is the entry pattern, a lazy body, and the exit. Other
+     *   nested modes have no statically known extent — their content is
+     *   scanned as plain text, leaving the closer check an approximation
+     *   there.
+     *
+     * @param string $mode the mode whose closer scan needs the spans
+     * @return string[] regex fragments, each matching one whole span
+     */
+    protected function opaqueSpans(string $mode): array
+    {
+        if (!isset($this->regexes[$mode])) {
+            return [];
+        }
+
+        $spans = [];
+        foreach ($this->regexes[$mode]->getPatterns() as $registered) {
+            $label = $registered['label'];
+            if ($label === self::MODE_EXIT) {
+                continue;
+            }
+            if ($label === true || $this->isSpecialMode($label)) {
+                $spans[] = '(?:' . ParallelRegex::escapePattern($registered['pattern']) . ')';
+                continue;
+            }
+            $exit = $this->verbatimExit($label);
+            if ($exit !== null) {
+                $spans[] = '(?:' . ParallelRegex::escapePattern($registered['pattern']) . '.*?' . $exit . ')';
+            }
+        }
+        return $spans;
+    }
+
+    /**
+     * The exit pattern of the given mode if the mode is verbatim, null
+     * otherwise.
+     *
+     * A mode is verbatim when its pattern set consists solely of exit
+     * patterns (e.g. nowiki): nothing can match inside it, so it consumes
+     * everything up to its first exit match. Several exits are combined
+     * into an alternation.
+     *
+     * @param string $mode the mode entered by an entry pattern
+     * @return string|null regex fragment matching the mode's exit
+     */
+    protected function verbatimExit(string $mode): ?string
+    {
+        if (!isset($this->regexes[$mode])) {
+            return null;
+        }
+
+        $exits = [];
+        foreach ($this->regexes[$mode]->getPatterns() as $registered) {
+            if ($registered['label'] !== self::MODE_EXIT) {
+                return null;
+            }
+            $exits[] = ParallelRegex::escapePattern($registered['pattern']);
+        }
+        if ($exits === []) {
+            return null;
+        }
+        return '(?:' . implode('|', $exits) . ')';
+    }
+
+    /**
+     * Forgets all closer scan verdicts. Called at the start of every
+     * parse() run, since the memos only hold for the subject they were
+     * computed on.
+     *
+     * @return void
+     */
+    protected function resetCloserMemos(): void
+    {
+        foreach ($this->closerPatterns as $closerPattern) {
+            $closerPattern->reset();
+        }
     }
 
     /**

--- a/inc/Parsing/Lexer/ParallelRegex.php
+++ b/inc/Parsing/Lexer/ParallelRegex.php
@@ -57,6 +57,26 @@ class ParallelRegex
     }
 
     /**
+     * Lists the registered patterns together with their labels, in
+     * registration order.
+     *
+     * The label tells how the lexer treats a match: true for a plain
+     * pattern consumed in place, Lexer::MODE_EXIT for an exit pattern,
+     * a mode name prefixed with Lexer::MODE_SPECIAL_PREFIX for a special
+     * pattern, and a bare mode name for an entry pattern into that mode.
+     *
+     * @return array[] list of ['pattern' => string, 'label' => bool|string]
+     */
+    public function getPatterns()
+    {
+        return array_map(
+            static fn($pattern, $label) => ['pattern' => $pattern, 'label' => $label],
+            $this->patterns,
+            $this->labels
+        );
+    }
+
+    /**
      * Attempts to split the string against all patterns at once.
      *
      * When `$offset` is non-zero, the match begins at that byte position in
@@ -85,6 +105,9 @@ class ParallelRegex
                 switch ($err) {
                     case PREG_BACKTRACK_LIMIT_ERROR:
                         msg('A PCRE backtrack error occured. Try to increase the pcre.backtrack_limit in php.ini', -1);
+                        break;
+                    case PREG_JIT_STACKLIMIT_ERROR:
+                        msg('A PCRE JIT stacklimit error occured. Try to disable pcre.jit in php.ini', -1);
                         break;
                     case PREG_RECURSION_LIMIT_ERROR:
                         msg('A PCRE recursion error occured. Try to increase the pcre.recursion_limit in php.ini', -1);
@@ -115,6 +138,62 @@ class ParallelRegex
     }
 
     /**
+     * Translates a pattern from the lexer convention into plain PCRE
+     * syntax: bare ( and ) match literally — only the (?...) group forms
+     * keep their regex meaning — and / needs no escaping despite the
+     * /-delimited compound. Any fragment embedded into a /-delimited
+     * regex alongside the registered patterns must go through this
+     * translation to compose correctly.
+     *
+     * @param string $pattern pattern in the lexer convention
+     * @return string plain PCRE pattern fragment
+     */
+    public static function escapePattern($pattern)
+    {
+        /*
+         * decompose the input pattern into "(", "(?", ")",
+         * "[...]", "[]..]", "[^]..]", "[...[:...:]..]", "\x"...
+         * elements.
+         */
+        preg_match_all('/\\\\.|' .
+                       '\(\?|' .
+                       '[()]|' .
+                       '\[\^?\]?(?:\\\\.|\[:[^]]*:\]|[^]\\\\])*\]|' .
+                       '[^[()\\\\]+/', $pattern, $elts);
+
+        $escaped = "";
+        $level = 0;
+
+        foreach ($elts[0] as $elt) {
+            /*
+             * for "(", ")" remember the nesting level, add "\"
+             * only to the non-"(?" ones.
+             */
+
+            switch ($elt) {
+                case '(':
+                    $escaped .= '\(';
+                    break;
+                case ')':
+                    if ($level > 0)
+                        $level--; /* closing (? */
+                    else $escaped .= '\\';
+                    $escaped .= ')';
+                    break;
+                case '(?':
+                    $level++;
+                    $escaped .= '(?';
+                    break;
+                default:
+                    if (str_starts_with($elt, '\\'))
+                        $escaped .= $elt;
+                    else $escaped .= str_replace('/', '\/', $elt);
+            }
+        }
+        return $escaped;
+    }
+
+    /**
      * Compounds the patterns into a single
      * regular expression separated with the
      * "or" operator. Caches the regex.
@@ -125,51 +204,11 @@ class ParallelRegex
     protected function getCompoundedRegex()
     {
         if ($this->regex == null) {
-            $cnt = count($this->patterns);
-            for ($i = 0; $i < $cnt; $i++) {
-                /*
-                 * decompose the input pattern into "(", "(?", ")",
-                 * "[...]", "[]..]", "[^]..]", "[...[:...:]..]", "\x"...
-                 * elements.
-                 */
-                preg_match_all('/\\\\.|' .
-                               '\(\?|' .
-                               '[()]|' .
-                               '\[\^?\]?(?:\\\\.|\[:[^]]*:\]|[^]\\\\])*\]|' .
-                               '[^[()\\\\]+/', $this->patterns[$i], $elts);
-
-                $pattern = "";
-                $level = 0;
-
-                foreach ($elts[0] as $elt) {
-                    /*
-                     * for "(", ")" remember the nesting level, add "\"
-                     * only to the non-"(?" ones.
-                     */
-
-                    switch ($elt) {
-                        case '(':
-                            $pattern .= '\(';
-                            break;
-                        case ')':
-                            if ($level > 0)
-                                $level--; /* closing (? */
-                            else $pattern .= '\\';
-                            $pattern .= ')';
-                            break;
-                        case '(?':
-                            $level++;
-                            $pattern .= '(?';
-                            break;
-                        default:
-                            if (str_starts_with($elt, '\\'))
-                                $pattern .= $elt;
-                            else $pattern .= str_replace('/', '\/', $elt);
-                    }
-                }
-                $this->patterns[$i] = "($pattern)";
-            }
-            $this->regex = "/" . implode("|", $this->patterns) . "/" . $this->getPerlMatchingFlags();
+            $groups = array_map(
+                static fn($pattern) => '(' . self::escapePattern($pattern) . ')',
+                $this->patterns
+            );
+            $this->regex = "/" . implode("|", $groups) . "/" . $this->getPerlMatchingFlags();
         }
         return $this->regex;
     }

--- a/inc/Parsing/Lexer/StateStack.php
+++ b/inc/Parsing/Lexer/StateStack.php
@@ -36,6 +36,17 @@ class StateStack
     }
 
     /**
+     * The full state stack, from the oldest (bottom) state to the current
+     * (top) one.
+     *
+     * @return string[]
+     */
+    public function getStack()
+    {
+        return $this->stack;
+    }
+
+    /**
      * Adds a state to the stack and sets it to be the current state.
      *
      * @param string $state        New state.

--- a/inc/Parsing/ParserMode/AbstractFormatting.php
+++ b/inc/Parsing/ParserMode/AbstractFormatting.php
@@ -3,6 +3,7 @@
 namespace dokuwiki\Parsing\ParserMode;
 
 use dokuwiki\Parsing\Handler;
+use dokuwiki\Parsing\Lexer\Lexer;
 use dokuwiki\Parsing\ModeRegistry;
 
 /**
@@ -63,6 +64,37 @@ abstract class AbstractFormatting extends AbstractMode
     abstract protected function getExitPattern(): string;
 
     /**
+     * Regex fragment matching a valid closer for this formatting: the
+     * closing delimiter itself, with flanking requirements expressed as
+     * lookarounds. A valid closer is exactly where the exit pattern would
+     * fire, so the default returns getExitPattern(). A subclass may
+     * override to demand more context than the exit does, or to return
+     * null for modes whose entry pattern already verifies its closer in
+     * linear time (e.g. a body that cannot contain the delimiter
+     * character, making the lookahead self-limiting).
+     *
+     * The pattern must match where the delimiter starts and must not
+     * consume flanking context: the lexer compares closer positions across
+     * modes to decide whether a nested delimiter may open, and a consumed
+     * flanking character would both skew that comparison and hide a closer
+     * that directly follows the opener (see Lexer::addCloserPattern()).
+     *
+     * When non-null, it is registered via Lexer::addCloserPattern() with the
+     * paragraph break as boundary: an opener candidate is accepted only when
+     * this fragment occurs between it and the next blank line, so an opener
+     * without a valid closer stays literal text and formatting never spans
+     * paragraphs. The entry pattern should then perform only cheap local
+     * checks (delimiter and flanking lookarounds); see addCloserPattern()
+     * for why the closer check must not live in the entry pattern itself.
+     *
+     * @return string|null
+     */
+    protected function getCloserPattern(): ?string
+    {
+        return $this->getExitPattern();
+    }
+
+    /**
      * @return string The mode name used for lexer registration
      */
     abstract protected function getModeName(): string;
@@ -86,6 +118,11 @@ abstract class AbstractFormatting extends AbstractMode
             $this->getExitPattern(),
             $this->getModeName()
         );
+
+        $closer = $this->getCloserPattern();
+        if ($closer !== null) {
+            $this->Lexer->addCloserPattern($closer, $this->getModeName(), Lexer::PARA_BREAK);
+        }
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/AbstractMode.php
+++ b/inc/Parsing/ParserMode/AbstractMode.php
@@ -51,25 +51,18 @@ abstract class AbstractMode
     //region Pattern building blocks
 
     /**
-     * Zero-width assertion: not at the start of a paragraph break.
+     * Zero-width assertion: not at the start of a paragraph break
+     * (Lexer::PARA_BREAK).
      *
-     * Paragraph boundaries are blank lines — two newlines possibly separated
-     * by horizontal whitespace. The lexer compiles all patterns with the `s`
-     * (DOTALL) flag, so a plain `.*` inside an entry-pattern lookahead would
-     * match across blank lines and let an unclosed delimiter greedily consume
-     * following paragraphs. Place this assertion before a character class to
-     * stop the match at a paragraph boundary.
-     */
-    protected const NOT_AT_PARA_BREAK = '(?!\n[ \t]*\n)';
-
-    /**
-     * Quantified group matching any character that does not start a paragraph
-     * break. Convenience for the common case of "consume until paragraph end".
+     * The lexer compiles all patterns with the `s` (DOTALL) flag, so a
+     * plain `.*` inside an entry-pattern lookahead would match across blank
+     * lines and let an unclosed delimiter greedily consume following
+     * paragraphs. Place this assertion before a character class to stop the
+     * match at a paragraph boundary.
      *
-     * Example:
-     *     return '\*\*(?=' . self::CONTENT_UNTIL_PARA . '\*\*)';
+     * @var string
      */
-    protected const CONTENT_UNTIL_PARA = '(?:' . self::NOT_AT_PARA_BREAK . '.)*';
+    protected const NOT_AT_PARA_BREAK = '(?!' . Lexer::PARA_BREAK . ')';
 
     /**
      * Character class: a single "non-word" character — ASCII whitespace or
@@ -86,6 +79,8 @@ abstract class AbstractMode
      * therefore correctly treats multibyte letters as word-like — preventing
      * intraword matches in non-Latin text (e.g. `für_etwas`, `日本_語`)
      * without requiring `u` flag support across the whole lexer.
+     *
+     * @var string
      */
     protected const NON_WORD_CHAR = '[\s!"#$%&\'()*+,\-./:;<=>?@\[\\\\\]^`{|}~]';
 
@@ -93,6 +88,8 @@ abstract class AbstractMode
      * Zero-width assertion: current position is preceded by a non-word
      * character, or is at the start of input/line. See {@see self::NON_WORD_CHAR}
      * for the multibyte reasoning.
+     *
+     * @var string
      */
     protected const NO_WORD_BEFORE = '(?:^|(?<=' . self::NON_WORD_CHAR . '))';
 
@@ -100,6 +97,8 @@ abstract class AbstractMode
      * Zero-width assertion: current position is followed by a non-word
      * character, or is at the end of input. Complement to
      * {@see self::NO_WORD_BEFORE}.
+     *
+     * @var string
      */
     protected const NO_WORD_AFTER = '(?:\z|(?=' . self::NON_WORD_CHAR . '))';
 

--- a/inc/Parsing/ParserMode/Deleted.php
+++ b/inc/Parsing/ParserMode/Deleted.php
@@ -19,7 +19,7 @@ class Deleted extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<del>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</del>)';
+        return '<del>(?=[^\s])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Emphasis.php
+++ b/inc/Parsing/ParserMode/Emphasis.php
@@ -18,17 +18,14 @@ class Emphasis extends AbstractFormatting
 
     /**
      * @inheritdoc
-     * @see https://github.com/dokuwiki/dokuwiki/issues/384
-     * @see https://github.com/dokuwiki/dokuwiki/issues/763
-     * @see https://github.com/dokuwiki/dokuwiki/issues/1468
      *
-     * Flanking rules (simplified): opener must be followed by non-whitespace
-     * non-`/`; closer must be preceded by non-whitespace non-colon (the colon
-     * exclusion protects `http://`-style URLs).
+     * Flanking rules: the opener must be followed by a non-whitespace
+     * character other than a slash, and the closer must be preceded by a
+     * non-whitespace character.
      */
     protected function getEntryPattern(): string
     {
-        return '//(?=[^\s/])(?=' . self::CONTENT_UNTIL_PARA . '[^\s:]//)';
+        return '//(?=[^\s/])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Footnote.php
+++ b/inc/Parsing/ParserMode/Footnote.php
@@ -39,20 +39,14 @@ class Footnote extends AbstractMode
     /** @inheritdoc */
     public function connectTo($mode)
     {
-        $this->Lexer->addEntryPattern(
-            '\x28\x28(?=.*\x29\x29)',
-            $mode,
-            'footnote'
-        );
+        $this->Lexer->addEntryPattern('\x28\x28', $mode, 'footnote');
     }
 
     /** @inheritdoc */
     public function postConnect()
     {
-        $this->Lexer->addExitPattern(
-            '\x29\x29',
-            'footnote'
-        );
+        $this->Lexer->addExitPattern('\x29\x29', 'footnote');
+        $this->Lexer->addCloserPattern('\x29\x29', 'footnote');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmBacktickDouble.php
+++ b/inc/Parsing/ParserMode/GfmBacktickDouble.php
@@ -30,23 +30,21 @@ class GfmBacktickDouble extends GfmBacktickSingle
     }
 
     /**
-     * Entry pattern. Same shape as the parent but with doubled
-     * delimiters. The body character class admits either a non-backtick
-     * or a lone backtick (one that isn't followed by another, so not
-     * part of a run-of-two) — such a stray backtick cannot form a valid
-     * n=2 closer.
+     * Delimiter: exactly two backticks, guarded against longer runs.
      */
-    protected function getEntryPattern(): string
-    {
-        return '(?<!`)``(?!`)(?='
-            . '(?:' . self::NOT_AT_PARA_BREAK . '(?:[^`]|`(?!`)))+'
-            . '(?<!`)``(?!`)'
-            . ')';
-    }
-
-    /** @inheritdoc */
-    protected function getExitPattern(): string
+    protected function getDelimiterPattern(): string
     {
         return '(?<!`)``(?!`)';
+    }
+
+    /**
+     * Span body. Admits a lone backtick (one that isn't followed by
+     * another, so not part of a run-of-two) instead of the parent's
+     * backtick runs — such a stray backtick cannot form a valid n=2
+     * closer. Deterministic and possessive like the parent's body.
+     */
+    protected function getBodyPattern(): string
+    {
+        return '(?:[^`\n]++|' . self::NOT_AT_PARA_BREAK . '\n|`(?!`))++';
     }
 }

--- a/inc/Parsing/ParserMode/GfmBacktickSingle.php
+++ b/inc/Parsing/ParserMode/GfmBacktickSingle.php
@@ -54,25 +54,47 @@ class GfmBacktickSingle extends AbstractMode
     }
 
     /**
-     * Entry pattern. The length-boundary guards (?<!`)...(?!`) around
-     * each delimiter ensure a run of two or more backticks is never read
-     * as an n=1 opener or closer. The body character class, which admits
-     * either a non-backtick or a run of two-or-more backticks, lets
-     * those longer runs live inside the body since they cannot be valid
-     * n=1 closers.
+     * Delimiter: a lone backtick. The length-boundary guards
+     * (?<!`)...(?!`) ensure a run of two or more backticks is never read
+     * as an n=1 opener or closer.
+     */
+    protected function getDelimiterPattern(): string
+    {
+        return '(?<!`)`(?!`)';
+    }
+
+    /**
+     * Span body. Admits runs of non-backticks, newlines that don't start
+     * a blank line, and runs of two-or-more backticks — the latter live
+     * inside the body since they cannot be valid n=1 closers.
+     *
+     * The alternatives start with mutually exclusive characters and all
+     * quantifiers are possessive, so a scan over the body never
+     * backtracks: it stops at the first lone backtick (or fails at the
+     * paragraph break) without accumulating backtracking state.
+     */
+    protected function getBodyPattern(): string
+    {
+        return '(?:[^`\n]++|' . self::NOT_AT_PARA_BREAK . '\n|``++)++';
+    }
+
+    /**
+     * Entry pattern: an opening delimiter whose lookahead verifies a body
+     * and a closing delimiter ahead. The lookahead is self-limiting — a
+     * lone backtick ahead is always a valid closer, so at most one scan
+     * per paragraph can fail — which keeps it linear without the memoized
+     * closer machinery of Lexer::addCloserPattern().
      */
     protected function getEntryPattern(): string
     {
-        return '(?<!`)`(?!`)(?='
-            . '(?:' . self::NOT_AT_PARA_BREAK . '(?:[^`]|``+))+'
-            . '(?<!`)`(?!`)'
-            . ')';
+        return $this->getDelimiterPattern()
+            . '(?=' . $this->getBodyPattern() . $this->getDelimiterPattern() . ')';
     }
 
-    /** Exit pattern. Same boundary guards as the entry. */
+    /** Exit pattern: the same delimiter that opened the span. */
     protected function getExitPattern(): string
     {
-        return '(?<!`)`(?!`)';
+        return $this->getDelimiterPattern();
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmCode.php
+++ b/inc/Parsing/ParserMode/GfmCode.php
@@ -85,15 +85,27 @@ class GfmCode extends AbstractMode
         //   (?=\n)                  — opener line must end at a newline;
         //                             without this anchor `` ``` aa ``` ``
         //                             on one line would parse as a fence
-        //   (?:(?!CLOSE).)*         — body: any char (DOTALL) that isn't
-        //                             the start of a close-fence line
+        //   (?:(?!CLOSE).)*+        — body: any char (DOTALL) that isn't
+        //                             the start of a close-fence line. The
+        //                             tempered dot stops at exactly the first
+        //                             CLOSE (the lookahead fails there), so
+        //                             no backtracking into the body is ever
+        //                             needed once it has stopped. The
+        //                             possessive quantifier makes that
+        //                             explicit: on an unclosed fence the body
+        //                             consumes to EOF, CLOSE fails, and the
+        //                             match fails at once instead of
+        //                             backtracking byte by byte — which the
+        //                             non-JIT PCRE engine does by retaining
+        //                             one frame per consumed byte, an
+        //                             unbounded memory spike on large fences.
         //   CLOSE = \nF{3,}[ \t]*(?=\n)  — close fence, required.
         //                             No `\z` fallback: unclosed fences stay
         //                             literal (see class docblock)
         $close = '\n' . $this->fenceChar . '{3,}[ \t]*(?=\n)';
         $this->Lexer->addSpecialPattern(
             '\n' . $this->fenceChar . '{3,}' . $this->infoClass . '(?=\n)'
-                . '(?:(?!' . $close . ').)*' . $close,
+                . '(?:(?!' . $close . ').)*+' . $close,
             $mode,
             $this->getModeName()
         );

--- a/inc/Parsing/ParserMode/GfmDeleted.php
+++ b/inc/Parsing/ParserMode/GfmDeleted.php
@@ -36,13 +36,7 @@ class GfmDeleted extends AbstractFormatting
         //                            are fenced-code markers, not strike)
         //   ~~                     — two opening tildes
         //   (?=[^\s~])             — next body char: not whitespace, not `~`
-        //   (?=                    — lookahead: a valid closer must exist
-        //     CONTENT_UNTIL_PARA   —   body that doesn't cross a blank line
-        //     [^\s]~~              —   non-whitespace, then closing `~~`
-        //     (?!~)                —   and not followed by another `~`
-        //   )
-        return '(?<!~)~~(?=[^\s~])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]~~(?!~))';
+        return '(?<!~)~~(?=[^\s~])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasis.php
+++ b/inc/Parsing/ParserMode/GfmEmphasis.php
@@ -36,13 +36,10 @@ class GfmEmphasis extends AbstractFormatting
         //   (?=                       — lookahead: a valid closer must exist
         //     [^\s*]                  —   first body char: not whitespace, not `*`
         //                                 (flanking-opener rule)
-        //     (?:                     —   optional: more body
-        //       (?:NOT_AT_PARA_BREAK  —     …any non-`*` char that doesn't
-        //          [^*])*             —     start a paragraph break
-        //       [^\s*]                —     last body char: not whitespace, not `*`
+        //     (?:NOT_AT_PARA_BREAK    —   possessive run of any non-`*` char
+        //        [^*])*+              —     that doesn't start a paragraph break
+        //     (?<![\s*])              —   last body char: not whitespace, not `*`
         //                                 (flanking-closer rule)
-        //     )?                      —   `?` so single-char bodies like `*a*`
-        //                                 also match
         //     \*                      —   closing `*`
         //   )
         // The lookahead only reaches the nearest `*` (its body is `[^*]`), so
@@ -50,7 +47,15 @@ class GfmEmphasis extends AbstractFormatting
         // closer scan cannot express. The inherited closer check additionally
         // keeps the opener from spanning an enclosing mode's closer (e.g. a
         // stray `*` inside ''glob/*.conf'').
-        return '\*(?=[^\s*](?:(?:' . self::NOT_AT_PARA_BREAK . '[^*])*[^\s*])?\*)';
+        //
+        // The body run is possessive and the flanking-closer rule is a
+        // lookbehind rather than a trailing character the run must give back:
+        // `[^*]` cannot match `*`, so the run always stops at the nearest `*`
+        // (or a paragraph break) and never needs to backtrack. A plain
+        // quantifier with a trailing `[^\s*]` forced backtracking on every
+        // opener, so a long run of `*` with no valid closer made the non-JIT
+        // PCRE engine retain one backtracking frame per byte.
+        return '\*(?=[^\s*](?:' . self::NOT_AT_PARA_BREAK . '[^*])*+(?<![\s*])\*)';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasis.php
+++ b/inc/Parsing/ParserMode/GfmEmphasis.php
@@ -45,6 +45,11 @@ class GfmEmphasis extends AbstractFormatting
         //                                 also match
         //     \*                      —   closing `*`
         //   )
+        // The lookahead only reaches the nearest `*` (its body is `[^*]`), so
+        // it enforces CommonMark's nearest-delimiter pairing that a plain
+        // closer scan cannot express. The inherited closer check additionally
+        // keeps the opener from spanning an enclosing mode's closer (e.g. a
+        // stray `*` inside ''glob/*.conf'').
         return '\*(?=[^\s*](?:(?:' . self::NOT_AT_PARA_BREAK . '[^*])*[^\s*])?\*)';
     }
 

--- a/inc/Parsing/ParserMode/GfmEmphasisStrong.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisStrong.php
@@ -38,16 +38,7 @@ class GfmEmphasisStrong extends AbstractFormatting
         //   \*\*\*                   — exactly three opening `*`
         //   (?=[^\s*])               — next body char: not whitespace, not `*`
         //                              (flanking-opener rule)
-        //   (?=                      — lookahead: a valid closer must exist
-        //     CONTENT_UNTIL_PARA     —   body that doesn't cross a paragraph
-        //     [^\s]                  —   last body char: not whitespace
-        //                              (flanking-closer rule)
-        //     \*\*\*                 —   closing `***`
-        //     (?!\*)                 —   and not followed by another `*`
-        //                              (exactly 3, not 4+)
-        //   )
-        return '(?<!\*)\*\*\*(?=[^\s*])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\*\*\*(?!\*))';
+        return '(?<!\*)\*\*\*(?=[^\s*])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasisStrongUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisStrongUnderscore.php
@@ -27,11 +27,8 @@ class GfmEmphasisStrongUnderscore extends GfmEmphasisStrong
     {
         // NO_WORD_BEFORE + `(?<!_)` blocks intraword and longer-run openers.
         // `(?=[^\s_])` enforces the flanking-opener rule.
-        // The closing-delimiter lookahead requires non-whitespace before `___`,
-        // `(?!_)` for exactly-3 length, and NO_WORD_AFTER for word-boundary.
         return self::NO_WORD_BEFORE
-            . '(?<!_)___(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]___(?!_)' . self::NO_WORD_AFTER . ')';
+            . '(?<!_)___(?=[^\s_])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmEmphasisUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmEmphasisUnderscore.php
@@ -33,12 +33,8 @@ class GfmEmphasisUnderscore extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        // Entry requires a valid closing `_` (non-whitespace char before it AND
-        // NO_WORD_AFTER following). Otherwise emphasis would open with no way
-        // to ever close (or close at an invalid position).
         return self::NO_WORD_BEFORE
-            . '_(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]_' . self::NO_WORD_AFTER . ')';
+            . '_(?=[^\s_])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmLink.php
+++ b/inc/Parsing/ParserMode/GfmLink.php
@@ -60,8 +60,9 @@ class GfmLink extends AbstractMode
     // Image sub-pattern reused for both the label alternative in the main
     // pattern and the image-as-label detector in handle(). No capture
     // groups here — the lexer wraps user patterns in a capture and
-    // additional captures would renumber unpredictably.
-    private const IMAGE_SUB = '!\[' . self::LABEL_CHAR . '*\]\(' . self::URL_CHAR . '+\)';
+    // additional captures would renumber unpredictably. The label/url
+    // quantifiers are possessive for the same reason as the main pattern.
+    private const IMAGE_SUB = '!\[' . self::LABEL_CHAR . '*+\]\(' . self::URL_CHAR . '++\)';
 
     /** @inheritdoc */
     public function getSort()
@@ -77,7 +78,13 @@ class GfmLink extends AbstractMode
         // image alternative explicitly matches one inline image. URL
         // slot is permissive — handle() does URL / title splitting
         // post-entry, mirroring how DW Internallink parses inside `[[...]]`.
-        $pattern = '\[(?!\[)(?:' . self::LABEL_CHAR . '+|' . self::IMAGE_SUB . ')\]\(' . self::URL_CHAR . '+\)';
+        //
+        // The label and url quantifiers are possessive: LABEL_CHAR never
+        // matches an unescaped `]` and URL_CHAR never matches an unescaped
+        // `)`, so each run stops exactly at its own closer and never needs to
+        // backtrack. A plain `+` here lets an unclosed `[text…` drive the
+        // non-JIT PCRE engine to retain one backtracking frame per byte.
+        $pattern = '\[(?!\[)(?:' . self::LABEL_CHAR . '++|' . self::IMAGE_SUB . ')\]\(' . self::URL_CHAR . '++\)';
         $this->Lexer->addSpecialPattern($pattern, $mode, 'gfm_link');
     }
 

--- a/inc/Parsing/ParserMode/GfmLink.php
+++ b/inc/Parsing/ParserMode/GfmLink.php
@@ -55,7 +55,7 @@ class GfmLink extends AbstractMode
     // permitted as long as it is not followed by a blank line — soft
     // line breaks inside link text are allowed by the spec, blank lines
     // are not (and they would also tie up `\n#`-anchored block modes).
-    private const LABEL_CHAR = '(?:\\\\.|[^\[\]\n]|\n(?![ \t]*\n))';
+    private const LABEL_CHAR = '(?:\\\\.|[^\[\]\n]|' . self::NOT_AT_PARA_BREAK . '\n)';
 
     // Image sub-pattern reused for both the label alternative in the main
     // pattern and the image-as-label detector in handle(). No capture

--- a/inc/Parsing/ParserMode/GfmQuote.php
+++ b/inc/Parsing/ParserMode/GfmQuote.php
@@ -84,7 +84,11 @@ class GfmQuote extends AbstractMode
      */
     public function connectTo($mode)
     {
-        $this->Lexer->addSpecialPattern('(?:^|\n)>[^\n]*(?:\n>[^\n]*)*', $mode, 'gfm_quote');
+        // The continuation group is possessive: each quote line ends at a
+        // `\n` that the next iteration re-anchors on, so the group never
+        // backtracks. Without it a very long blockquote makes the non-JIT
+        // PCRE engine retain one backtracking frame per line.
+        $this->Lexer->addSpecialPattern('(?:^|\n)>[^\n]*(?:\n>[^\n]*)*+', $mode, 'gfm_quote');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/GfmStrongUnderscore.php
+++ b/inc/Parsing/ParserMode/GfmStrongUnderscore.php
@@ -34,8 +34,7 @@ class GfmStrongUnderscore extends AbstractFormatting
     protected function getEntryPattern(): string
     {
         return self::NO_WORD_BEFORE
-            . '__(?=[^\s_])'
-            . '(?=' . self::CONTENT_UNTIL_PARA . '[^\s]__' . self::NO_WORD_AFTER . ')';
+            . '__(?=[^\s_])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Media.php
+++ b/inc/Parsing/ParserMode/Media.php
@@ -16,8 +16,12 @@ class Media extends AbstractMode
     /** @inheritdoc */
     public function connectTo($mode)
     {
-        // Word boundaries?
-        $this->Lexer->addSpecialPattern("\{\{(?:[^\}]|(?:\}[^\}]))+\}\}", $mode, 'media');
+        // Body is possessive: it can only match up to the first `}}` (neither
+        // alternative accepts `}}`), so it never needs to backtrack to let the
+        // closing `}}` match. Without the possessive quantifier an unclosed
+        // `{{` followed by a large body drives the non-JIT PCRE engine to
+        // retain one backtracking frame per byte — an unbounded memory spike.
+        $this->Lexer->addSpecialPattern("\{\{(?:[^\}]|(?:\}[^\}]))++\}\}", $mode, 'media');
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Monospace.php
+++ b/inc/Parsing/ParserMode/Monospace.php
@@ -19,7 +19,7 @@ class Monospace extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '\x27\x27(?=[^\s\x27])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\x27\x27)';
+        return '\x27\x27(?=[^\s\x27])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Strong.php
+++ b/inc/Parsing/ParserMode/Strong.php
@@ -22,7 +22,7 @@ class Strong extends AbstractFormatting
         // Flanking rules (simplified): opener must be followed by non-whitespace
         // non-`*`; closer must be preceded by non-whitespace. This rejects
         // `** foo**`, `**foo **`, and empty pairs `****`.
-        return '\*\*(?=[^\s*])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]\*\*)';
+        return '\*\*(?=[^\s*])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Subscript.php
+++ b/inc/Parsing/ParserMode/Subscript.php
@@ -19,7 +19,7 @@ class Subscript extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<sub>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</sub>)';
+        return '<sub>(?=[^\s])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Superscript.php
+++ b/inc/Parsing/ParserMode/Superscript.php
@@ -19,7 +19,7 @@ class Superscript extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '<sup>(?=[^\s])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]</sup>)';
+        return '<sup>(?=[^\s])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Underline.php
+++ b/inc/Parsing/ParserMode/Underline.php
@@ -19,7 +19,7 @@ class Underline extends AbstractFormatting
     /** @inheritdoc */
     protected function getEntryPattern(): string
     {
-        return '__(?=[^\s_])(?=' . self::CONTENT_UNTIL_PARA . '[^\s]__)';
+        return '__(?=[^\s_])';
     }
 
     /** @inheritdoc */

--- a/inc/Parsing/ParserMode/Windowssharelink.php
+++ b/inc/Parsing/ParserMode/Windowssharelink.php
@@ -17,7 +17,11 @@ class Windowssharelink extends AbstractMode
     /** @inheritdoc */
     public function preConnect()
     {
-        $this->pattern = "\\\\\\\\\w+?(?:\\\\[\w\-$]+)+";
+        // The path-segment group is possessive: `[\w\-$]+` stops at each
+        // backslash, so successive segments never overlap and the group never
+        // needs to backtrack. Without it a long `\\host\a\b\c…` run makes the
+        // non-JIT PCRE engine retain one backtracking frame per segment.
+        $this->pattern = "\\\\\\\\\w+?(?:\\\\[\w\-$]+)++";
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
This replaces #4684 - the goal is still to avoid expensive lookaheads for finding the matching closing syntax as introduced during the GFM refactor.

This branch removes the closer scan from the opening pattern and instead lets the lexer do a separate scan for the closer. These scans are inexpensive because they use no backtracking and the results can be cached for the parse run.

The closer pattern and (paragraph) boundary are set via a new addCloserPattern() which plugins can also use to speed up their handling in the future.

The branch also introduces a few more regex improvements for the core modes.

I reviewed and refactored the code a couple of times and I think it's as tight and reasonable as possible. It is still not a fool proof parser. Broken syntax (especially plugin syntax and wrong nesting) can still mess up the page - but that has been the case for the last 20 years, so we should not be off worse. On the contrary - this change should catch quite a few common pitfalls and mistakes and make the parser a bit faster.

On the long term it might be worth investigating if we could switch the entire parser but:

* keep backwards compatibility with plugins
* keep backwards compatibility with the instructions and renderer system
* allow some of the currently unsupported quirks of markdown parsing


