### PR TITLE
fix(css): point unclosed-block errors at the right file

### DIFF
--- a/_test/tests/lib/exe/css_find_unbalanced_brace_file.test.php
+++ b/_test/tests/lib/exe/css_find_unbalanced_brace_file.test.php
@@ -1,0 +1,110 @@
+<?php
+
+require_once DOKU_INC.'lib/exe/css.php';
+
+class css_find_unbalanced_brace_file_test extends DokuWikiTest {
+
+    private function buildCss(array $mediatypeFiles) {
+        $css = '';
+        foreach ($mediatypeFiles as $mediatype => $files) {
+            $css .= "\n@media $mediatype {";
+            $css .= "/* START $mediatype styles */\n";
+            foreach ($files as $path => $content) {
+                $css .= "\n/* XXXXXXXXX $path XXXXXXXXX */\n";
+                $css .= $content . "\n";
+            }
+            $css .= "\n} /* /@media END $mediatype styles */\n";
+        }
+        return $css;
+    }
+
+    function test_balanced() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => 'body { font-family: sans-serif; }',
+                '/lib/plugins/usermanager/screen.less' => '.um { color: black; }',
+            ],
+            'speech' => [
+                '/lib/plugins/usermanager/speech.less' => '.um { color: black; }',
+            ],
+        ]);
+        $this->assertNull(css_find_unbalanced_brace_file($css));
+    }
+
+    function test_unclosed_in_early_file() {
+        // the scenario from #4707: typo in conf/userstyle.css should be
+        // detected, not the last file (usermanager/speech.less)
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => 'body { font-family: sans-serif; }',
+                '/lib/plugins/usermanager/screen.less' => '.um { color: black; }',
+                '/conf/userstyle.css' => '.dokuwiki {',
+                '/lib/plugins/config/screen.less' => '.cfg { color: red; }',
+            ],
+            'all' => [
+                '/lib/styles/all.css' => 'a { color: blue; }',
+            ],
+            'speech' => [
+                '/lib/plugins/usermanager/speech.less' => '.um { color: black; }',
+            ],
+        ]);
+        $this->assertEquals('/conf/userstyle.css', css_find_unbalanced_brace_file($css));
+    }
+
+    function test_unclosed_in_last_file() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => 'body { font-family: sans-serif; }',
+                '/conf/userstyle.css' => '.dokuwiki {',
+            ],
+        ]);
+        $this->assertEquals('/conf/userstyle.css', css_find_unbalanced_brace_file($css));
+    }
+
+    function test_extra_closing_brace() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => 'body { color: red; } }',
+                '/lib/plugins/usermanager/screen.less' => '.um { color: black; }',
+            ],
+        ]);
+        $this->assertEquals('/lib/styles/screen.css', css_find_unbalanced_brace_file($css));
+    }
+
+    function test_braces_in_strings() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => 'body { content: "{ this is a { string } }"; }',
+                '/conf/userstyle.css' => '.dokuwiki { color: red; }',
+            ],
+        ]);
+        $this->assertNull(css_find_unbalanced_brace_file($css));
+    }
+
+    function test_braces_in_comments() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => "/* a comment with { braces } */\nbody { color: red; }",
+                '/conf/userstyle.css' => '.dokuwiki { color: red; }',
+            ],
+        ]);
+        $this->assertNull(css_find_unbalanced_brace_file($css));
+    }
+
+    function test_nested_blocks() {
+        $css = $this->buildCss([
+            'screen' => [
+                '/lib/styles/screen.css' => '.outer { .inner { color: red; } }',
+                '/conf/userstyle.css' => '.dokuwiki { .nested { color: blue; }',
+            ],
+            'speech' => [
+                '/lib/plugins/usermanager/speech.less' => '.um { color: black; }',
+            ],
+        ]);
+        $this->assertEquals('/conf/userstyle.css', css_find_unbalanced_brace_file($css));
+    }
+
+    function test_no_file_headers() {
+        $this->assertNull(css_find_unbalanced_brace_file('body { color: red; }'));
+    }
+}

