### PR TITLE
Avoid firing PARSER_HANDLER_DONE in sub parsers

### DIFF
--- a/_test/tests/Parsing/HandlerTest.php
+++ b/_test/tests/Parsing/HandlerTest.php
@@ -127,4 +127,36 @@ class HandlerTest extends \DokuWikiTest
         $this->assertSame(['datetime'], $args[1]);
         $this->assertSame('~~INFO:datetime~~', $args[3]);
     }
+
+    /**
+     * PARSER_HANDLER_DONE marks a finished document, so finalize() fires it for
+     * a top-level parse; the per-item and per-blockquote sub-parses the built-in
+     * Markdown modes run fire PARSER_SUBHANDLER_DONE instead. Firing the
+     * document event per item let a plugin hooking it (e.g. struct's
+     * auto-output) inject a call into every list item, which defeated
+     * GfmListblock's tight-item detection and wrapped each item in a paragraph.
+     */
+    function testFinalizeFiresDocumentAndSubParserEventsSeparately()
+    {
+        global $EVENT_HANDLER;
+        $main = 0;
+        $sub = 0;
+        $EVENT_HANDLER->register_hook('PARSER_HANDLER_DONE', 'AFTER', null, function () use (&$main) {
+            $main++;
+        });
+        $EVENT_HANDLER->register_hook('PARSER_SUBHANDLER_DONE', 'AFTER', null, function () use (&$sub) {
+            $sub++;
+        });
+
+        // top-level parse fires PARSER_HANDLER_DONE only (also the BC contract
+        // for legacy new Doku_Handler() sub-parsing)
+        (new Handler(new ModeRegistry('md')))->finalize();
+        $this->assertSame(1, $main, 'main parse must fire PARSER_HANDLER_DONE');
+        $this->assertSame(0, $sub, 'main parse must not fire PARSER_SUBHANDLER_DONE');
+
+        // sub-parser handler fires PARSER_SUBHANDLER_DONE only
+        (new Handler(new ModeRegistry('md'), true))->finalize();
+        $this->assertSame(1, $main, 'sub-parse must not fire PARSER_HANDLER_DONE');
+        $this->assertSame(1, $sub, 'sub-parse must fire PARSER_SUBHANDLER_DONE');
+    }
 }

--- a/inc/Parsing/Handler.php
+++ b/inc/Parsing/Handler.php
@@ -38,14 +38,19 @@ class Handler
     /** @var ModeRegistry the registry of the parse this handler belongs to */
     protected ModeRegistry $registry;
 
+    /** @var bool whether this handler drives a sub-parse */
+    protected bool $isSubParser = false;
+
     /**
      * @param ModeRegistry|null $registry the registry of the parse, so handler
      *     methods and plugin handle()/render() can ask for the active syntax.
      *     Null is a deprecated backward-compatibility path for the legacy
      *     manual sub-parsing pattern (new Doku_Handler() with no argument): a
      *     registry for the configured syntax is built in that case.
+     * @param bool $isSubParser true for the sub-parser instances the built-in
+     *     modes spin up per list item or blockquote.
      */
-    public function __construct(?ModeRegistry $registry = null)
+    public function __construct(?ModeRegistry $registry = null, bool $isSubParser = false)
     {
         if (!$registry instanceof ModeRegistry) {
             global $conf;
@@ -57,6 +62,7 @@ class Handler
             $registry = new ModeRegistry($conf['syntax']);
         }
         $this->registry = $registry;
+        $this->isSubParser = $isSubParser;
         $this->reset();
     }
 
@@ -241,7 +247,9 @@ class Handler
      * Called from the parser. Calls finalise() on the call writer, closes open
      * sections, rewrites blocks and adds document_start and document_end calls.
      *
-     * @triggers PARSER_HANDLER_DONE
+     * @triggers PARSER_HANDLER_DONE for the top-level document parse
+     * @triggers PARSER_SUBHANDLER_DONE for the sub-parses the built-in modes
+     *     run per list item or blockquote (see the $isSubParser flag)
      */
     public function finalize()
     {
@@ -255,7 +263,11 @@ class Handler
         $B = new Block();
         $this->calls = $B->process($this->calls);
 
-        Event::createAndTrigger('PARSER_HANDLER_DONE', $this);
+        if ($this->isSubParser) {
+            Event::createAndTrigger('PARSER_SUBHANDLER_DONE', $this);
+        } else {
+            Event::createAndTrigger('PARSER_HANDLER_DONE', $this);
+        }
 
         array_unshift($this->calls, ['document_start', [], 0]);
         $last_call = end($this->calls);

--- a/inc/Parsing/ModeRegistry.php
+++ b/inc/Parsing/ModeRegistry.php
@@ -362,7 +362,7 @@ class ModeRegistry
             $excluded = array_merge($excluded, $categories[$cat] ?? []);
         }
 
