### PR TITLE
sort GFM strikethrough last

### DIFF
--- a/_test/tests/Parsing/ParserMode/GfmDeletedTest.php
+++ b/_test/tests/Parsing/ParserMode/GfmDeletedTest.php
@@ -201,7 +201,7 @@ class GfmDeletedTest extends ParserTestBase
     public function testSortValue()
     {
         $mode = new GfmDeleted();
-        $this->assertSame(130, $mode->getSort());
+        $this->assertSame(1000, $mode->getSort());
     }
 
     public function testRejectedOpenerBeforeValidSpanStaysLiteral()

--- a/inc/Parsing/ParserMode/GfmDeleted.php
+++ b/inc/Parsing/ParserMode/GfmDeleted.php
@@ -13,7 +13,11 @@ class GfmDeleted extends AbstractFormatting
     /** @inheritdoc */
     public function getSort()
     {
-        return 130;
+        // Deliberately sorted last: many plugins claim `~~KEYWORD~~` macros
+        // (e.g. ~~TOC~~, ~~NOFOOTER~~) whose opener the strikethrough entry
+        // pattern also matches. A high sort lets those plugins parse first
+        // and keep their syntax; plain ~~text~~ still falls through to here.
+        return 1000;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
Markdown uses `~~` to mark text as deleted. But we have many plugins that use `~~FOO~~` as their syntax. Those plugins use all kinds of sorts up to 999. With strike-through at 130 those plugins broke.

There should be no harm in raising the sort to 1000, but it auto-fixes all those plugins when using markdown or mixed modes.