--- a/lib/exe/css.php
+++ b/lib/exe/css.php
@@ -195,6 +195,39 @@ function css_out()
 }
 
 /**
+ * Find the file with an unbalanced brace count in the concatenated CSS
+ *
+ * @param string $css
+ * @return string|null
+ */
+function css_find_unbalanced_brace_file($css)
+{
+    // split on the file header comments css_out() inserts; captures the path
+    $parts = preg_split(
+        '/\/\* XXXXXXXXX (.*?) XXXXXXXXX \*\//',
+        $css, -1, PREG_SPLIT_DELIM_CAPTURE
+    );
+
+    $depth = 0;
+    for ($i = 1, $n = count($parts); $i < $n; $i += 2) {
+        $file = $parts[$i];
+        $content = $parts[$i + 1] ?? '';
+        $start = $depth;
+
+        // don't count the @media wrapper braces, or braces in comments/strings
+        $content = preg_replace('/^@media\s+\S+\s*\{/m', '', $content);
+        $content = preg_replace('/^\}\s*\/\*\s*\/@media.*$/m', '', $content);
+        $content = preg_replace('/\/\*.*?\*\//s', '', $content);
+        $content = preg_replace('/(["\']).*?(?<!\\\\)\1/s', '', $content);
+
+        $depth += substr_count($content, '{') - substr_count($content, '}');
+
+        if ($depth != $start) return $file;
+    }
+    return null;
+}
+
+/**
  * Uses phpless to parse LESS in our CSS
  *
  * most of this function is error handling to show a nice useful error when
@@ -226,13 +259,23 @@ function css_parseless($css)
             $msg = substr($msg, 0, -1 * strlen($m[0])); //remove useless linenumber
             $lno = $m[1];
 
-            // walk upwards to last include
-            $lines = explode("\n", $css);
-            for ($i = $lno - 1; $i >= 0; $i--) {
-                if (preg_match('/\/(\* XXXXXXXXX )(.*?)( XXXXXXXXX \*)\//', $lines[$i], $m)) {
-                    // we found it, add info to message
-                    $msg .= ' in ' . $m[2] . ' at line ' . ($lno - $i);
-                    break;
+            // "unclosed block" is reported at the end of the concatenated
+            // CSS, so walking backwards blames the last file, not the real
+            // culprit. Track brace balance per file instead.
+            if (stripos($msg, 'unclosed block') !== false) {
+                $file = css_find_unbalanced_brace_file($css);
+                if ($file !== null) {
+                    $msg .= ' in ' . $file;
+                }
+            } else {
+                // walk upwards to last include
+                $lines = explode("\n", $css);
+                for ($i = $lno - 1; $i >= 0; $i--) {
+                    if (preg_match('/\/(\* XXXXXXXXX )(.*?)( XXXXXXXXX \*)\//', $lines[$i], $m)) {
+                        // we found it, add info to message
+                        $msg .= ' in ' . $m[2] . ' at line ' . ($lno - $i);
+                        break;
+                    }
                 }
             }
         }
@@ -240,7 +283,9 @@ function css_parseless($css)
         // something went wrong
         $error = 'A fatal error occured during compilation of the CSS files. ' .
             'If you recently installed a new plugin or template it ' .
-            'might be broken and you should try disabling it again. [' . $msg . ']';
+            'might be broken and you should try disabling it again. ' .
+            'This may also be caused by a syntax error in a userstyle ' .
+            'or template style file. [' . $msg . ']';
 
         echo ".dokuwiki:before {
             content: '$error';


### PR DESCRIPTION
When css_parseless() hits an "unclosed block" error, it walks backwards from the reported line and blames the last included file instead of the one with the actual typo. This tracks brace balance per file so the error points at the real culprit.

I'm setting up DokuWiki for my own notes and project docs. Saw this issue and wanted to contribute a fix.

Fixes #4707