-        $parser = new Parser(new Handler($this), $this);
+        $parser = new Parser(new Handler($this, true), $this);
         foreach ($this->getModes() as $m) {
             if (in_array($m['mode'], $excluded, true)) continue;
             // Mode objects expose a single $Lexer slot which Parser::addMode()

--- a/inc/Parsing/ParserMode/GfmListblock.php
+++ b/inc/Parsing/ParserMode/GfmListblock.php
@@ -26,14 +26,18 @@ use dokuwiki\Parsing\ModeRegistry;
  * itself (defensive guard against lexer re-entry on pathological inputs;
  * normal nested lists are caught by the outer pattern instead).
  *
- * Each item's sub-parsed calls are wrapped in a `nest` instruction (see
- * Handler\Nest) before they reach the outer handler. This is essential:
- * the sub-parser's Block rewriter has already wrapped multi-paragraph
- * content in `p_open`/`p_close`, and without nest-wrapping the main
- * handler's Block rewriter would see those paragraphs and add another
- * `<p>` around the entire replayed range, producing nested `<p>` tags.
- * Block treats `nest` as opaque and the renderer base class unwraps it
- * transparently — the same pattern Footnote uses.
+ * Each item's sub-parsed calls are wrapped in a nest instruction (see
+ * Handler\Nest) before they reach the outer handler. The sub-parse has
+ * already run its own finalize - the call-writer rewriters plus the
+ * Block paragraph pass - producing a complete instruction sequence for
+ * the item. The main handler finalizes the whole document afterwards;
+ * wrapping the item in nest keeps it opaque to that second pass (Block
+ * copies a nest call verbatim instead of descending into it), so the
+ * item's block structure is preserved and replayed as-is by the renderer
+ * base class. This is the isolation Footnote has always relied on nest
+ * for, so nested block content is not re-stitched by the outer rewriters.
+ * Nest also merges adjacent cdata and drops stray eol as it buffers,
+ * sealing the item boundary.
  *
  * Indentation rule: depth = (indent / 2) + 1. Tabs become two spaces. 1- and
  * 3-space indents round down. Marker characters: -, *, + (unordered) and
@@ -145,10 +149,10 @@ class GfmListblock extends AbstractMode
             $itemCalls = $this->filterSubCalls($subHandler->calls);
             if (empty($itemCalls)) continue; // empty item — nothing to emit
 
-            // Wrap the item content in a Nest so the main handler's Block
-            // rewriter does not double-wrap our already-paragraphed content.
-            // Block treats `nest` as opaque and the renderer base class
-            // unwraps it transparently, the same pattern Footnote uses.
+            // Wrap the item content in a Nest so the outer handler's
+            // finalize (its rewriters and Block pass) does not re-process
+            // this already-finalized sub-tree: Block copies a nest call
+            // verbatim and the renderer base class replays it as-is.
             $outer = $handler->getCallWriter();
             $nest = new Nest($outer);
             $handler->setCallWriter($nest);


### PR DESCRIPTION
Markdown uses sub parsers for parsing list item and blockquote content. Those parsers currently fire their own PARSER_HANDLER_DONE event. Plugins handling this event usually expect the event to be fired only once. One such plugin is struct with its struct_output mechanism. This resulted in weird rendering of lists when using markdown mode.

This fix fires the event only for the main parser and introduces a new event (same event data) PARSER_SUBHANDLER_DONE to be triggered for the sub handlers.

I am unsure if this should go into a hotfix.  For lists it only affects md+dw and md syntax. But for blockquotes it's probably an issue for all modes. I attached an analysis how plugins currently handle the PARSER_HANDLER_DONE.

Most plugins don't seem to care either way. But those that do, I think it would be hard to work around this issue without the change of this PR, so I am slightly leaning towards hotfix.
